### PR TITLE
feat(mcp): per-compile timeout + input-size cap

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/dlouwers/typst-d2-mcp/internal/preprocessor"
 	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
@@ -21,19 +23,63 @@ const (
 	serverName    = "typst-d2-mcp"
 	serverVersion = "1.0.0"
 
-	envTransport = "TYPST_D2_MCP_TRANSPORT"
-	envAddr      = "TYPST_D2_MCP_ADDR"
-	envPath      = "TYPST_D2_MCP_PATH"
-	envWorkspace = "TYPST_D2_MCP_WORKSPACE"
+	envTransport      = "TYPST_D2_MCP_TRANSPORT"
+	envAddr           = "TYPST_D2_MCP_ADDR"
+	envPath           = "TYPST_D2_MCP_PATH"
+	envWorkspace      = "TYPST_D2_MCP_WORKSPACE"
+	envCompileTimeout = "TYPST_D2_MCP_COMPILE_TIMEOUT"
+	envMaxInputBytes  = "TYPST_D2_MCP_MAX_INPUT_BYTES"
 
-	defaultAddr = ":8080"
-	defaultPath = "/mcp"
+	defaultAddr           = ":8080"
+	defaultPath           = "/mcp"
+	defaultCompileTimeout = 30 * time.Second
+	defaultMaxInputBytes  = int64(1 << 20) // 1 MiB
 
 	// pdfURIPrefix is the scheme + host used by the compile tool when it
 	// returns a ResourceLink for the produced PDF. Clients can fetch the
 	// bytes via the standard MCP resources/read call against this URI.
 	pdfURIPrefix = "typst-d2://pdf/"
 )
+
+// compileTimeout reads the configured per-compile budget. A value of zero
+// disables the extra timeout and leaves the calling request context in
+// charge.
+func compileTimeout() time.Duration {
+	return durationEnv(envCompileTimeout, defaultCompileTimeout)
+}
+
+// maxInputBytes is the upper bound on accepted file content (both the
+// .typ file fed to compile_typst_with_d2 and the decoded content written
+// by put_file). It bounds memory + parser work before any d2/typst exec.
+func maxInputBytes() int64 {
+	return int64Env(envMaxInputBytes, defaultMaxInputBytes)
+}
+
+func durationEnv(key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d < 0 {
+		fmt.Fprintf(os.Stderr, "%s: invalid duration %q, using default %s\n", key, v, def)
+		return def
+	}
+	return d
+}
+
+func int64Env(key string, def int64) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n < 0 {
+		fmt.Fprintf(os.Stderr, "%s: invalid integer %q, using default %d\n", key, v, def)
+		return def
+	}
+	return n
+}
 
 // serverInstructions is sent once at the MCP initialize handshake. Moving
 // this guidance out of the per-tool description keeps it available to the
@@ -261,8 +307,29 @@ func handleCompileTypst(resolver workspace.Resolver) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		processed, err := preprocessor.Preprocess(resolver, filePath)
+		if info, err := os.Stat(resolvedIn); err == nil {
+			if limit := maxInputBytes(); info.Size() > limit {
+				return mcp.NewToolResultError(fmt.Sprintf(
+					"input file too large: %d bytes (limit %d, set %s to raise)",
+					info.Size(), limit, envMaxInputBytes,
+				)), nil
+			}
+		}
+
+		if tmo := compileTimeout(); tmo > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, tmo)
+			defer cancel()
+		}
+
+		processed, err := preprocessor.Preprocess(ctx, resolver, filePath)
 		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return mcp.NewToolResultError(fmt.Sprintf(
+					"compile exceeded %s (set %s to raise)",
+					compileTimeout(), envCompileTimeout,
+				)), nil
+			}
 			return mcp.NewToolResultErrorFromErr("Preprocessing failed", err), nil
 		}
 
@@ -283,6 +350,12 @@ func handleCompileTypst(resolver workspace.Resolver) server.ToolHandlerFunc {
 		cmd := exec.CommandContext(ctx, "typst", "compile", tmpFile.Name(), resolvedOut)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return mcp.NewToolResultError(fmt.Sprintf(
+					"compile exceeded %s (set %s to raise)",
+					compileTimeout(), envCompileTimeout,
+				)), nil
+			}
 			errMsg := fmt.Sprintf("Typst compilation failed: %s\nOutput: %s", err.Error(), string(output))
 			return mcp.NewToolResultError(errMsg), nil
 		}
