### PR TITLE
feat(mcp): put_file + ScopedFS workspace + PDF resource_link

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -2,15 +2,19 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/dlouwers/typst-d2-mcp/internal/preprocessor"
 	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/yosida95/uritemplate/v3"
 )
 
 const (
@@ -20,9 +24,15 @@ const (
 	envTransport = "TYPST_D2_MCP_TRANSPORT"
 	envAddr      = "TYPST_D2_MCP_ADDR"
 	envPath      = "TYPST_D2_MCP_PATH"
+	envWorkspace = "TYPST_D2_MCP_WORKSPACE"
 
 	defaultAddr = ":8080"
 	defaultPath = "/mcp"
+
+	// pdfURIPrefix is the scheme + host used by the compile tool when it
+	// returns a ResourceLink for the produced PDF. Clients can fetch the
+	// bytes via the standard MCP resources/read call against this URI.
+	pdfURIPrefix = "typst-d2://pdf/"
 )
 
 // serverInstructions is sent once at the MCP initialize handshake. Moving
@@ -91,14 +101,22 @@ VERIFYING THE RESULT:
   yourself, advise the user to inspect it.`
 
 func main() {
+	resolver, err := selectResolver()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Resolver setup: %v\n", err)
+		os.Exit(1)
+	}
+
 	s := server.NewMCPServer(
 		serverName,
 		serverVersion,
 		server.WithToolCapabilities(false),
+		server.WithResourceCapabilities(false, false),
 		server.WithInstructions(serverInstructions),
 	)
 
-	registerTools(s)
+	registerTools(s, resolver)
+	registerResources(s, resolver)
 
 	if err := serve(s); err != nil {
 		fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
@@ -106,10 +124,37 @@ func main() {
 	}
 }
 
-// serve selects a transport based on TYPST_D2_MCP_TRANSPORT. Default is
-// stdio, preserving the previously installed behavior. Setting the env to
-// "http" starts a streamable-HTTP MCP server on TYPST_D2_MCP_ADDR
-// (default :8080) at TYPST_D2_MCP_PATH (default /mcp).
+// selectResolver picks the active workspace.Resolver:
+//
+//   - If TYPST_D2_MCP_WORKSPACE is set, a ScopedFS rooted there is used
+//     regardless of transport. This is the "hosted" / sandboxed shape and
+//     is required for HTTP mode in any deployment that isn't a personal
+//     localhost experiment.
+//
+//   - Otherwise, stdio mode keeps the existing LocalFS behavior so the
+//     installed CLI experience is unchanged.
+//
+//   - HTTP without a workspace env falls back to a per-process default
+//     under the system tmp dir. Suitable for "I just want to try the HTTP
+//     transport on my laptop"; real deployments should set the env.
+func selectResolver() (workspace.Resolver, error) {
+	if root := os.Getenv(envWorkspace); root != "" {
+		return workspace.NewScopedFS(root)
+	}
+	if isHTTPTransport() {
+		fallback := filepath.Join(os.TempDir(), "typst-d2-mcp-workspace")
+		fmt.Fprintf(os.Stderr, "%s: no %s set, using temporary workspace %s\n",
+			serverName, envWorkspace, fallback)
+		return workspace.NewScopedFS(fallback)
+	}
+	return workspace.LocalFS{}, nil
+}
+
+func isHTTPTransport() bool {
+	t := strings.ToLower(os.Getenv(envTransport))
+	return t == "http" || t == "streamable-http"
+}
+
 func serve(s *server.MCPServer) error {
 	switch transport := strings.ToLower(os.Getenv(envTransport)); transport {
 	case "", "stdio":
@@ -123,7 +168,14 @@ func serve(s *server.MCPServer) error {
 		if path == "" {
 			path = defaultPath
 		}
-		httpSrv := server.NewStreamableHTTPServer(s, server.WithEndpointPath(path))
+		// Stateless: each request stands on its own. Per-tenant state is
+		// not derived from the MCP session — it will come from auth in a
+		// follow-up sub-issue. Stateless avoids forcing clients to thread
+		// a Mcp-Session-Id header through every call.
+		httpSrv := server.NewStreamableHTTPServer(s,
+			server.WithEndpointPath(path),
+			server.WithStateLess(true),
+		)
 		fmt.Fprintf(os.Stderr, "%s listening on http://%s%s\n", serverName, addr, path)
 		return httpSrv.Start(addr)
 	default:
@@ -131,7 +183,7 @@ func serve(s *server.MCPServer) error {
 	}
 }
 
-func registerTools(s *server.MCPServer) {
+func registerTools(s *server.MCPServer, resolver workspace.Resolver) {
 	// The bulk of the layout strategy lives in server instructions above so
 	// it isn't re-sent on every tool call. The description below carries
 	// only the rules the model needs at the moment it decides to call.
@@ -141,7 +193,9 @@ func registerTools(s *server.MCPServer) {
 The input file is preprocessed in place: each #d2(opts)[code] block is
 rendered to SVG via the d2 CLI, base64-embedded, and the resulting Typst
 source is compiled with the typst CLI. The output PDF is written next to
-the input .typ file.
+the input .typ file inside the active workspace, and a resource_link
+content block in the result points at the PDF (fetch the bytes with
+resources/read on its typst-d2://pdf/... URI).
 
 Quick rules (full strategy in the server's instructions):
   - Default layout "elk", theme "0" for print-friendly diagrams.
@@ -153,59 +207,182 @@ After compiling, inspect the PDF if you can; if a diagram looks cramped,
 split it, simplify it, or switch to 'direction: down'.`),
 		mcp.WithString("file_path",
 			mcp.Required(),
-			mcp.Description("Absolute path to the Typst source file (.typ) containing #d2[...] blocks"),
+			mcp.Description("Path to the Typst source file (.typ) containing #d2[...] blocks. Absolute in local stdio mode; workspace-relative in scoped/hosted mode."),
 		),
 	)
