### PR TITLE
feat(mcp): per-user UTC-day compile quota (the "1 doc/day" tier)

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -39,11 +40,13 @@ const (
 	envPublicURL    = "TYPST_D2_MCP_PUBLIC_URL"
 	envGitHubID     = "TYPST_D2_MCP_GITHUB_CLIENT_ID"
 	envGitHubSecret = "TYPST_D2_MCP_GITHUB_CLIENT_SECRET"
+	envQuotaPerDay  = "TYPST_D2_MCP_QUOTA_PER_DAY"
 
 	defaultAddr           = ":8080"
 	defaultPath           = "/mcp"
 	defaultCompileTimeout = 30 * time.Second
 	defaultMaxInputBytes  = int64(1 << 20) // 1 MiB
+	defaultQuotaPerDay    = 1
 
 	// pdfURIPrefix is the scheme + host used by the compile tool when it
 	// returns a ResourceLink for the produced PDF. Clients can fetch the
@@ -63,6 +66,14 @@ func compileTimeout() time.Duration {
 // by put_file). It bounds memory + parser work before any d2/typst exec.
 func maxInputBytes() int64 {
 	return int64Env(envMaxInputBytes, defaultMaxInputBytes)
+}
+
+// quotaPerDay is the per-user UTC-day ceiling on successful compile
+// attempts; 0 disables the check. Only enforced for non-anonymous
+// identities (i.e. authenticated users), so self-hosted single-tenant
+// deployments stay unmetered.
+func quotaPerDay() int {
+	return int(int64Env(envQuotaPerDay, int64(defaultQuotaPerDay)))
 }
 
 func durationEnv(key string, def time.Duration) time.Duration {
@@ -163,7 +174,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	backend, ghHandlers, closer, err := selectAuth()
+	backend, ghHandlers, store, closer, err := selectAuth()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Auth setup: %v\n", err)
 		os.Exit(1)
@@ -180,10 +191,10 @@ func main() {
 		server.WithInstructions(serverInstructions),
 	)
 
-	registerTools(s, factory)
+	registerTools(s, factory, store)
 	registerResources(s, factory)
 
-	fmt.Fprintf(os.Stderr, "%s: auth=%s\n", serverName, backend.Name())
+	fmt.Fprintf(os.Stderr, "%s: auth=%s quota_per_day=%d\n", serverName, backend.Name(), quotaPerDay())
 
 	if err := serve(s, backend, ghHandlers); err != nil {
 		fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
@@ -231,28 +242,30 @@ func selectFactory() (workspace.Factory, error) {
 	return workspace.TenantFactory{Root: abs}, nil
 }
 
-// selectAuth picks the active auth.Backend and, for the GitHub backend,
-// returns its HTTP handlers and a cleanup closure (the SQLite store).
-func selectAuth() (auth.Backend, *gitHubHandlers, func(), error) {
+// selectAuth picks the active auth.Backend and, for the GitHub
+// backend, returns its HTTP handlers, the shared SQLite store (used by
+// both auth lookups and the compile-quota counter), and a cleanup
+// closure that closes the store. For AUTH=none the store is nil.
+func selectAuth() (auth.Backend, *gitHubHandlers, *authdb.Store, func(), error) {
 	mode := strings.ToLower(os.Getenv(envAuth))
 	switch mode {
 	case "", "none":
-		return auth.None{}, nil, nil, nil
+		return auth.None{}, nil, nil, nil, nil
 	case "github":
 		dbPath := os.Getenv(envDB)
 		if dbPath == "" {
-			return nil, nil, nil, fmt.Errorf("%s=github requires %s to be set", envAuth, envDB)
+			return nil, nil, nil, nil, fmt.Errorf("%s=github requires %s to be set", envAuth, envDB)
 		}
 		clientID := os.Getenv(envGitHubID)
 		clientSecret := os.Getenv(envGitHubSecret)
 		publicURL := os.Getenv(envPublicURL)
 		if clientID == "" || clientSecret == "" || publicURL == "" {
-			return nil, nil, nil, fmt.Errorf("%s=github requires %s, %s, and %s",
+			return nil, nil, nil, nil, fmt.Errorf("%s=github requires %s, %s, and %s",
 				envAuth, envGitHubID, envGitHubSecret, envPublicURL)
 		}
 		store, err := authdb.Open(dbPath)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("open auth db: %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("open auth db: %w", err)
 		}
 		gh := &auth.GitHub{
 			Cfg: auth.GitHubConfig{
@@ -263,9 +276,9 @@ func selectAuth() (auth.Backend, *gitHubHandlers, func(), error) {
 			Store: store,
 		}
 		closer := func() { _ = store.Close() }
-		return gh, &gitHubHandlers{login: gh.ServeLogin, callback: gh.ServeCallback}, closer, nil
+		return gh, &gitHubHandlers{login: gh.ServeLogin, callback: gh.ServeCallback}, store, closer, nil
 	default:
-		return nil, nil, nil, fmt.Errorf("unknown %s=%q (expected none or github)", envAuth, mode)
+		return nil, nil, nil, nil, fmt.Errorf("unknown %s=%q (expected none or github)", envAuth, mode)
 	}
 }
 
@@ -344,7 +357,7 @@ func resolverFor(ctx context.Context, factory workspace.Factory) (workspace.Reso
 }
 
 
-func registerTools(s *server.MCPServer, factory workspace.Factory) {
+func registerTools(s *server.MCPServer, factory workspace.Factory, store *authdb.Store) {
 	// The bulk of the layout strategy lives in server instructions above so
 	// it isn't re-sent on every tool call. The description below carries
 	// only the rules the model needs at the moment it decides to call.
@@ -371,7 +384,7 @@ split it, simplify it, or switch to 'direction: down'.`),
 			mcp.Description("Path to the Typst source file (.typ) containing #d2[...] blocks. Absolute in local stdio mode; workspace-relative in scoped/hosted mode."),
 		),
 	)
-	s.AddTool(compileTypstTool, handleCompileTypst(factory))
+	s.AddTool(compileTypstTool, handleCompileTypst(factory, store))
 
 	putFileTool := mcp.NewTool("put_file",
 		mcp.WithDescription(`Write a file into the server's active workspace.
@@ -410,11 +423,29 @@ func registerResources(s *server.MCPServer, factory workspace.Factory) {
 	s.AddResourceTemplate(tmpl, handleReadPDF(factory))
 }
 
-func handleCompileTypst(factory workspace.Factory) server.ToolHandlerFunc {
+func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		filePath, err := request.RequireString("file_path")
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		// Quota gate runs first so a quota-exceeded user pays no
+		// compute cost. Only authenticated identities are metered;
+		// stdio + AUTH=none stay unlimited.
+		id, _ := identity.FromContext(ctx)
+		if store != nil && !id.IsAnonymous() {
+			limit := quotaPerDay()
+			today := time.Now().UTC().Format("2006-01-02")
+			if err := store.IncrementCompile(ctx, id.UserID, today, limit); err != nil {
+				if errors.Is(err, authdb.ErrQuotaExceeded) {
+					return mcp.NewToolResultError(fmt.Sprintf(
+						"quota exceeded: %d compile(s) per UTC day per user (resets at 00:00 UTC; set %s to raise)",
+						limit, envQuotaPerDay,
+					)), nil
+				}
+				return mcp.NewToolResultErrorFromErr("quota check", err), nil
+			}
 		}
 
 		resolver, err := resolverFor(ctx, factory)

--- a/internal/authdb/authdb.go
+++ b/internal/authdb/authdb.go
@@ -26,6 +26,10 @@ import (
 // plaintext does not match any stored hash.
 var ErrInvalidKey = errors.New("invalid api key")
 
+// ErrQuotaExceeded is returned by IncrementCompile when the caller
+// has already reached the configured per-day quota.
+var ErrQuotaExceeded = errors.New("quota exceeded")
+
 // keyPrefix tags every plaintext key so support / logging code can
 // recognise leaks at a glance and operators can grep for them.
 const keyPrefix = "ttd2_"
@@ -69,6 +73,12 @@ CREATE TABLE IF NOT EXISTS api_keys (
   key_hash     BLOB    NOT NULL UNIQUE,
   created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   last_used_at TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS compiles (
+  user_id  TEXT    NOT NULL,
+  utc_date TEXT    NOT NULL,
+  count    INTEGER NOT NULL,
+  PRIMARY KEY(user_id, utc_date)
 );
 `
 	_, err := s.db.Exec(ddl)
@@ -153,4 +163,48 @@ WHERE k.key_hash = ?
 		GitHubLogin: githubLogin,
 		Email:       email.String,
 	}, nil
+}
+
+// IncrementCompile atomically reads the user's compile count for
+// utcDate and increments it. It returns ErrQuotaExceeded if the count
+// already equals or exceeds limit before the increment; in that case
+// no row is changed. A limit <= 0 is treated as "no quota" and the
+// call returns nil without touching the database.
+//
+// utcDate is the caller-supplied YYYY-MM-DD string for the day the
+// compile is attributed to. Passing it explicitly (rather than
+// computing it inside the store) lets tests cover day-rollover
+// without waiting for midnight.
+func (s *Store) IncrementCompile(ctx context.Context, userID, utcDate string, limit int) error {
+	if limit <= 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var count int
+	err = tx.QueryRowContext(ctx,
+		`SELECT count FROM compiles WHERE user_id = ? AND utc_date = ?`,
+		userID, utcDate,
+	).Scan(&count)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("read compile count: %w", err)
+	}
+	if count >= limit {
+		return ErrQuotaExceeded
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO compiles(user_id, utc_date, count) VALUES(?, ?, 1)
+ON CONFLICT(user_id, utc_date) DO UPDATE SET count = count + 1
+`, userID, utcDate); err != nil {
+		return fmt.Errorf("upsert compile count: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
 }

--- a/internal/authdb/authdb_test.go
+++ b/internal/authdb/authdb_test.go
@@ -64,6 +64,50 @@ func TestIdentityForKey_Invalid(t *testing.T) {
 	}
 }
 
+func TestIncrementCompile_UnderAtOver(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	const u, day = "gh:42", "2026-05-19"
+
+	// Two successful increments under a limit of 3.
+	for i := 0; i < 2; i++ {
+		if err := s.IncrementCompile(ctx, u, day, 3); err != nil {
+			t.Fatalf("increment %d under limit: %v", i, err)
+		}
+	}
+
+	// Third hits the limit exactly — still allowed.
+	if err := s.IncrementCompile(ctx, u, day, 3); err != nil {
+		t.Fatalf("third increment (at limit boundary): %v", err)
+	}
+
+	// Fourth is over the limit.
+	err := s.IncrementCompile(ctx, u, day, 3)
+	if !errors.Is(err, ErrQuotaExceeded) {
+		t.Errorf("over-limit err = %v, want ErrQuotaExceeded", err)
+	}
+
+	// Same user, next day — fresh counter.
+	if err := s.IncrementCompile(ctx, u, "2026-05-20", 3); err != nil {
+		t.Errorf("next-day fresh counter: %v", err)
+	}
+
+	// Different user on the same day — independent counter.
+	if err := s.IncrementCompile(ctx, "gh:99", day, 1); err != nil {
+		t.Errorf("different user same day: %v", err)
+	}
+}
+
+func TestIncrementCompile_LimitZeroDisabled(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		if err := s.IncrementCompile(ctx, "gh:1", "2026-05-19", 0); err != nil {
+			t.Fatalf("limit=0 should be a no-op, got %v", err)
+		}
+	}
+}
+
 func TestUpsertRefreshesProfile(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
Fifth sub-issue of the hosted/local parity epic #2. Adds the actual free-tier ceiling the project was started to support, building directly on the identity now in request context (sub-issue #3).

## What changed

- **`authdb`** — new `compiles(user_id, utc_date, count)` table and `IncrementCompile(ctx, userID, utcDate, limit)` that wraps a `SELECT + UPSERT` in a single transaction. Returns `ErrQuotaExceeded` when the user has already hit the day's ceiling; `limit <= 0` is treated as "disabled" and short-circuits without touching the DB. `utcDate` is caller-supplied so tests cover day rollover without waiting for midnight.
- **`cmd/typst-d2-mcp`** — `TYPST_D2_MCP_QUOTA_PER_DAY` (default `1`, `0` disables). `compile_typst_with_d2` charges the counter **before** any preprocessing or exec, so a quota-exceeded user burns no CPU. Quota only applies to non-anonymous identities — stdio + `AUTH=none` deployments stay unmetered.

Only `compile_typst_with_d2` is metered; `put_file` and `resources/read` are not, since the actual d2 + typst CPU spend lives in the compile path.

## Tests

- `authdb_test.go`: increments under the limit; the third call at the boundary still succeeds; the fourth exceeds with `ErrQuotaExceeded`; next-day counter is independent; different user on the same day is independent; `limit=0` is a no-op.

## End-to-end smoke (devcontainer, real d2 + typst)

```
AUTH=github  QUOTA=2  user gh:42:
  compiles 1-2                  → ok
  compile 3                     → "quota exceeded" structured error
  put_file after exceed         → ok (not metered)
  different user gh:99          → fresh counter, first compile ok

AUTH=none    QUOTA=1:
  5 compiles back-to-back       → all ok (anonymous skips quota)
```

`go vet`, `go test`, `golangci-lint`, `govulncheck` all clean.

## Remaining on the umbrella

- **#5** Outbound PDF storage with TTL'd signed URLs (alternative to embedded blob in `resources/read`).
- **#7** Deployment + ops: Dockerfile, structured logging, deployment docs (network namespacing so the typst child can't fetch `@preview` packages over the public internet).
- **#8** Self-hosted parity verification (`AUTH=none` end-to-end check — already implicitly covered by the existing smokes).

Refers #2