@@ -335,6 +408,13 @@ func handlePutFile(resolver workspace.Resolver) server.ToolHandlerFunc {
 			data = d
 		default:
 			return mcp.NewToolResultError(fmt.Sprintf("unknown encoding %q (expected utf8 or base64)", encoding)), nil
+		}
+
+		if limit := maxInputBytes(); int64(len(data)) > limit {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"content too large: %d bytes (limit %d, set %s to raise)",
+				len(data), limit, envMaxInputBytes,
+			)), nil
 		}
 
 		if _, err := workspace.WriteFile(resolver, path, data); err != nil {

--- a/cmd/typst-d2-mcp/main_test.go
+++ b/cmd/typst-d2-mcp/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDurationEnv(t *testing.T) {
+	const key = "TYPST_D2_MCP_TEST_DURATION"
+	tests := []struct {
+		name string
+		set  string
+		want time.Duration
+	}{
+		{"unset uses default", "", 17 * time.Second},
+		{"valid duration", "5s", 5 * time.Second},
+		{"valid sub-second", "250ms", 250 * time.Millisecond},
+		{"garbage falls back", "not-a-duration", 17 * time.Second},
+		{"negative falls back", "-1s", 17 * time.Second},
+		{"zero accepted", "0", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(key, tt.set)
+			if got := durationEnv(key, 17*time.Second); got != tt.want {
+				t.Errorf("durationEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInt64Env(t *testing.T) {
+	const key = "TYPST_D2_MCP_TEST_INT"
+	tests := []struct {
+		name string
+		set  string
+		want int64
+	}{
+		{"unset uses default", "", 100},
+		{"valid integer", "4096", 4096},
+		{"zero accepted", "0", 0},
+		{"garbage falls back", "abc", 100},
+		{"negative falls back", "-1", 100},
+		{"large value", "1099511627776", 1099511627776},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(key, tt.set)
+			if got := int64Env(key, 100); got != tt.want {
+				t.Errorf("int64Env() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/d2/d2.go
+++ b/internal/d2/d2.go
@@ -3,6 +3,7 @@ package d2
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 )
@@ -11,8 +12,10 @@ import (
 type Options map[string]string
 
 // Render executes the D2 CLI to render D2 code to SVG.
-// Uses stdin->stdout streaming, no temporary files.
-func Render(code string, options Options) (string, error) {
+// Uses stdin->stdout streaming, no temporary files. The provided context
+// bounds the d2 invocation — pass a context.WithTimeout from the calling
+// tool handler to enforce per-compile budgets.
+func Render(ctx context.Context, code string, options Options) (string, error) {
 	cmd := []string{"d2"}
 
 	// Add options
@@ -44,7 +47,7 @@ func Render(code string, options Options) (string, error) {
 	cmd = append(cmd, "-", "-")
 
 	// Execute D2
-	d2Cmd := exec.Command(cmd[0], cmd[1:]...)
+	d2Cmd := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
 	d2Cmd.Stdin = bytes.NewBufferString(code)
 
 	var stdout, stderr bytes.Buffer
@@ -52,6 +55,9 @@ func Render(code string, options Options) (string, error) {
 	d2Cmd.Stderr = &stderr
 
 	if err := d2Cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("d2 rendering: %w", ctx.Err())
+		}
 		if _, lookErr := exec.LookPath("d2"); lookErr != nil {
 			return "", fmt.Errorf("d2 command not found. Install from: https://d2lang.com/tour/install")
 		}

--- a/internal/preprocessor/preprocessor.go
+++ b/internal/preprocessor/preprocessor.go
@@ -2,6 +2,7 @@
 package preprocessor
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -23,17 +24,20 @@ type D2Block struct {
 
 // PreprocessFile reads a Typst file from the local filesystem, processes all
 // D2 blocks, and returns the modified content. It is a back-compat wrapper
-// around Preprocess that uses workspace.LocalFS as the resolver, preserving
-// the original behavior used by the typst-d2-prep CLI.
+// around Preprocess that uses workspace.LocalFS as the resolver and a
+// background context, preserving the original behavior used by the
+// typst-d2-prep CLI.
 func PreprocessFile(inputPath string) (string, error) {
-	return Preprocess(workspace.LocalFS{}, inputPath)
+	return Preprocess(context.Background(), workspace.LocalFS{}, inputPath)
 }
 
 // Preprocess resolves inputPath through the supplied workspace.Resolver,
 // reads the resulting file, processes all D2 blocks, and returns the
 // modified Typst content. Callers in HTTP mode pass a tenant-scoped
-// resolver; the stdio path passes workspace.LocalFS.
-func Preprocess(r workspace.Resolver, inputPath string) (string, error) {
+// resolver; the stdio path passes workspace.LocalFS. The context bounds
+// each d2.Render invocation — pass a context.WithTimeout from the tool
+// handler to enforce a per-compile budget.
+func Preprocess(ctx context.Context, r workspace.Resolver, inputPath string) (string, error) {
 	resolved, err := r.Resolve(inputPath)
 	if err != nil {
 		return "", fmt.Errorf("resolve path: %w", err)
@@ -63,7 +67,7 @@ func Preprocess(r workspace.Resolver, inputPath string) (string, error) {
 		fmt.Fprintf(os.Stderr, "  [%d/%d] Rendering diagram...\n", len(d2Blocks)-i, len(d2Blocks))
 
 		// Render D2 to SVG
-		svg, err := d2.Render(block.Code, block.Options)
+		svg, err := d2.Render(ctx, block.Code, block.Options)
 		if err != nil {
 			return "", fmt.Errorf("failed to render diagram %d: %w", i+1, err)
 		}


### PR DESCRIPTION
Third sub-issue of the hosted/local parity epic #2. Abuse caps that are cheap to ship now and hard to retrofit once auth + quota are wired up. A malicious or runaway LLM can no longer wedge the server by submitting a giant `.typ` or by triggering a slow/infinite Typst/D2 evaluation.

## What changed

- **`internal/d2.Render`** now takes a `context.Context` and uses `exec.CommandContext`. `context.DeadlineExceeded` surfaces as a clean rendering error.
- **`internal/preprocessor.Preprocess`** takes the context and threads it to `d2.Render`. `PreprocessFile(path)` keeps its zero-arg shape (used by the `typst-d2-prep` CLI) by passing `context.Background()`.
- **Per-compile timeout** via `TYPST_D2_MCP_COMPILE_TIMEOUT` (default `30s`, set to `0` to defer to caller ctx). `compile_typst_with_d2` wraps the request ctx with `context.WithTimeout` before preprocessing or invoking typst; deadline-exceeded is returned as a structured tool error.
- **Input-size cap** via `TYPST_D2_MCP_MAX_INPUT_BYTES` (default `1 MiB`): applied to `compile_typst_with_d2`'s input file (`Stat` before reading) and to `put_file`'s decoded content. Limit is included in the error message so operators can raise it intentionally.
- Unit tests for the env-parsing helpers.

## Smoke results (devcontainer, real d2 + typst)

```
size cap (TYPST_D2_MCP_MAX_INPUT_BYTES=1024):
  small put_file (100 bytes)             → ok
  big put_file (2048 bytes)              → rejected: "too large"
  oversized compile input                → rejected: "too large"

timeout knob (TYPST_D2_MCP_COMPILE_TIMEOUT=60s):
  normal compile                         → resource_link returned

timeout knob (TYPST_D2_MCP_COMPILE_TIMEOUT=1ms):
  normal compile                         → rejected: "exceeded"
```

`go vet`, `go test`, `golangci-lint`, `govulncheck` all clean.

## Deferred to ops / deployment

These belong to the runtime environment, not the binary:

- **Privilege drop** — run the d2 / typst child processes as a non-root user, ideally under a Linux user namespace or seccomp policy. Document in the deployment guide once it lands.
- **Typst offline mode** — pass `--package-cache-path` pointing at a pre-populated cache (with `@preview/based` already present) and run the container in a network namespace that blocks egress. Prevents the typst child from fetching arbitrary `@preview` packages.

Refers #2