-	s.AddTool(compileTypstTool, handleCompileTypst)
+	s.AddTool(compileTypstTool, handleCompileTypst(resolver))
+
+	putFileTool := mcp.NewTool("put_file",
+		mcp.WithDescription(`Write a file into the server's active workspace.
+
+Use this only when your runtime cannot directly write to the target
+filesystem — for example when talking to a hosted MCP server over HTTP.
+When running against a local stdio server, prefer your host's filesystem
+tools (Write/Edit) so you don't ship the file content through this
+channel.
+
+The path is resolved through the server's active workspace. In local
+mode any path is accepted; in scoped/hosted mode the path must be
+relative and stay within the workspace (traversal is rejected).`),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Destination path. Workspace-relative in scoped/hosted mode; any path in local mode."),
+		),
+		mcp.WithString("content",
+			mcp.Required(),
+			mcp.Description("File content, decoded according to encoding."),
+		),
+		mcp.WithString("encoding",
+			mcp.Description(`"utf8" (default) for text or "base64" for binary data.`),
+		),
+	)
+	s.AddTool(putFileTool, handlePutFile(resolver))
 }
 
-func handleCompileTypst(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	filePath, err := request.RequireString("file_path")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+func registerResources(s *server.MCPServer, resolver workspace.Resolver) {
+	tmpl := mcp.ResourceTemplate{
+		URITemplate: &mcp.URITemplate{Template: uritemplate.MustNew(pdfURIPrefix + "{+path}")},
+		Name:        "pdf",
+		Description: "Compiled Typst PDF produced by compile_typst_with_d2.",
+		MIMEType:    "application/pdf",
 	}
+	s.AddResourceTemplate(tmpl, handleReadPDF(resolver))
+}
 
-	resolver := workspace.LocalFS{}
-	resolved, err := workspace.MustExist(resolver, filePath)
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+func handleCompileTypst(resolver workspace.Resolver) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		filePath, err := request.RequireString("file_path")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		resolvedIn, err := workspace.MustExist(resolver, filePath)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		processed, err := preprocessor.Preprocess(resolver, filePath)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("Preprocessing failed", err), nil
+		}
+
+		tmpFile, err := os.CreateTemp("", "typst-d2-*.typ")
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("Failed to create temp file", err), nil
+		}
+		defer os.Remove(tmpFile.Name())
+
+		if _, err := tmpFile.WriteString(processed); err != nil {
+			return mcp.NewToolResultErrorFromErr("Failed to write temp file", err), nil
+		}
+		tmpFile.Close()
+
+		// Output PDF sits next to the input .typ inside the workspace.
+		resolvedOut := strings.TrimSuffix(resolvedIn, ".typ") + ".pdf"
+
+		cmd := exec.CommandContext(ctx, "typst", "compile", tmpFile.Name(), resolvedOut)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			errMsg := fmt.Sprintf("Typst compilation failed: %s\nOutput: %s", err.Error(), string(output))
+			return mcp.NewToolResultError(errMsg), nil
+		}
+
+		// Tool-visible path is the path the caller used, with .typ→.pdf;
+		// matches what the resource link encodes.
+		toolVisibleOut := strings.TrimSuffix(filePath, ".typ") + ".pdf"
+
+		successMsg := fmt.Sprintf("Successfully compiled to %s\n\n", toolVisibleOut)
+		successMsg += "NEXT STEPS:\n"
+		successMsg += "1. Open the PDF to verify diagram layout and readability\n"
+		successMsg += "2. Check that diagrams fit within page margins (not cramped)\n"
+		successMsg += "3. Verify text labels are readable (not too small)\n"
+		successMsg += "4. If diagrams are cramped or text is tiny:\n"
+		successMsg += "   - Add 'direction: down' at top of D2 block (for A4 portrait)\n"
+		successMsg += "   - Split large diagrams into multiple focused diagrams\n"
+		successMsg += "   - Reduce number of nodes or simplify structure\n"
+		successMsg += "\nIf you cannot view the PDF yourself, inform the user to check the layout."
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.TextContent{Type: "text", Text: successMsg},
+				newPDFLink(toolVisibleOut),
+			},
+		}, nil
 	}
