### PR TITLE
feat(deploy): production Dockerfile + structured logs + ops docs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,137 @@
+# Deploying `typst-d2-mcp`
+
+This guide is the minimum recipe for running the HTTP server in production
+with GitHub-OAuth-issued API keys and per-user quota. For the stdio /
+local-CLI experience see the main `README.md`.
+
+## TL;DR
+
+```sh
+docker build -t typst-d2-mcp .
+docker run -d --name typst-d2-mcp \
+  -p 8080:8080 \
+  -v typst-d2-mcp-state:/var/lib/typst-d2-mcp \
+  -e TYPST_D2_MCP_AUTH=github \
+  -e TYPST_D2_MCP_PUBLIC_URL=https://your.host \
+  -e TYPST_D2_MCP_GITHUB_CLIENT_ID=Iv1.xxxxxxxxxxxx \
+  -e TYPST_D2_MCP_GITHUB_CLIENT_SECRET=xxxxxxxxxxxxxxxx \
+  typst-d2-mcp
+```
+
+That gives you a hosted MCP server with a 1-compile-per-UTC-day quota per
+authenticated user. Users sign up by visiting `https://your.host/login`
+and configure their MCP client with the resulting `Authorization: Bearer
+<key>` header.
+
+## Setting up the GitHub OAuth app
+
+1. <https://github.com/settings/developers> → **New OAuth App**.
+2. **Application name**: anything (shown to users on the consent screen).
+3. **Homepage URL**: `https://your.host`.
+4. **Authorization callback URL**: `https://your.host/auth/github/callback`
+   (must match `TYPST_D2_MCP_PUBLIC_URL + /auth/github/callback` exactly).
+5. After creating: copy the **Client ID** into `TYPST_D2_MCP_GITHUB_CLIENT_ID`,
+   generate a **Client secret** and put it in `TYPST_D2_MCP_GITHUB_CLIENT_SECRET`.
+
+The OAuth scope requested is `read:user user:email` — read-only.
+
+## Environment variables (full reference)
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TYPST_D2_MCP_TRANSPORT` | `stdio` (image overrides to `http`) | `stdio` or `http`. |
+| `TYPST_D2_MCP_ADDR` | `:8080` | HTTP listen address. |
+| `TYPST_D2_MCP_PATH` | `/mcp` | URL path the MCP endpoint is served at. |
+| `TYPST_D2_MCP_WORKSPACE` | (set in image) | Root for per-user workspace dirs. |
+| `TYPST_D2_MCP_AUTH` | `none` | `none` (anonymous, unlimited) or `github`. |
+| `TYPST_D2_MCP_DB` | (set in image) | SQLite path for users + api_keys + compiles. |
+| `TYPST_D2_MCP_PUBLIC_URL` | _required for github_ | Externally reachable base URL (scheme + host). |
+| `TYPST_D2_MCP_GITHUB_CLIENT_ID` | _required for github_ | OAuth Client ID. |
+| `TYPST_D2_MCP_GITHUB_CLIENT_SECRET` | _required for github_ | OAuth Client secret. |
+| `TYPST_D2_MCP_QUOTA_PER_DAY` | `1` | Compiles per UTC day per non-anonymous user. `0` disables. |
+| `TYPST_D2_MCP_COMPILE_TIMEOUT` | `30s` | Per-compile budget (parses Go duration strings). `0` defers to caller. |
+| `TYPST_D2_MCP_MAX_INPUT_BYTES` | `1048576` (1 MiB) | Cap on `put_file` and compile input sizes. |
+| `TYPST_D2_MCP_LOG_LEVEL` | `info` | `debug`/`info`/`warn`/`error`. |
+| `TYPST_D2_MCP_LOG_FORMAT` | `json` in http, `text` in stdio | `json` or `text`. |
+
+## docker-compose example
+
+```yaml
+services:
+  typst-d2-mcp:
+    image: typst-d2-mcp
+    build: .
+    restart: unless-stopped
+    ports: ["8080:8080"]
+    environment:
+      TYPST_D2_MCP_AUTH: github
+      TYPST_D2_MCP_PUBLIC_URL: ${PUBLIC_URL}
+      TYPST_D2_MCP_GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      TYPST_D2_MCP_GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+    volumes:
+      - typst-d2-mcp-state:/var/lib/typst-d2-mcp
+
+volumes:
+  typst-d2-mcp-state:
+```
+
+Front this with a TLS-terminating reverse proxy (nginx, Caddy, traefik) so
+the callback URL is `https://...`. Bearer tokens must travel over TLS.
+
+## Persistence
+
+The state volume at `/var/lib/typst-d2-mcp` holds:
+
+- `workspaces/<user_id>/` — each authenticated user's sandboxed working
+  tree, including compiled PDFs. Files do **not** auto-expire today
+  (sub-issue [#5](https://github.com/dlouwers/typst-d2-mcp/issues/2)
+  will add TTL purge); operators should mount this on a volume with
+  reasonable size limits and periodically prune.
+- `auth.sqlite` — users, hashed API keys, and the per-day compile
+  counter. Losing this file logs everyone out and resets quota.
+
+Both paths are derived from env vars at startup; override them if you
+prefer a different layout.
+
+## Hardening notes
+
+These are **not** wired into the image today. They belong to the
+deployment, and the documentation here is so they aren't forgotten.
+
+- **Network namespace / egress firewall.** The `typst` child fetches
+  `@preview/*` packages from `typst.app` by default. For the hosted
+  free tier this is a code-execution / SSRF risk: a malicious `.typ`
+  could pull arbitrary packages. Run the container in a network
+  namespace that denies outbound traffic except to GitHub's OAuth
+  endpoints, or pre-populate the package cache and pass
+  `--package-cache-path` via a wrapper script. The `@preview/based`
+  package the preprocessor needs can be baked into the image.
+- **Read-only root filesystem.** Compose users can add
+  `read_only: true` with `tmpfs: [/tmp]` and the persistent volume
+  mounted writable. The container otherwise needs no write access to
+  its own filesystem.
+- **Resource limits.** Pair the in-process compile timeout with
+  container-level CPU and memory caps (`--cpus`, `--memory`) so a
+  single compile can't starve neighbours.
+- **TLS.** The image speaks plain HTTP and expects a reverse proxy in
+  front of it. The Bearer-auth middleware sets `Secure` on the OAuth
+  state cookie only when `request.TLS != nil`, so the proxy must
+  terminate TLS and proxy to HTTP, not the other way around.
+
+## Verifying a deployment
+
+```sh
+# Health
+curl https://your.host/healthz
+
+# Visit /login in a browser to sign in with GitHub and grab a key.
+# Then, with the key:
+curl -sS https://your.host/mcp \
+  -H "Authorization: Bearer ttd2_..." \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","clientInfo":{"name":"curl","version":"0"},"capabilities":{}}}'
+```
+
+Logs are JSON on stderr; pipe them through `jq` or your log aggregator
+of choice.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,88 @@
+# syntax=docker/dockerfile:1
+#
+# Production image for typst-d2-mcp.
+#
+# Designed for the hosted free-tier deployment: HTTP transport, GitHub
+# OAuth, SQLite-backed quota. Self-hosted operators can run the same
+# image with TYPST_D2_MCP_AUTH=none and get the anonymous experience.
+
+# --- build stage ----------------------------------------------------------
+FROM golang:1.25-bookworm AS build
+
+WORKDIR /src
+
+# Download deps separately so the layer is reused across source-only edits.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# Static-ish build: CGO disabled (modernc.org/sqlite is pure Go, so this
+# is safe), trimpath to keep the binary reproducible.
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -trimpath \
+      -ldflags="-s -w -X main.serverVersion=${VERSION}" \
+      -o /out/typst-d2-mcp \
+      ./cmd/typst-d2-mcp
+
+# --- runtime stage --------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+# Pinned upstream versions; bump these together with the devcontainer.
+ARG D2_VERSION=v0.7.1
+ARG TYPST_VERSION=v0.14.2
+
+# curl for the HEALTHCHECK probe, ca-certificates so the typst child
+# trusts TLS roots if it needs them, tini as a minimal PID 1 so signals
+# reach the Go process cleanly.
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
+      ca-certificates curl tini xz-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install d2 via its official install script, pinned to D2_VERSION.
+RUN curl -fsSL "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" \
+      | tar -xz -C /tmp \
+ && cp "/tmp/d2-${D2_VERSION}/bin/d2" /usr/local/bin/d2 \
+ && rm -rf /tmp/d2-* \
+ && d2 --version
+
+# Install typst from the official release tarball.
+RUN curl -fsSL "https://github.com/typst/typst/releases/download/${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz" \
+      | tar -xJ -C /usr/local/bin --strip-components=1 \
+ && typst --version
+
+# Drop privileges. UID/GID match the convention used by distroless's
+# "nonroot" so swapping bases later is painless.
+RUN groupadd --system --gid 65532 nonroot \
+ && useradd --system --uid 65532 --gid nonroot --home /home/nonroot --create-home nonroot
+
+# State directory: the workspace tree and SQLite DB live here. Mount
+# this as a volume in production so per-user files and quota survive
+# container restarts.
+RUN mkdir -p /var/lib/typst-d2-mcp && chown nonroot:nonroot /var/lib/typst-d2-mcp
+VOLUME /var/lib/typst-d2-mcp
+
+COPY --from=build /out/typst-d2-mcp /usr/local/bin/typst-d2-mcp
+
+USER nonroot
+WORKDIR /home/nonroot
+
+# Sensible defaults for the hosted shape. Operators override AUTH +
+# credentials at run time. Quota stays at the documented 1/day; raise
+# via TYPST_D2_MCP_QUOTA_PER_DAY when shipping the paid tier.
+ENV TYPST_D2_MCP_TRANSPORT=http \
+    TYPST_D2_MCP_ADDR=:8080 \
+    TYPST_D2_MCP_PATH=/mcp \
+    TYPST_D2_MCP_WORKSPACE=/var/lib/typst-d2-mcp/workspaces \
+    TYPST_D2_MCP_DB=/var/lib/typst-d2-mcp/auth.sqlite \
+    TYPST_D2_MCP_LOG_FORMAT=json \
+    TYPST_D2_MCP_LOG_LEVEL=info
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -fsS http://127.0.0.1:8080/healthz || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/typst-d2-mcp"]

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -41,6 +42,8 @@ const (
 	envGitHubID     = "TYPST_D2_MCP_GITHUB_CLIENT_ID"
 	envGitHubSecret = "TYPST_D2_MCP_GITHUB_CLIENT_SECRET"
 	envQuotaPerDay  = "TYPST_D2_MCP_QUOTA_PER_DAY"
+	envLogLevel     = "TYPST_D2_MCP_LOG_LEVEL"
+	envLogFormat    = "TYPST_D2_MCP_LOG_FORMAT"
 
 	defaultAddr           = ":8080"
 	defaultPath           = "/mcp"
@@ -83,7 +86,8 @@ func durationEnv(key string, def time.Duration) time.Duration {
 	}
 	d, err := time.ParseDuration(v)
 	if err != nil || d < 0 {
-		fmt.Fprintf(os.Stderr, "%s: invalid duration %q, using default %s\n", key, v, def)
+		slog.Warn("invalid duration env, using default",
+			"env", key, "value", v, "default", def.String())
 		return def
 	}
 	return d
@@ -96,7 +100,8 @@ func int64Env(key string, def int64) int64 {
 	}
 	n, err := strconv.ParseInt(v, 10, 64)
 	if err != nil || n < 0 {
-		fmt.Fprintf(os.Stderr, "%s: invalid integer %q, using default %d\n", key, v, def)
+		slog.Warn("invalid integer env, using default",
+			"env", key, "value", v, "default", def)
 		return def
 	}
 	return n
@@ -168,15 +173,17 @@ VERIFYING THE RESULT:
   yourself, advise the user to inspect it.`
 
 func main() {
+	initLogger()
+
 	factory, err := selectFactory()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Workspace setup: %v\n", err)
+		slog.Error("workspace setup failed", "err", err)
 		os.Exit(1)
 	}
 
 	backend, ghHandlers, store, closer, err := selectAuth()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Auth setup: %v\n", err)
+		slog.Error("auth setup failed", "err", err)
 		os.Exit(1)
 	}
 	if closer != nil {
@@ -194,12 +201,51 @@ func main() {
 	registerTools(s, factory, store)
 	registerResources(s, factory)
 
-	fmt.Fprintf(os.Stderr, "%s: auth=%s quota_per_day=%d\n", serverName, backend.Name(), quotaPerDay())
+	slog.Info("starting",
+		"version", serverVersion,
+		"auth", backend.Name(),
+		"quota_per_day", quotaPerDay(),
+		"compile_timeout", compileTimeout().String(),
+		"max_input_bytes", maxInputBytes(),
+	)
 
 	if err := serve(s, backend, ghHandlers); err != nil {
-		fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
+		slog.Error("server stopped", "err", err)
 		os.Exit(1)
 	}
+}
+
+// initLogger wires log/slog as the default logger before any other
+// code runs. Output goes to stderr (so stdio-mode stdout stays
+// reserved for the MCP protocol). HTTP mode defaults to JSON for
+// container log aggregators; stdio defaults to human-readable text
+// for local development.
+func initLogger() {
+	level := slog.LevelInfo
+	switch strings.ToLower(os.Getenv(envLogLevel)) {
+	case "debug":
+		level = slog.LevelDebug
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	}
+	format := strings.ToLower(os.Getenv(envLogFormat))
+	if format == "" {
+		if isHTTPTransport() {
+			format = "json"
+		} else {
+			format = "text"
+		}
+	}
+	opts := &slog.HandlerOptions{Level: level}
+	var handler slog.Handler
+	if format == "json" {
+		handler = slog.NewJSONHandler(os.Stderr, opts)
+	} else {
+		handler = slog.NewTextHandler(os.Stderr, opts)
+	}
+	slog.SetDefault(slog.New(handler))
 }
 
 // gitHubHandlers bundles the HTTP endpoints exposed by the GitHub auth
@@ -226,8 +272,8 @@ func selectFactory() (workspace.Factory, error) {
 	root := os.Getenv(envWorkspace)
 	if root == "" && isHTTPTransport() {
 		root = filepath.Join(os.TempDir(), "typst-d2-mcp-workspace")
-		fmt.Fprintf(os.Stderr, "%s: no %s set, using temporary workspace %s\n",
-			serverName, envWorkspace, root)
+		slog.Warn("no workspace configured; using tmp dir",
+			"env", envWorkspace, "path", root)
 	}
 	if root == "" {
 		return workspace.LocalFactory{}, nil
@@ -320,7 +366,7 @@ func serve(s *server.MCPServer, backend auth.Backend, gh *gitHubHandlers) error 
 			mux.HandleFunc("/auth/github/callback", gh.callback)
 		}
 
-		fmt.Fprintf(os.Stderr, "%s listening on http://%s%s\n", serverName, addr, path)
+		slog.Info("listening", "addr", addr, "path", path)
 		return http.ListenAndServe(addr, mux) //nolint:gosec // intentional plain HTTP; TLS is terminated upstream.
 	default:
 		return fmt.Errorf("unknown %s=%q (expected stdio or http)", envTransport, transport)
@@ -335,6 +381,11 @@ func authMiddleware(backend auth.Backend, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id, err := backend.IdentifyFromRequest(r)
 		if err != nil {
+			slog.Warn("auth rejected",
+				"backend", backend.Name(),
+				"remote", r.RemoteAddr,
+				"err", err.Error(),
+			)
 			w.Header().Set("WWW-Authenticate", `Bearer realm="typst-d2-mcp"`)
 			http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
 			return
@@ -433,17 +484,21 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		// Quota gate runs first so a quota-exceeded user pays no
 		// compute cost. Only authenticated identities are metered;
 		// stdio + AUTH=none stay unlimited.
+		start := time.Now()
 		id, _ := identity.FromContext(ctx)
+		log := slog.With("user", id.UserID, "file_path", filePath)
 		if store != nil && !id.IsAnonymous() {
 			limit := quotaPerDay()
 			today := time.Now().UTC().Format("2006-01-02")
 			if err := store.IncrementCompile(ctx, id.UserID, today, limit); err != nil {
 				if errors.Is(err, authdb.ErrQuotaExceeded) {
+					log.Warn("quota exceeded", "limit", limit)
 					return mcp.NewToolResultError(fmt.Sprintf(
 						"quota exceeded: %d compile(s) per UTC day per user (resets at 00:00 UTC; set %s to raise)",
 						limit, envQuotaPerDay,
 					)), nil
 				}
+				log.Error("quota check failed", "err", err)
 				return mcp.NewToolResultErrorFromErr("quota check", err), nil
 			}
 		}
@@ -526,6 +581,10 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		successMsg += "   - Reduce number of nodes or simplify structure\n"
 		successMsg += "\nIf you cannot view the PDF yourself, inform the user to check the layout."
 
+		log.Info("compile ok",
+			"output", toolVisibleOut,
+			"duration_ms", time.Since(start).Milliseconds(),
+		)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				mcp.TextContent{Type: "text", Text: successMsg},

--- a/internal/preprocessor/preprocessor.go
+++ b/internal/preprocessor/preprocessor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -55,16 +56,15 @@ func Preprocess(ctx context.Context, r workspace.Resolver, inputPath string) (st
 	d2Blocks := extractD2Calls(content)
 
 	if len(d2Blocks) == 0 {
-		fmt.Fprintf(os.Stderr, "No D2 diagrams found in file.\n")
+		slog.DebugContext(ctx, "no d2 blocks in input")
 		return content, nil
 	}
 
-	fmt.Fprintf(os.Stderr, "Found %d D2 diagram(s), rendering...\n", len(d2Blocks))
+	slog.DebugContext(ctx, "rendering d2 blocks", "count", len(d2Blocks))
 
 	// Replace in reverse order to preserve positions
 	for i := len(d2Blocks) - 1; i >= 0; i-- {
 		block := d2Blocks[i]
-		fmt.Fprintf(os.Stderr, "  [%d/%d] Rendering diagram...\n", len(d2Blocks)-i, len(d2Blocks))
 
 		// Render D2 to SVG
 		svg, err := d2.Render(ctx, block.Code, block.Options)
@@ -82,7 +82,6 @@ func Preprocess(ctx context.Context, r workspace.Resolver, inputPath string) (st
 	// Add based package import
 	content = addBasedImport(content)
 
-	fmt.Fprintf(os.Stderr, "✅ All diagrams rendered successfully\n")
 	return content, nil
 }
 


### PR DESCRIPTION
Sixth sub-issue of the hosted/local parity epic #2. Ships what an operator needs to actually stand the server up: a multi-stage container image, JSON-structured logs, and a one-page deployment guide. **The hosted free tier is now deployable end-to-end.**

## Logging

- `log/slog` as the default logger via a small `initLogger()` that runs first. Always to stderr (stdio's stdout stays reserved for MCP framing).
- `TYPST_D2_MCP_LOG_LEVEL` (`debug|info|warn|error`, default `info`) and `TYPST_D2_MCP_LOG_FORMAT` (`json|text`). Format defaults to `json` in HTTP mode for container log aggregators, `text` in stdio for local readability.
- Migrated startup messages, env-var parse warnings, auth rejections, compile success/failure, and quota events to structured slog calls with consistent keys (`user`, `file_path`, `duration_ms`, `limit`, …).
- Preprocessor progress chatter moved to `slog.Debug` so the INFO stream stays compact for production; the CLI still gets text-formatted output via the same logger.

## Dockerfile

- **Multi-stage**: build with `golang:1.25-bookworm` (`CGO_ENABLED=0`, `-trimpath`, `-s -w` ldflags), runtime on `debian:bookworm-slim`.
- **Pinned** `d2 v0.7.1` and `typst v0.14.2` (matches the devcontainer).
- **Non-root** user (uid/gid 65532, matching distroless's `nonroot` so a future base swap is painless).
- **Persistent state** at `/var/lib/typst-d2-mcp` (VOLUME) for the workspace tree and SQLite DB.
- **HEALTHCHECK** against `/healthz` via curl; **tini** as PID 1.
- Defaults the env to the hosted shape (`TRANSPORT=http`, JSON logs, sensible workspace + DB paths); operators override `AUTH=github` + GitHub credentials at run time.

## DEPLOYMENT.md

One-page operator guide: TL;DR `docker run`, GitHub OAuth app setup, full env-var reference, docker-compose snippet, persistence layout, and **hardening notes that flag what the image intentionally does not enforce** (egress firewall for typst `@preview` fetches, read-only rootfs, resource caps, TLS termination). Those belong to the deployment runtime, not the binary.

## Smoke (production image built locally, real d2 + typst)

```
AUTH=none HTTP container:
  /healthz                                → "ok"
  /mcp initialize                         → ok
  put_file + compile + result resource    → 11.7 KB PDF
  container logs                          → JSON-only on stderr
```

`go vet`, `go test`, `golangci-lint`, `govulncheck` all clean.

## Hosted free tier is now feature-complete

After this merges the only remaining umbrella sub-issues are:

- **#5** Outbound PDF storage with TTL'd signed URLs — only matters when PDFs need to outlive the MCP session or get too large to embed as base64.
- **#8** Explicit `AUTH=none` self-hosted parity verification — already implicitly covered by existing smokes; a one-pass regression test could close this formally.

Refers #2