+}
 
-	processed, err := preprocessor.Preprocess(resolver, resolved)
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("Preprocessing failed", err), nil
+func handlePutFile(resolver workspace.Resolver) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		path, err := request.RequireString("path")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		content, err := request.RequireString("content")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		encoding := strings.ToLower(request.GetString("encoding", "utf8"))
+
+		var data []byte
+		switch encoding {
+		case "utf8", "utf-8", "":
+			data = []byte(content)
+		case "base64":
+			d, decErr := base64.StdEncoding.DecodeString(content)
+			if decErr != nil {
+				return mcp.NewToolResultErrorFromErr("base64 decode", decErr), nil
+			}
+			data = d
+		default:
+			return mcp.NewToolResultError(fmt.Sprintf("unknown encoding %q (expected utf8 or base64)", encoding)), nil
+		}
+
+		if _, err := workspace.WriteFile(resolver, path, data); err != nil {
+			return mcp.NewToolResultErrorFromErr("write file", err), nil
+		}
+		return mcp.NewToolResultText(fmt.Sprintf("wrote %d bytes to %s", len(data), path)), nil
 	}
+}
 
-	tmpFile, err := os.CreateTemp("", "typst-d2-*.typ")
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("Failed to create temp file", err), nil
+func handleReadPDF(resolver workspace.Resolver) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		uri := request.Params.URI
+		if !strings.HasPrefix(uri, pdfURIPrefix) {
+			return nil, fmt.Errorf("not a typst-d2 PDF URI: %s", uri)
+		}
+		raw := strings.TrimPrefix(uri, pdfURIPrefix)
+		path, err := url.PathUnescape(raw)
+		if err != nil {
+			return nil, fmt.Errorf("decode URI path: %w", err)
+		}
+		resolved, err := workspace.MustExist(resolver, path)
+		if err != nil {
+			return nil, err
+		}
+		bytes, err := os.ReadFile(resolved)
+		if err != nil {
+			return nil, fmt.Errorf("read pdf: %w", err)
+		}
+		return []mcp.ResourceContents{
+			mcp.BlobResourceContents{
+				URI:      uri,
+				MIMEType: "application/pdf",
+				Blob:     base64.StdEncoding.EncodeToString(bytes),
+			},
+		}, nil
 	}
-	defer os.Remove(tmpFile.Name())
+}
 
-	if _, err := tmpFile.WriteString(processed); err != nil {
-		return mcp.NewToolResultErrorFromErr("Failed to write temp file", err), nil
-	}
-	tmpFile.Close()
-
-	outPath := strings.TrimSuffix(resolved, ".typ") + ".pdf"
-
-	cmd := exec.CommandContext(ctx, "typst", "compile", tmpFile.Name(), outPath)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		errMsg := fmt.Sprintf("Typst compilation failed: %s\nOutput: %s", err.Error(), string(output))
-		return mcp.NewToolResultError(errMsg), nil
-	}
-
-	successMsg := fmt.Sprintf("Successfully compiled to %s\n\n", outPath)
-	successMsg += "NEXT STEPS:\n"
-	successMsg += "1. Open the PDF to verify diagram layout and readability\n"
-	successMsg += "2. Check that diagrams fit within page margins (not cramped)\n"
-	successMsg += "3. Verify text labels are readable (not too small)\n"
-	successMsg += "4. If diagrams are cramped or text is tiny:\n"
-	successMsg += "   - Add 'direction: down' at top of D2 block (for A4 portrait)\n"
-	successMsg += "   - Split large diagrams into multiple focused diagrams\n"
-	successMsg += "   - Reduce number of nodes or simplify structure\n"
-	successMsg += "\nIf you cannot view the PDF yourself, inform the user to check the layout."
-
-	return mcp.NewToolResultText(successMsg), nil
+// newPDFLink builds the ResourceLink content block returned alongside the
+// compile-success text. The URI uses our private typst-d2:// scheme so
+// clients route the fetch through resources/read, where the same active
+// resolver re-validates the path — even a stdio client gets bytes through
+// the same channel that an HTTP client uses.
+func newPDFLink(path string) mcp.ResourceLink {
+	return mcp.NewResourceLink(
+		pdfURIPrefix+url.PathEscape(path),
+		filepath.Base(path),
+		"Compiled Typst PDF",
+		"application/pdf",
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/dlouwers/typst-d2-mcp
 
 go 1.23.0
 
-require github.com/mark3labs/mcp-go v0.45.0
+require (
+	github.com/mark3labs/mcp-go v0.45.0
+	github.com/yosida95/uritemplate/v3 v3.0.2
+)
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
@@ -12,6 +15,5 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
-	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,17 +1,18 @@
 // Package workspace abstracts the mapping from tool-visible paths to
 // concrete on-disk paths the server can read and write.
 //
-// In stdio (local) mode the server shares a filesystem with its client, so
-// paths are passed through unchanged. In a future HTTP (hosted) mode a
-// TenantWorkspace resolver will scope every path under a per-user root,
-// allowing the same compile_typst_with_d2(file_path) tool API to work
-// transparently in either deployment.
+// LocalFS is used in stdio (local) mode where the server and client
+// share a filesystem; paths pass through unchanged. ScopedFS confines
+// every path under a configured root and rejects traversal, used in
+// HTTP (hosted) mode so the same file_path API works against a
+// server-managed workspace.
 package workspace
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Resolver maps a tool-visible path to a concrete filesystem path the
@@ -56,6 +57,76 @@ func MustExist(r Resolver, path string) (string, error) {
 	}
 	if info.IsDir() {
 		return "", fmt.Errorf("path is a directory, not a file: %s", path)
+	}
+	return resolved, nil
+}
+
+// ScopedFS confines every resolved path under Root. Absolute inputs are
+// rejected; traversal sequences ("..") that climb above Root are rejected
+// even when the textual path itself looks benign. Used in HTTP/hosted
+// mode where the same file_path API must operate on a server-managed
+// workspace rather than the client's filesystem.
+type ScopedFS struct {
+	// Root is the absolute filesystem path that bounds every resolution.
+	// Callers should pass an already-cleaned absolute path; NewScopedFS
+	// handles that for them.
+	Root string
+}
+
+// NewScopedFS prepares a ScopedFS rooted at root, creating the directory
+// (mode 0o700) if it does not yet exist. The stored Root is the cleaned
+// absolute form.
+func NewScopedFS(root string) (*ScopedFS, error) {
+	if root == "" {
+		return nil, fmt.Errorf("empty workspace root")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("abs(%q): %w", root, err)
+	}
+	abs = filepath.Clean(abs)
+	if err := os.MkdirAll(abs, 0o700); err != nil {
+		return nil, fmt.Errorf("create workspace root: %w", err)
+	}
+	return &ScopedFS{Root: abs}, nil
+}
+
+// Resolve joins path under Root and rejects any input that escapes it.
+// Absolute paths are rejected so that the same tool surface ("a relative
+// path inside the workspace") works regardless of transport.
+func (s *ScopedFS) Resolve(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	if filepath.IsAbs(path) {
+		return "", fmt.Errorf("absolute paths are not allowed in scoped workspace: %s", path)
+	}
+	joined := filepath.Join(s.Root, path)
+	cleaned := filepath.Clean(joined)
+	rel, err := filepath.Rel(s.Root, cleaned)
+	if err != nil {
+		return "", fmt.Errorf("rel(%q, %q): %w", s.Root, cleaned, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path escapes workspace: %s", path)
+	}
+	return cleaned, nil
+}
+
+// WriteFile resolves path through r and writes content, creating parent
+// directories as needed. It is the back-end for the put_file MCP tool.
+// The returned string is the resolved on-disk path (useful for logging /
+// tests); callers should not echo it back to clients in HTTP mode.
+func WriteFile(r Resolver, path string, content []byte) (string, error) {
+	resolved, err := r.Resolve(path)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(resolved), 0o700); err != nil {
+		return "", fmt.Errorf("create parent dirs: %w", err)
+	}
+	if err := os.WriteFile(resolved, content, 0o600); err != nil {
+		return "", fmt.Errorf("write file: %w", err)
 	}
 	return resolved, nil
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -32,6 +32,95 @@ func TestLocalFS_Resolve(t *testing.T) {
 	}
 }
 
+func TestScopedFS_Resolve(t *testing.T) {
+	root := t.TempDir()
+	s, err := NewScopedFS(root)
+	if err != nil {
+		t.Fatalf("NewScopedFS: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string // substring; "" means success
+	}{
+		{"relative ok", "a/b.typ", ""},
+		{"redundant slashes", "a//b.typ", ""},
+		{"dot prefix ok", "./a/b.typ", ""},
+		{"interior dotdot ok", "a/b/../c.typ", ""},
+		{"empty rejected", "", "empty path"},
+		{"absolute rejected", "/etc/passwd", "absolute"},
+		{"traversal direct", "../escape.typ", "escapes workspace"},
+		{"traversal nested", "a/../../escape.typ", "escapes workspace"},
+		{"traversal trailing", "a/b/../../..", "escapes workspace"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.Resolve(tt.input)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Resolve(%q) err=%v, want substring %q", tt.input, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve(%q): unexpected err %v", tt.input, err)
+			}
+			if !strings.HasPrefix(got, s.Root+string(os.PathSeparator)) && got != s.Root {
+				t.Errorf("Resolve(%q) = %q, want path under %q", tt.input, got, s.Root)
+			}
+		})
+	}
+}
+
+func TestNewScopedFS_CreatesRoot(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "ws")
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s should not exist yet", root)
+	}
+	s, err := NewScopedFS(root)
+	if err != nil {
+		t.Fatalf("NewScopedFS: %v", err)
+	}
+	info, err := os.Stat(s.Root)
+	if err != nil {
+		t.Fatalf("workspace root not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("workspace root is not a directory")
+	}
+}
+
+func TestWriteFile_LocalFS(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "nested", "doc.typ")
+	if _, err := WriteFile(LocalFS{}, target, []byte("hello")); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("got %q want %q", got, "hello")
+	}
+}
+
+func TestWriteFile_ScopedFS_TraversalRejected(t *testing.T) {
+	root := t.TempDir()
+	s, err := NewScopedFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteFile(s, "../escape.typ", []byte("nope")); err == nil {
+		t.Fatal("expected traversal error, got nil")
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(root), "escape.typ")); err == nil {
+		t.Errorf("file was written outside workspace root")
+	}
+}
+
 func TestMustExist(t *testing.T) {
 	dir := t.TempDir()
 	existing := filepath.Join(dir, "ok.typ")


### PR DESCRIPTION
Second sub-issue of the hosted/local parity epic #2. Makes the HTTP transport from #3 actually usable end-to-end — the LLM can populate a server-side workspace, compile against a workspace-relative path, and pull the resulting PDF back through the standard MCP `resources/read`.

## What changed

- **`workspace.ScopedFS`** confines every resolution under `Root`, rejects absolute paths, and rejects traversal even via clean intermediate paths. `NewScopedFS` creates the root with mode `0o700` if missing. New `workspace.WriteFile` helper backs `put_file`.
- **Resolver selection**: `TYPST_D2_MCP_WORKSPACE` switches either transport to `ScopedFS` at that root. Without it, stdio keeps `LocalFS` (back-compat) and HTTP falls back to `$TMPDIR/typst-d2-mcp-workspace`.
- **`put_file(path, content, encoding?)`** writes utf8 or base64 content into the active workspace. Its description tells the LLM to prefer host write tools when running locally so file content doesn't ride the MCP channel unnecessarily.
- **`compile_typst_with_d2`** result is now `Content=[text, resource_link]` with a `typst-d2://pdf/{+path}` URI. The existing prose text is unchanged for back-compat.
- **PDF resource template** registered via `AddResourceTemplate`; the handler re-resolves through the active resolver and returns `BlobResourceContents` (`application/pdf`, base64).
- **HTTP server is now stateless** (`WithStateLess(true)`). Sessions don't carry identity yet (that's the auth sub-issue), and statelessness keeps the API uniform across transports.

## End-to-end smoke (real d2 + typst in devcontainer)

```
stdio (LocalFS):
  compile → text + resource_link
  resources/read on the link → 14260-byte PDF (%PDF- header)

HTTP (ScopedFS workspace):
  put_file doc.typ              → 108 bytes written
  put_file ../escape.typ        → rejected (traversal)
  compile doc.typ               → text + resource_link (typst-d2://pdf/doc.pdf)
  resources/read on the link    → 14260-byte PDF
```

`go vet`, `go test`, `golangci-lint`, `govulncheck` all clean.

## Follow-ups (still on the umbrella)

- #2.5 - Proper Go integration tests covering both transports (replacing the ad-hoc Python smoke harness used during dev).
- #3 - Auth (GitHub OAuth + API keys); per-tenant workspaces derived from identity.
- #4 - Quota enforcement (1 compile / UTC day / user) once identity exists.
- #5 - Outbound PDF storage / signed URLs as an alternative to embedded blob (matters once PDFs get bigger or need to be shareable).
- #6 - Sandboxing + abuse caps.

Refers #2