### PR TITLE
feat(auth): MCP-spec OAuth 2.1 + PKCE Authorization Server

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,9 +19,14 @@ docker run -d --name typst-d2-mcp \
 ```
 
 That gives you a hosted MCP server with a 1-compile-per-UTC-day quota per
-authenticated user. Users sign up by visiting `https://your.host/login`
-and configure their MCP client with the resulting `Authorization: Bearer
-<key>` header.
+authenticated user. Users add it to their MCP client (Claude.ai, Claude
+Desktop, etc.) by pasting `https://your.host/mcp`; the client discovers
+the OAuth Authorization Server, registers itself, walks the user
+through GitHub sign-in, and stores the resulting access token itself —
+nothing to copy and paste.
+
+The same access tokens work for headless/CI use: capture one by driving
+the OAuth flow once and reuse it as `Authorization: Bearer <token>`.
 
 ## Setting up the GitHub OAuth app
 
@@ -124,8 +129,20 @@ deployment, and the documentation here is so they aren't forgotten.
 # Health
 curl https://your.host/healthz
 
-# Visit /login in a browser to sign in with GitHub and grab a key.
-# Then, with the key:
+# OAuth discovery: every MCP client starts here.
+curl https://your.host/.well-known/oauth-protected-resource
+curl https://your.host/.well-known/oauth-authorization-server
+
+# Driving /mcp without a token returns 401 with a WWW-Authenticate
+# pointing at resource_metadata — the entire OAuth dance is bootstrapped
+# from that one header.
+curl -sSi https://your.host/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","clientInfo":{"name":"curl","version":"0"},"capabilities":{}}}'
+
+# Once an MCP client (Claude.ai, Claude Desktop, …) has walked the user
+# through the OAuth flow, it sends Bearer on /mcp:
 curl -sS https://your.host/mcp \
   -H "Authorization: Bearer ttd2_..." \
   -H "Content-Type: application/json" \

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -258,11 +258,17 @@ func initLogger() {
 	slog.SetDefault(slog.New(handler))
 }
 
-// gitHubHandlers bundles the HTTP endpoints exposed by the GitHub auth
-// backend; nil when AUTH is not "github".
+// gitHubHandlers bundles the HTTP endpoints exposed by the GitHub
+// auth backend; nil when AUTH is not "github". The set covers both
+// the GitHub round-trip and the MCP-spec OAuth Authorization Server
+// (RFC 6749 + 7591 + 7636 + 8414 + 9728) handlers.
 type gitHubHandlers struct {
-	login    http.HandlerFunc
-	callback http.HandlerFunc
+	githubCallback          http.HandlerFunc
+	wellKnownResource       http.HandlerFunc
+	wellKnownAuthServer     http.HandlerFunc
+	register                http.HandlerFunc
+	authorize               http.HandlerFunc
+	token                   http.HandlerFunc
 }
 
 // selectFactory picks the workspace.Factory used to mint per-request
@@ -332,7 +338,14 @@ func selectAuth() (auth.Backend, *gitHubHandlers, *authdb.Store, func(), error) 
 			Store: store,
 		}
 		closer := func() { _ = store.Close() }
-		return gh, &gitHubHandlers{login: gh.ServeLogin, callback: gh.ServeCallback}, store, closer, nil
+		return gh, &gitHubHandlers{
+			githubCallback:      gh.ServeCallback,
+			wellKnownResource:   gh.ServeWellKnownProtectedResource,
+			wellKnownAuthServer: gh.ServeWellKnownAuthorizationServer,
+			register:            gh.ServeRegister,
+			authorize:           gh.ServeAuthorize,
+			token:               gh.ServeToken,
+		}, store, closer, nil
 	default:
 		return nil, nil, nil, nil, fmt.Errorf("unknown %s=%q (expected none or github)", envAuth, mode)
 	}
@@ -365,15 +378,33 @@ func serve(s *server.MCPServer, backend auth.Backend, gh *gitHubHandlers) error 
 			server.WithStateLess(true),
 		)
 
+		// Resource-metadata pointer is only emitted when an OAuth AS
+		// is actually wired up (i.e. AUTH=github). For AUTH=none the
+		// middleware skips the auth check entirely so the 401 path is
+		// unreachable anyway.
+		var resourceMetadataURL string
+		if gh != nil {
+			resourceMetadataURL = strings.TrimRight(os.Getenv(envPublicURL), "/") + "/.well-known/oauth-protected-resource"
+		}
+
 		mux := http.NewServeMux()
-		mux.Handle(path, authMiddleware(backend, httpSrv))
+		mux.Handle(path, authMiddleware(backend, httpSrv, resourceMetadataURL))
 		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		})
 		if gh != nil {
-			mux.HandleFunc("/login", gh.login)
-			mux.HandleFunc("/auth/github/callback", gh.callback)
+			// MCP-spec OAuth Authorization Server endpoints. The
+			// callback URL stays at /auth/github/callback to match the
+			// GitHub OAuth app registration; everything else is the
+			// public AS surface that MCP clients (Claude.ai etc.)
+			// discover and drive.
+			mux.HandleFunc("/.well-known/oauth-protected-resource", gh.wellKnownResource)
+			mux.HandleFunc("/.well-known/oauth-authorization-server", gh.wellKnownAuthServer)
+			mux.HandleFunc("/register", gh.register)
+			mux.HandleFunc("/authorize", gh.authorize)
+			mux.HandleFunc("/token", gh.token)
+			mux.HandleFunc("/auth/github/callback", gh.githubCallback)
 		}
 
 		// /metrics binds to a separate listener so it never shares
@@ -413,9 +444,15 @@ func startMetricsListener() {
 
 // authMiddleware identifies the principal behind r via backend and
 // attaches the resulting Identity to the request context. Backends
-// that don't admit anonymous traffic (i.e. GitHub) cause a 401 when
-// IdentifyFromRequest returns an error.
-func authMiddleware(backend auth.Backend, h http.Handler) http.Handler {
+// that don't admit anonymous traffic (i.e. GitHub) cause a 401 with
+// a WWW-Authenticate that carries the resource_metadata URL — that
+// pointer is what MCP clients (Claude.ai etc.) follow to discover
+// the OAuth Authorization Server and start the dance themselves.
+func authMiddleware(backend auth.Backend, h http.Handler, resourceMetadataURL string) http.Handler {
+	wwwAuth := `Bearer realm="typst-d2-mcp"`
+	if resourceMetadataURL != "" {
+		wwwAuth += `, resource_metadata="` + resourceMetadataURL + `"`
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id, err := backend.IdentifyFromRequest(r)
 		if err != nil {
@@ -425,7 +462,7 @@ func authMiddleware(backend auth.Backend, h http.Handler) http.Handler {
 				"remote", r.RemoteAddr,
 				"err", err.Error(),
 			)
-			w.Header().Set("WWW-Authenticate", `Bearer realm="typst-d2-mcp"`)
+			w.Header().Set("WWW-Authenticate", wwwAuth)
 			http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
 			return
 		}

--- a/internal/auth/github.go
+++ b/internal/auth/github.go
@@ -2,13 +2,11 @@ package auth
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -96,72 +94,80 @@ func (g *GitHub) IdentifyFromRequest(r *http.Request) (identity.Identity, error)
 // Name returns the backend's startup label.
 func (*GitHub) Name() string { return "github" }
 
-// ServeLogin handles GET /login. It mints a random state, stashes it
-// in a short-lived HttpOnly cookie, and redirects to GitHub's OAuth
-// authorize URL.
-func (g *GitHub) ServeLogin(w http.ResponseWriter, r *http.Request) {
-	state, err := randomState()
-	if err != nil {
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     "ttd2_oauth_state",
-		Value:    state,
-		Path:     "/auth/",
-		HttpOnly: true,
-		Secure:   r.TLS != nil,
-		SameSite: http.SameSiteLaxMode,
-		MaxAge:   300, // 5 minutes
-	})
-	q := url.Values{}
-	q.Set("client_id", g.Cfg.ClientID)
-	q.Set("redirect_uri", g.Cfg.redirectURL())
-	q.Set("scope", "read:user user:email")
-	q.Set("state", state)
-	http.Redirect(w, r, g.Cfg.authorizeURL()+"?"+q.Encode(), http.StatusFound)
-}
-
-// ServeCallback handles GET /auth/github/callback. It verifies the
-// state cookie, exchanges the auth code for a GitHub access token,
-// fetches the user, upserts them in authdb, mints an API key, and
-// shows the key to the user exactly once.
+// ServeCallback handles GET /auth/github/callback. The `state`
+// parameter is the authorize-session id created by ServeAuthorize in
+// oauth.go — we look it up to find the MCP client we're authorizing,
+// exchange the GitHub code for the user, mint a one-shot
+// authorization code bound to the original PKCE challenge, and
+// redirect the user's browser back to the MCP client's redirect_uri
+// with that code. The MCP client then calls /token to swap it for an
+// access token.
 func (g *GitHub) ServeCallback(w http.ResponseWriter, r *http.Request) {
-	state := r.URL.Query().Get("state")
+	sessionID := r.URL.Query().Get("state")
 	code := r.URL.Query().Get("code")
-	if state == "" || code == "" {
+	if sessionID == "" || code == "" {
 		http.Error(w, "missing state or code", http.StatusBadRequest)
 		return
 	}
-	cookie, err := r.Cookie("ttd2_oauth_state")
-	if err != nil || cookie.Value != state {
-		http.Error(w, "state mismatch", http.StatusBadRequest)
+	session, err := g.Store.ConsumeAuthorizeSession(r.Context(), sessionID)
+	if err != nil {
+		// Don't redirect: we have no trusted redirect_uri to bounce
+		// to (the session was the source of that trust).
+		slog.Warn("authorize session missing", "session_id", sessionID, "err", err)
+		http.Error(w, "authorize session not found or expired", http.StatusBadRequest)
 		return
 	}
-	// Consume the cookie either way.
-	http.SetCookie(w, &http.Cookie{Name: "ttd2_oauth_state", Path: "/auth/", MaxAge: -1})
 
 	ghToken, err := g.exchangeCode(r.Context(), code)
 	if err != nil {
-		http.Error(w, "code exchange failed: "+err.Error(), http.StatusBadGateway)
+		redirectOAuthError(w, r, session.RedirectURI, session.ClientState,
+			"server_error", "code exchange failed")
 		return
 	}
 	gu, err := g.fetchUser(r.Context(), ghToken)
 	if err != nil {
-		http.Error(w, "github user fetch failed: "+err.Error(), http.StatusBadGateway)
+		redirectOAuthError(w, r, session.RedirectURI, session.ClientState,
+			"server_error", "github user fetch failed")
 		return
 	}
-	userID, err := g.Store.UpsertGitHubUser(r.Context(), gu.ID, gu.Login, gu.Email)
+	userDBID, err := g.Store.UpsertGitHubUser(r.Context(), gu.ID, gu.Login, gu.Email)
 	if err != nil {
-		http.Error(w, "user upsert failed: "+err.Error(), http.StatusInternalServerError)
+		slog.Error("upsert user", "err", err)
+		redirectOAuthError(w, r, session.RedirectURI, session.ClientState,
+			"server_error", "user upsert failed")
 		return
 	}
-	key, err := g.Store.IssueAPIKey(r.Context(), userID)
+	authzCode, err := g.Store.MintAuthorizationCode(r.Context(), authdb.AuthorizationCode{
+		UserDBID:            userDBID,
+		ClientID:            session.ClientID,
+		RedirectURI:         session.RedirectURI,
+		CodeChallenge:       session.CodeChallenge,
+		CodeChallengeMethod: session.CodeChallengeMethod,
+		Scope:               session.Scope,
+	})
 	if err != nil {
-		http.Error(w, "key issue failed: "+err.Error(), http.StatusInternalServerError)
+		slog.Error("mint authorization code", "err", err)
+		redirectOAuthError(w, r, session.RedirectURI, session.ClientState,
+			"server_error", "could not mint authorization code")
 		return
 	}
-	writeKeyPage(w, gu.Login, key)
+	slog.Info("oauth authorize ok",
+		"client_id", session.ClientID,
+		"user", gu.Login,
+		"github_id", gu.ID,
+	)
+	u, err := url.Parse(session.RedirectURI)
+	if err != nil {
+		http.Error(w, "invalid redirect_uri in session", http.StatusInternalServerError)
+		return
+	}
+	q := u.Query()
+	q.Set("code", authzCode)
+	if session.ClientState != "" {
+		q.Set("state", session.ClientState)
+	}
+	u.RawQuery = q.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
 }
 
 func bearerToken(r *http.Request) string {
@@ -171,14 +177,6 @@ func bearerToken(r *http.Request) string {
 		return strings.TrimSpace(h[len(p):])
 	}
 	return ""
-}
-
-func randomState() (string, error) {
-	var b [24]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return "", err
-	}
-	return base64.RawURLEncoding.EncodeToString(b[:]), nil
 }
 
 type githubUser struct {
@@ -251,15 +249,3 @@ func (g *GitHub) fetchUser(ctx context.Context, ghToken string) (githubUser, err
 	return u, nil
 }
 
-func writeKeyPage(w http.ResponseWriter, login, key string) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = fmt.Fprintf(w, `<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><title>typst-d2-mcp API key</title></head>
-<body style="font-family:system-ui,sans-serif;max-width:40rem;margin:2rem auto;padding:0 1rem;line-height:1.5">
-<h1>Hello, %s</h1>
-<p>Your typst-d2-mcp API key is shown below. <strong>Copy it now — it will not be displayed again.</strong></p>
-<pre style="background:#f4f4f4;padding:1rem;border-radius:6px;font-size:1rem;overflow-x:auto">%s</pre>
-<p>Configure your MCP client to send this key as <code>Authorization: Bearer &lt;key&gt;</code> on the MCP HTTP endpoint.</p>
-</body></html>`, html.EscapeString(login), html.EscapeString(key))
-}

--- a/internal/auth/github_test.go
+++ b/internal/auth/github_test.go
@@ -1,13 +1,15 @@
 package auth
 
 import (
-	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -34,28 +36,9 @@ func fakeGitHub(t *testing.T, code, accessToken string, login string, githubID i
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":` + intToStr(githubID) + `,"login":"` + login + `","email":"` + email + `"}`))
+		_, _ = w.Write([]byte(`{"id":` + strconv.FormatInt(githubID, 10) + `,"login":"` + login + `","email":"` + email + `"}`))
 	})
 	return httptest.NewServer(mux)
-}
-
-func intToStr(n int64) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var b []byte
-	for n > 0 {
-		b = append([]byte{byte('0' + n%10)}, b...)
-		n /= 10
-	}
-	if neg {
-		b = append([]byte("-"), b...)
-	}
-	return string(b)
 }
 
 func newGitHubBackend(t *testing.T, fakeURL string) *GitHub {
@@ -103,108 +86,6 @@ func TestGitHub_IdentifyFromRequest_InvalidKey(t *testing.T) {
 	}
 }
 
-func TestGitHub_OAuth_RoundTrip(t *testing.T) {
-	ts := fakeGitHub(t, "code-xyz", "gh-token-abc", "octocat", 42, "octo@example.com")
-	defer ts.Close()
-
-	g := newGitHubBackend(t, ts.URL)
-
-	// Step 1: /login should redirect to the (fake) GitHub authorize URL
-	// with state cookie.
-	loginReq := httptest.NewRequest(http.MethodGet, "/login", nil)
-	loginResp := httptest.NewRecorder()
-	g.ServeLogin(loginResp, loginReq)
-	if loginResp.Code != http.StatusFound {
-		t.Fatalf("/login status = %d, want 302", loginResp.Code)
-	}
-	loc := loginResp.Header().Get("Location")
-	if !strings.HasPrefix(loc, ts.URL+"/login/oauth/authorize") {
-		t.Errorf("redirect location = %q, want authorize URL", loc)
-	}
-	u, _ := url.Parse(loc)
-	state := u.Query().Get("state")
-	if state == "" {
-		t.Fatal("authorize URL missing state")
-	}
-	cookies := loginResp.Result().Cookies()
-	var stateCookie *http.Cookie
-	for _, c := range cookies {
-		if c.Name == "ttd2_oauth_state" {
-			stateCookie = c
-		}
-	}
-	if stateCookie == nil {
-		t.Fatal("ttd2_oauth_state cookie not set")
-	}
-	if stateCookie.Value != state {
-		t.Errorf("cookie value = %q, state param = %q", stateCookie.Value, state)
-	}
-
-	// Step 2: simulate GitHub redirecting back to /callback with code+state.
-	cbReq := httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=code-xyz&state="+state, nil)
-	cbReq.AddCookie(stateCookie)
-	cbResp := httptest.NewRecorder()
-	g.ServeCallback(cbResp, cbReq)
-	if cbResp.Code != http.StatusOK {
-		body, _ := io.ReadAll(cbResp.Result().Body)
-		t.Fatalf("/callback status = %d, body=%s", cbResp.Code, body)
-	}
-	body, _ := io.ReadAll(cbResp.Result().Body)
-	bodyStr := string(body)
-	if !strings.Contains(bodyStr, "octocat") {
-		t.Errorf("response body missing GitHub login: %s", bodyStr)
-	}
-	// Extract the key from the <pre> block.
-	start := strings.Index(bodyStr, "ttd2_")
-	if start < 0 {
-		t.Fatalf("key not present in response body: %s", bodyStr)
-	}
-	end := start
-	for end < len(bodyStr) && bodyStr[end] != '<' && bodyStr[end] != '\n' {
-		end++
-	}
-	key := bodyStr[start:end]
-
-	// Step 3: the freshly minted key should authenticate via the backend.
-	authReq := httptest.NewRequest(http.MethodPost, "/mcp", nil)
-	authReq.Header.Set("Authorization", "Bearer "+key)
-	id, err := g.IdentifyFromRequest(authReq)
-	if err != nil {
-		t.Fatalf("auth with new key failed: %v", err)
-	}
-	if id.GitHubLogin != "octocat" || id.UserID != "gh:42" || id.Email != "octo@example.com" {
-		t.Errorf("identity after callback = %+v", id)
-	}
-}
-
-func TestGitHub_Callback_StateMismatch(t *testing.T) {
-	ts := fakeGitHub(t, "c", "t", "octocat", 42, "")
-	defer ts.Close()
-	g := newGitHubBackend(t, ts.URL)
-
-	req := httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=c&state=evil", nil)
-	req.AddCookie(&http.Cookie{Name: "ttd2_oauth_state", Value: "good"})
-	resp := httptest.NewRecorder()
-	g.ServeCallback(resp, req)
-	if resp.Code != http.StatusBadRequest {
-		t.Errorf("state mismatch should yield 400, got %d", resp.Code)
-	}
-}
-
-func TestGitHub_Callback_BadCode(t *testing.T) {
-	ts := fakeGitHub(t, "correct-code", "t", "octocat", 42, "")
-	defer ts.Close()
-	g := newGitHubBackend(t, ts.URL)
-
-	req := httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=wrong&state=s", nil)
-	req.AddCookie(&http.Cookie{Name: "ttd2_oauth_state", Value: "s"})
-	resp := httptest.NewRecorder()
-	g.ServeCallback(resp, req)
-	if resp.Code != http.StatusBadGateway {
-		t.Errorf("bad code should yield 502, got %d", resp.Code)
-	}
-}
-
 func TestNone_AlwaysAnonymous(t *testing.T) {
 	id, err := None{}.IdentifyFromRequest(httptest.NewRequest(http.MethodPost, "/", nil))
 	if err != nil {
@@ -215,6 +96,218 @@ func TestNone_AlwaysAnonymous(t *testing.T) {
 	}
 }
 
-// _ = context.Background silences linters that flag unused imports
-// when the file is built in isolation.
-var _ = context.Background
+// TestOAuth_FullRoundTrip walks the full MCP-spec OAuth dance against
+// a mocked GitHub: register → authorize → GitHub callback → token →
+// /mcp Bearer use. It's the closest unit-level coverage we have of
+// what a real MCP client (e.g. Claude.ai) would do at first connect.
+func TestOAuth_FullRoundTrip(t *testing.T) {
+	ts := fakeGitHub(t, "gh-code-xyz", "gh-access-abc", "octocat", 42, "octo@example.com")
+	defer ts.Close()
+
+	g := newGitHubBackend(t, ts.URL)
+
+	// Step 1: client registers via DCR.
+	regBody := `{"client_name":"mock-mcp-client","redirect_uris":["https://localhost/cb"]}`
+	regReq := httptest.NewRequest(http.MethodPost, pathRegister, strings.NewReader(regBody))
+	regReq.Header.Set("Content-Type", "application/json")
+	regResp := httptest.NewRecorder()
+	g.ServeRegister(regResp, regReq)
+	if regResp.Code != http.StatusCreated {
+		t.Fatalf("/register status = %d, body=%s", regResp.Code, regResp.Body.String())
+	}
+	var reg map[string]any
+	if err := json.Unmarshal(regResp.Body.Bytes(), &reg); err != nil {
+		t.Fatalf("decode register: %v", err)
+	}
+	clientID, _ := reg["client_id"].(string)
+	if !strings.HasPrefix(clientID, "ttd2cli_") {
+		t.Fatalf("unexpected client_id %q", clientID)
+	}
+
+	// Step 2: client makes the user-facing /authorize request. PKCE.
+	verifier := "the-verifier-must-be-at-least-43-chars-long-okay"
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", "https://localhost/cb")
+	q.Set("state", "client-state-123")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("scope", "mcp")
+	azReq := httptest.NewRequest(http.MethodGet, pathAuthorize+"?"+q.Encode(), nil)
+	azResp := httptest.NewRecorder()
+	g.ServeAuthorize(azResp, azReq)
+	if azResp.Code != http.StatusFound {
+		t.Fatalf("/authorize status = %d, body=%s", azResp.Code, azResp.Body.String())
+	}
+	loc, _ := url.Parse(azResp.Header().Get("Location"))
+	if !strings.HasPrefix(loc.String(), ts.URL+"/login/oauth/authorize") {
+		t.Fatalf("expected redirect to GitHub authorize, got %s", loc)
+	}
+	sessionID := loc.Query().Get("state")
+	if sessionID == "" || !strings.HasPrefix(sessionID, "ttd2sess_") {
+		t.Fatalf("github state should be the authorize session id, got %q", sessionID)
+	}
+
+	// Step 3: GitHub redirects back to /auth/github/callback with the
+	// session_id as state and a code we'll exchange.
+	cbReq := httptest.NewRequest(http.MethodGet, pathGitHubCallback+"?code=gh-code-xyz&state="+sessionID, nil)
+	cbResp := httptest.NewRecorder()
+	g.ServeCallback(cbResp, cbReq)
+	if cbResp.Code != http.StatusFound {
+		t.Fatalf("/auth/github/callback status = %d, body=%s", cbResp.Code, cbResp.Body.String())
+	}
+	cbLoc, _ := url.Parse(cbResp.Header().Get("Location"))
+	if cbLoc.Scheme+"://"+cbLoc.Host+cbLoc.Path != "https://localhost/cb" {
+		t.Fatalf("callback redirect target = %s, want https://localhost/cb", cbLoc)
+	}
+	if cbLoc.Query().Get("state") != "client-state-123" {
+		t.Errorf("client_state not echoed: %q", cbLoc.Query().Get("state"))
+	}
+	authzCode := cbLoc.Query().Get("code")
+	if authzCode == "" || !strings.HasPrefix(authzCode, "ttd2code_") {
+		t.Fatalf("missing/invalid authorization code: %q", authzCode)
+	}
+
+	// Step 4: client redeems the code at /token.
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", authzCode)
+	form.Set("redirect_uri", "https://localhost/cb")
+	form.Set("client_id", clientID)
+	form.Set("code_verifier", verifier)
+	tokReq := httptest.NewRequest(http.MethodPost, pathToken, strings.NewReader(form.Encode()))
+	tokReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokResp := httptest.NewRecorder()
+	g.ServeToken(tokResp, tokReq)
+	if tokResp.Code != http.StatusOK {
+		t.Fatalf("/token status = %d, body=%s", tokResp.Code, tokResp.Body.String())
+	}
+	var tok map[string]any
+	if err := json.Unmarshal(tokResp.Body.Bytes(), &tok); err != nil {
+		t.Fatalf("decode token: %v", err)
+	}
+	accessToken, _ := tok["access_token"].(string)
+	if !strings.HasPrefix(accessToken, "ttd2_") {
+		t.Fatalf("unexpected access_token shape: %q", accessToken)
+	}
+	if tt, _ := tok["token_type"].(string); !strings.EqualFold(tt, "Bearer") {
+		t.Errorf("token_type = %q, want Bearer", tt)
+	}
+
+	// Step 5: the access token authenticates against /mcp.
+	mcpReq := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	mcpReq.Header.Set("Authorization", "Bearer "+accessToken)
+	id, err := g.IdentifyFromRequest(mcpReq)
+	if err != nil {
+		t.Fatalf("access token doesn't authenticate: %v", err)
+	}
+	if id.GitHubLogin != "octocat" || id.UserID != "gh:42" {
+		t.Errorf("identity = %+v", id)
+	}
+
+	// Step 6: the code is one-shot. Second redemption must fail.
+	tok2 := httptest.NewRecorder()
+	g.ServeToken(tok2, httptest.NewRequest(http.MethodPost, pathToken, strings.NewReader(form.Encode())))
+	tok2.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+	if tok2.Code == http.StatusOK {
+		t.Errorf("code replay should fail, got 200")
+	}
+}
+
+func TestOAuth_PKCEMismatch(t *testing.T) {
+	ts := fakeGitHub(t, "c", "t", "octocat", 7, "")
+	defer ts.Close()
+	g := newGitHubBackend(t, ts.URL)
+
+	// Register, authorize, callback with one verifier, then redeem
+	// with a different one. /token should reject.
+	c, _ := g.Store.RegisterClient(t.Context(), "x", []string{"https://localhost/cb"}, "none")
+	sum := sha256.Sum256([]byte("verifier-A-and-must-be-at-least-43-chars-long"))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", c.ClientID)
+	q.Set("redirect_uri", "https://localhost/cb")
+	q.Set("state", "s")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	azResp := httptest.NewRecorder()
+	g.ServeAuthorize(azResp, httptest.NewRequest(http.MethodGet, pathAuthorize+"?"+q.Encode(), nil))
+	loc, _ := url.Parse(azResp.Header().Get("Location"))
+	sid := loc.Query().Get("state")
+	cb := httptest.NewRecorder()
+	g.ServeCallback(cb, httptest.NewRequest(http.MethodGet, pathGitHubCallback+"?code=c&state="+sid, nil))
+	cbLoc, _ := url.Parse(cb.Header().Get("Location"))
+	code := cbLoc.Query().Get("code")
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", "https://localhost/cb")
+	form.Set("client_id", c.ClientID)
+	form.Set("code_verifier", "verifier-B-totally-different-but-also-43-chars-of-text")
+	tokResp := httptest.NewRecorder()
+	tokReq := httptest.NewRequest(http.MethodPost, pathToken, strings.NewReader(form.Encode()))
+	tokReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	g.ServeToken(tokResp, tokReq)
+	if tokResp.Code == http.StatusOK {
+		t.Errorf("PKCE mismatch should fail, got 200: %s", tokResp.Body.String())
+	}
+}
+
+func TestOAuth_Register_RejectsBadRedirectURI(t *testing.T) {
+	g := newGitHubBackend(t, "")
+	cases := []string{
+		`{"client_name":"x","redirect_uris":["http://example.com/cb"]}`,         // plain http, not localhost
+		`{"client_name":"x","redirect_uris":["not-a-url"]}`,                    // not absolute
+		`{"client_name":"x","redirect_uris":[]}`,                                // empty
+		`{"client_name":"x","redirect_uris":["https://x"],"token_endpoint_auth_method":"client_secret_basic"}`, // confidential client
+	}
+	for _, body := range cases {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, pathRegister, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		g.ServeRegister(resp, req)
+		if resp.Code/100 != 4 {
+			t.Errorf("expected 4xx for %s, got %d: %s", body, resp.Code, resp.Body.String())
+		}
+	}
+}
+
+func TestOAuth_WellKnown(t *testing.T) {
+	g := newGitHubBackend(t, "")
+	g.Cfg.PublicURL = "https://example.test"
+
+	w := httptest.NewRecorder()
+	g.ServeWellKnownProtectedResource(w, httptest.NewRequest(http.MethodGet, pathProtectedResource, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	var pr map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &pr)
+	if pr["resource"] != "https://example.test" {
+		t.Errorf("resource = %v", pr["resource"])
+	}
+
+	w2 := httptest.NewRecorder()
+	g.ServeWellKnownAuthorizationServer(w2, httptest.NewRequest(http.MethodGet, pathAuthorizationServer, nil))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("status %d", w2.Code)
+	}
+	var as map[string]any
+	_ = json.Unmarshal(w2.Body.Bytes(), &as)
+	want := map[string]string{
+		"authorization_endpoint": "https://example.test/authorize",
+		"token_endpoint":         "https://example.test/token",
+		"registration_endpoint":  "https://example.test/register",
+		"issuer":                 "https://example.test",
+	}
+	for k, v := range want {
+		if as[k] != v {
+			t.Errorf("%s = %v, want %v", k, as[k], v)
+		}
+	}
+}

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -1,0 +1,348 @@
+package auth
+
+// OAuth-AS HTTP handlers. Together with github.go these implement the
+// MCP-spec OAuth 2.1 + PKCE flow:
+//
+//   1. /.well-known/oauth-protected-resource    (RFC 9728)
+//   2. /.well-known/oauth-authorization-server  (RFC 8414)
+//   3. POST /register                            (RFC 7591 Dynamic
+//                                                Client Registration)
+//   4. GET  /authorize                           (RFC 6749 §4.1 + RFC
+//                                                7636 PKCE)
+//   5. GET  /auth/github/callback                (defined in github.go;
+//                                                now ends in a 302 to
+//                                                the MCP client's
+//                                                redirect_uri with our
+//                                                one-shot code)
+//   6. POST /token                               (RFC 6749 §4.1.3)
+//
+// User authentication is delegated to GitHub. The access token issued
+// at /token is the same opaque ttd2_ key shape the manual flow used,
+// stored as sha256 in authdb.api_keys — the Bearer middleware
+// validates both kinds the same way.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+)
+
+const (
+	pathProtectedResource     = "/.well-known/oauth-protected-resource"
+	pathAuthorizationServer   = "/.well-known/oauth-authorization-server"
+	pathRegister              = "/register"
+	pathAuthorize             = "/authorize"
+	pathToken                 = "/token"
+	pathGitHubCallback        = "/auth/github/callback"
+
+	defaultScope = "mcp"
+)
+
+// ServeWellKnownProtectedResource implements RFC 9728 §3. The
+// response tells MCP clients which Authorization Server issues tokens
+// for this Resource Server.
+func (g *GitHub) ServeWellKnownProtectedResource(w http.ResponseWriter, r *http.Request) {
+	base := strings.TrimRight(g.Cfg.PublicURL, "/")
+	writeJSON(w, http.StatusOK, map[string]any{
+		"resource":                 base,
+		"authorization_servers":    []string{base},
+		"scopes_supported":         []string{defaultScope},
+		"bearer_methods_supported": []string{"header"},
+	})
+}
+
+// ServeWellKnownAuthorizationServer implements RFC 8414. Advertises
+// the endpoints we expose and the small subset of OAuth 2.1 features
+// we support — public clients, code grant, S256 PKCE only.
+func (g *GitHub) ServeWellKnownAuthorizationServer(w http.ResponseWriter, r *http.Request) {
+	base := strings.TrimRight(g.Cfg.PublicURL, "/")
+	writeJSON(w, http.StatusOK, map[string]any{
+		"issuer":                                base,
+		"authorization_endpoint":                base + pathAuthorize,
+		"token_endpoint":                        base + pathToken,
+		"registration_endpoint":                 base + pathRegister,
+		"scopes_supported":                      []string{defaultScope},
+		"response_types_supported":              []string{"code"},
+		"response_modes_supported":              []string{"query"},
+		"grant_types_supported":                 []string{"authorization_code"},
+		"code_challenge_methods_supported":      []string{"S256"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+	})
+}
+
+// ServeRegister implements RFC 7591 Dynamic Client Registration. v1
+// accepts public clients only — no `client_secret` is ever returned.
+// MCP clients (Claude.ai etc.) register on first connection and reuse
+// the assigned client_id across sessions.
+func (g *GitHub) ServeRegister(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		ClientName              string   `json:"client_name"`
+		RedirectURIs            []string `json:"redirect_uris"`
+		TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16<<10)).Decode(&req); err != nil {
+		oauthError(w, http.StatusBadRequest, "invalid_client_metadata", err.Error())
+		return
+	}
+	if req.ClientName == "" {
+		req.ClientName = "unnamed mcp client"
+	}
+	if len(req.RedirectURIs) == 0 {
+		oauthError(w, http.StatusBadRequest, "invalid_redirect_uri", "redirect_uris must be non-empty")
+		return
+	}
+	for _, u := range req.RedirectURIs {
+		if !isValidRedirectURI(u) {
+			oauthError(w, http.StatusBadRequest, "invalid_redirect_uri",
+				"redirect URIs must be absolute https URLs (or http://localhost/* for development)")
+			return
+		}
+	}
+	if req.TokenEndpointAuthMethod == "" {
+		req.TokenEndpointAuthMethod = "none"
+	}
+	if req.TokenEndpointAuthMethod != "none" {
+		oauthError(w, http.StatusBadRequest, "invalid_client_metadata",
+			"only public clients (token_endpoint_auth_method=none) are supported in v1")
+		return
+	}
+	client, err := g.Store.RegisterClient(r.Context(), req.ClientName, req.RedirectURIs, req.TokenEndpointAuthMethod)
+	if err != nil {
+		slog.Error("register client failed", "err", err)
+		oauthError(w, http.StatusInternalServerError, "server_error", "could not register client")
+		return
+	}
+	slog.Info("oauth client registered",
+		"client_id", client.ClientID,
+		"client_name", client.ClientName,
+	)
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"client_id":                  client.ClientID,
+		"client_name":                client.ClientName,
+		"redirect_uris":              client.RedirectURIs,
+		"token_endpoint_auth_method": client.TokenEndpointAuthMethod,
+		"client_id_issued_at":        client.CreatedAt.Unix(),
+		"grant_types":                []string{"authorization_code"},
+		"response_types":             []string{"code"},
+	})
+}
+
+// ServeAuthorize implements RFC 6749 §4.1.1 with PKCE (RFC 7636).
+// Validates the MCP client's request, stores it as an in-flight
+// authorize session, then redirects the user to GitHub for actual
+// authentication. The GitHub `state` is the session_id, so the
+// callback can find its way back to the right MCP client.
+func (g *GitHub) ServeAuthorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	clientID := q.Get("client_id")
+	redirectURI := q.Get("redirect_uri")
+	responseType := q.Get("response_type")
+	codeChallenge := q.Get("code_challenge")
+	codeChallengeMethod := q.Get("code_challenge_method")
+	state := q.Get("state")
+	scope := q.Get("scope")
+
+	if clientID == "" || redirectURI == "" {
+		// Per spec: if client_id or redirect_uri is invalid, do NOT
+		// redirect — show the error to the user/agent directly. A
+		// missing redirect_uri means we have nowhere safe to bounce.
+		http.Error(w, "client_id and redirect_uri are required", http.StatusBadRequest)
+		return
+	}
+	client, err := g.Store.LookupClient(r.Context(), clientID)
+	if err != nil {
+		http.Error(w, "unknown client_id", http.StatusBadRequest)
+		return
+	}
+	if !contains(client.RedirectURIs, redirectURI) {
+		http.Error(w, "redirect_uri not registered for this client", http.StatusBadRequest)
+		return
+	}
+	// From here on, errors get redirected back to the MCP client as
+	// per RFC 6749 §4.1.2.1.
+	if responseType != "code" {
+		redirectOAuthError(w, r, redirectURI, state, "unsupported_response_type",
+			"only response_type=code is supported")
+		return
+	}
+	if codeChallenge == "" || codeChallengeMethod != "S256" {
+		redirectOAuthError(w, r, redirectURI, state, "invalid_request",
+			"PKCE is required: code_challenge and code_challenge_method=S256")
+		return
+	}
+	if scope == "" {
+		scope = defaultScope
+	}
+	sessionID, err := g.Store.CreateAuthorizeSession(r.Context(), authdb.AuthorizeSession{
+		ClientID:            clientID,
+		RedirectURI:         redirectURI,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
+		Scope:               scope,
+		ClientState:         state,
+	})
+	if err != nil {
+		slog.Error("create authorize session", "err", err)
+		redirectOAuthError(w, r, redirectURI, state, "server_error", "could not start authorization")
+		return
+	}
+	// Hand off to GitHub for user authentication. session_id IS the
+	// GitHub `state` — the callback handler reads it directly.
+	gq := url.Values{}
+	gq.Set("client_id", g.Cfg.ClientID)
+	gq.Set("redirect_uri", g.Cfg.redirectURL())
+	gq.Set("scope", "read:user user:email")
+	gq.Set("state", sessionID)
+	http.Redirect(w, r, g.Cfg.authorizeURL()+"?"+gq.Encode(), http.StatusFound)
+}
+
+// ServeToken implements RFC 6749 §4.1.3 + RFC 7636 §4.6. Verifies
+// the PKCE code_verifier against the stored challenge and mints an
+// access token. v1 issues a non-expiring opaque token (matches the
+// existing API-key shape); refresh tokens are deferred (#13).
+func (g *GitHub) ServeToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "could not parse form body")
+		return
+	}
+	grantType := r.PostFormValue("grant_type")
+	code := r.PostFormValue("code")
+	redirectURI := r.PostFormValue("redirect_uri")
+	clientID := r.PostFormValue("client_id")
+	codeVerifier := r.PostFormValue("code_verifier")
+
+	if grantType != "authorization_code" {
+		oauthError(w, http.StatusBadRequest, "unsupported_grant_type",
+			"only authorization_code is supported")
+		return
+	}
+	if code == "" || clientID == "" || redirectURI == "" || codeVerifier == "" {
+		oauthError(w, http.StatusBadRequest, "invalid_request",
+			"code, client_id, redirect_uri, and code_verifier are all required")
+		return
+	}
+	consumed, _, err := g.Store.ConsumeAuthorizationCode(r.Context(), code)
+	if err != nil {
+		oauthError(w, http.StatusBadRequest, "invalid_grant", "code not found, expired, or already used")
+		return
+	}
+	if consumed.ClientID != clientID || consumed.RedirectURI != redirectURI {
+		oauthError(w, http.StatusBadRequest, "invalid_grant", "client_id or redirect_uri mismatch")
+		return
+	}
+	if !verifyPKCE(codeVerifier, consumed.CodeChallenge, consumed.CodeChallengeMethod) {
+		oauthError(w, http.StatusBadRequest, "invalid_grant", "PKCE verifier does not match challenge")
+		return
+	}
+	token, err := g.Store.IssueAPIKey(r.Context(), consumed.UserDBID)
+	if err != nil {
+		slog.Error("issue token", "err", err)
+		oauthError(w, http.StatusInternalServerError, "server_error", "could not issue token")
+		return
+	}
+	slog.Info("oauth token issued",
+		"client_id", clientID,
+		"user_db_id", consumed.UserDBID,
+		"scope", consumed.Scope,
+	)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token": token,
+		"token_type":   "Bearer",
+		"scope":        consumed.Scope,
+	})
+}
+
+func verifyPKCE(verifier, challenge, method string) bool {
+	if method != "S256" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	expected := base64.RawURLEncoding.EncodeToString(sum[:])
+	return expected == challenge
+}
+
+// isValidRedirectURI matches the MCP spec's relaxed rules: production
+// clients must use https; localhost is allowed plain http for dev
+// convenience (RFC 8252 §7.3).
+func isValidRedirectURI(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || !u.IsAbs() {
+		return false
+	}
+	switch u.Scheme {
+	case "https":
+		return true
+	case "http":
+		host := u.Hostname()
+		return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	}
+	return false
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func oauthError(w http.ResponseWriter, status int, code, description string) {
+	writeJSON(w, status, map[string]string{
+		"error":             code,
+		"error_description": description,
+	})
+}
+
+// redirectOAuthError bounces an authorization-phase error back to the
+// MCP client's redirect_uri carrying the original state, per
+// RFC 6749 §4.1.2.1. The MCP client surfaces the error to its
+// user — we don't render anything ourselves.
+func redirectOAuthError(w http.ResponseWriter, r *http.Request, redirectURI, state, code, description string) {
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		http.Error(w, description, http.StatusBadRequest)
+		return
+	}
+	q := u.Query()
+	q.Set("error", code)
+	if description != "" {
+		q.Set("error_description", description)
+	}
+	if state != "" {
+		q.Set("state", state)
+	}
+	u.RawQuery = q.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}
+
+// Silence unused-import linter for symbols only touched in tests.
+var (
+	_ = errors.Is
+	_ = context.Background
+	_ = fmt.Sprintf
+)

--- a/internal/authdb/authdb.go
+++ b/internal/authdb/authdb.go
@@ -52,6 +52,10 @@ func Open(path string) (*Store, error) {
 		_ = db.Close()
 		return nil, err
 	}
+	if err := s.migrateOAuth(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	return s, nil
 }
 

--- a/internal/authdb/oauth.go
+++ b/internal/authdb/oauth.go
@@ -1,0 +1,333 @@
+package authdb
+
+// OAuth-AS storage. Three small tables that together turn the API-key
+// machinery in authdb.go into a working RFC 6749 + RFC 7591 + RFC 7636
+// Authorization Server:
+//
+//   - oauth_clients              — dynamic (RFC 7591) registration of
+//                                  MCP clients. Public clients only at
+//                                  v1; no client_secret column.
+//   - oauth_authorize_sessions   — short-lived state for the round-trip
+//                                  through GitHub. The session_id is
+//                                  also our `state` param sent to
+//                                  GitHub, so the callback can find its
+//                                  way back to the right MCP client.
+//   - oauth_authorization_codes  — one-shot codes returned from the
+//                                  callback to the MCP client, redeemed
+//                                  at /token. PKCE challenge stored
+//                                  here so the verifier can be checked
+//                                  at redemption time.
+//
+// Expiry is enforced by checking expires_at in each read; SQLite has
+// no native TTL.
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Authorize-session and authorization-code lifetimes. Both are tight by
+// design — an OAuth dance that takes longer than these is almost
+// certainly an attacker or a hung browser, not a legitimate user.
+const (
+	AuthorizeSessionTTL = 10 * time.Minute
+	AuthorizationCodeTTL = 60 * time.Second
+)
+
+// Errors callers should be able to distinguish in tests and at the
+// handler boundary.
+var (
+	ErrUnknownClient        = errors.New("unknown oauth client")
+	ErrSessionNotFound      = errors.New("authorize session not found or expired")
+	ErrAuthorizationCode    = errors.New("authorization code not found, expired, or already used")
+	ErrPKCEMismatch         = errors.New("pkce verifier does not match challenge")
+)
+
+// OAuthClient is the public-facing shape of a registered MCP client.
+type OAuthClient struct {
+	ClientID                string
+	ClientName              string
+	RedirectURIs            []string
+	TokenEndpointAuthMethod string
+	CreatedAt               time.Time
+}
+
+// AuthorizeSession is the server-side state held between the MCP
+// client's /authorize request and GitHub's callback. The SessionID
+// doubles as our `state` param sent to GitHub.
+type AuthorizeSession struct {
+	SessionID           string
+	ClientID            string
+	RedirectURI         string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Scope               string
+	ClientState         string
+	ExpiresAt           time.Time
+}
+
+// AuthorizationCode is the one-shot code redeemed at /token.
+type AuthorizationCode struct {
+	Code                string
+	UserDBID            int64
+	ClientID            string
+	RedirectURI         string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Scope               string
+}
+
+func (s *Store) migrateOAuth() error {
+	const ddl = `
+CREATE TABLE IF NOT EXISTS oauth_clients (
+  client_id                  TEXT PRIMARY KEY,
+  client_name                TEXT NOT NULL,
+  redirect_uris              TEXT NOT NULL, -- JSON-encoded array
+  token_endpoint_auth_method TEXT NOT NULL DEFAULT 'none',
+  created_at                 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS oauth_authorize_sessions (
+  session_id            TEXT PRIMARY KEY,
+  client_id             TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
+  redirect_uri          TEXT NOT NULL,
+  code_challenge        TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL DEFAULT 'S256',
+  scope                 TEXT,
+  client_state          TEXT NOT NULL,
+  expires_at            TIMESTAMP NOT NULL
+);
+CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
+  code                  TEXT PRIMARY KEY,
+  user_id               INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  client_id             TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
+  redirect_uri          TEXT NOT NULL,
+  code_challenge        TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL DEFAULT 'S256',
+  scope                 TEXT,
+  used                  INTEGER NOT NULL DEFAULT 0,
+  expires_at            TIMESTAMP NOT NULL
+);
+`
+	if _, err := s.db.Exec(ddl); err != nil {
+		return fmt.Errorf("migrate oauth schema: %w", err)
+	}
+	return nil
+}
+
+// RegisterClient persists a dynamic client registration and returns
+// the assigned client_id. Caller is responsible for validating the
+// redirect URI shapes (https + matching host policy) before calling.
+func (s *Store) RegisterClient(ctx context.Context, name string, redirectURIs []string, authMethod string) (OAuthClient, error) {
+	if name == "" || len(redirectURIs) == 0 {
+		return OAuthClient{}, fmt.Errorf("client_name and redirect_uris are required")
+	}
+	if authMethod == "" {
+		authMethod = "none"
+	}
+	clientID, err := randomToken("ttd2cli_")
+	if err != nil {
+		return OAuthClient{}, err
+	}
+	urisJSON, err := json.Marshal(redirectURIs)
+	if err != nil {
+		return OAuthClient{}, fmt.Errorf("marshal redirect_uris: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO oauth_clients(client_id, client_name, redirect_uris, token_endpoint_auth_method)
+VALUES(?, ?, ?, ?)
+`, clientID, name, string(urisJSON), authMethod); err != nil {
+		return OAuthClient{}, fmt.Errorf("insert oauth client: %w", err)
+	}
+	return OAuthClient{
+		ClientID:                clientID,
+		ClientName:              name,
+		RedirectURIs:            redirectURIs,
+		TokenEndpointAuthMethod: authMethod,
+		CreatedAt:               time.Now().UTC(),
+	}, nil
+}
+
+// LookupClient returns the registered client or ErrUnknownClient.
+func (s *Store) LookupClient(ctx context.Context, clientID string) (OAuthClient, error) {
+	var (
+		name, urisJSON, authMethod string
+		createdAt                  time.Time
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT client_name, redirect_uris, token_endpoint_auth_method, created_at
+		   FROM oauth_clients WHERE client_id = ?`, clientID,
+	).Scan(&name, &urisJSON, &authMethod, &createdAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return OAuthClient{}, ErrUnknownClient
+	}
+	if err != nil {
+		return OAuthClient{}, fmt.Errorf("lookup oauth client: %w", err)
+	}
+	var uris []string
+	if err := json.Unmarshal([]byte(urisJSON), &uris); err != nil {
+		return OAuthClient{}, fmt.Errorf("decode redirect_uris: %w", err)
+	}
+	return OAuthClient{
+		ClientID:                clientID,
+		ClientName:              name,
+		RedirectURIs:            uris,
+		TokenEndpointAuthMethod: authMethod,
+		CreatedAt:               createdAt,
+	}, nil
+}
+
+// CreateAuthorizeSession persists an in-flight /authorize request and
+// returns the session_id (which is also used as the GitHub `state`).
+// Caller validates the request shape; this method only stores.
+func (s *Store) CreateAuthorizeSession(ctx context.Context, in AuthorizeSession) (string, error) {
+	sid, err := randomToken("ttd2sess_")
+	if err != nil {
+		return "", err
+	}
+	if in.CodeChallengeMethod == "" {
+		in.CodeChallengeMethod = "S256"
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO oauth_authorize_sessions(
+  session_id, client_id, redirect_uri,
+  code_challenge, code_challenge_method, scope, client_state, expires_at)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+`,
+		sid, in.ClientID, in.RedirectURI,
+		in.CodeChallenge, in.CodeChallengeMethod, in.Scope, in.ClientState,
+		time.Now().UTC().Add(AuthorizeSessionTTL),
+	); err != nil {
+		return "", fmt.Errorf("insert authorize session: %w", err)
+	}
+	return sid, nil
+}
+
+// ConsumeAuthorizeSession reads and deletes the session in one txn —
+// the GitHub callback can fire exactly once per /authorize, and we
+// don't want a duplicate-replay to re-enter the flow.
+func (s *Store) ConsumeAuthorizeSession(ctx context.Context, sessionID string) (AuthorizeSession, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AuthorizeSession{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var out AuthorizeSession
+	err = tx.QueryRowContext(ctx, `
+SELECT session_id, client_id, redirect_uri, code_challenge, code_challenge_method,
+       COALESCE(scope, ''), client_state, expires_at
+  FROM oauth_authorize_sessions WHERE session_id = ?
+`, sessionID).Scan(
+		&out.SessionID, &out.ClientID, &out.RedirectURI,
+		&out.CodeChallenge, &out.CodeChallengeMethod, &out.Scope,
+		&out.ClientState, &out.ExpiresAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AuthorizeSession{}, ErrSessionNotFound
+	}
+	if err != nil {
+		return AuthorizeSession{}, fmt.Errorf("read authorize session: %w", err)
+	}
+	if time.Now().UTC().After(out.ExpiresAt) {
+		_, _ = tx.ExecContext(ctx, `DELETE FROM oauth_authorize_sessions WHERE session_id = ?`, sessionID)
+		_ = tx.Commit()
+		return AuthorizeSession{}, ErrSessionNotFound
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM oauth_authorize_sessions WHERE session_id = ?`, sessionID); err != nil {
+		return AuthorizeSession{}, fmt.Errorf("delete authorize session: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return AuthorizeSession{}, fmt.Errorf("commit: %w", err)
+	}
+	return out, nil
+}
+
+// MintAuthorizationCode issues a one-shot code bound to the user +
+// client + PKCE challenge from a completed authorize session.
+func (s *Store) MintAuthorizationCode(ctx context.Context, in AuthorizationCode) (string, error) {
+	code, err := randomToken("ttd2code_")
+	if err != nil {
+		return "", err
+	}
+	if in.CodeChallengeMethod == "" {
+		in.CodeChallengeMethod = "S256"
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO oauth_authorization_codes(
+  code, user_id, client_id, redirect_uri,
+  code_challenge, code_challenge_method, scope, expires_at)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+`,
+		code, in.UserDBID, in.ClientID, in.RedirectURI,
+		in.CodeChallenge, in.CodeChallengeMethod, in.Scope,
+		time.Now().UTC().Add(AuthorizationCodeTTL),
+	); err != nil {
+		return "", fmt.Errorf("insert authorization code: %w", err)
+	}
+	return code, nil
+}
+
+// ConsumeAuthorizationCode atomically marks the code as used and
+// returns its bound data. Replay of the same code returns
+// ErrAuthorizationCode — and per RFC 6749 §10.5 the server SHOULD
+// invalidate any tokens already issued from that code; we'd handle
+// that in a follow-up since v1 issues exactly one token per code.
+func (s *Store) ConsumeAuthorizationCode(ctx context.Context, code string) (AuthorizationCode, int64, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AuthorizationCode{}, 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		out       AuthorizationCode
+		used      int
+		expiresAt time.Time
+	)
+	err = tx.QueryRowContext(ctx, `
+SELECT code, user_id, client_id, redirect_uri, code_challenge, code_challenge_method,
+       COALESCE(scope, ''), used, expires_at
+  FROM oauth_authorization_codes WHERE code = ?
+`, code).Scan(
+		&out.Code, &out.UserDBID, &out.ClientID, &out.RedirectURI,
+		&out.CodeChallenge, &out.CodeChallengeMethod, &out.Scope,
+		&used, &expiresAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AuthorizationCode{}, 0, ErrAuthorizationCode
+	}
+	if err != nil {
+		return AuthorizationCode{}, 0, fmt.Errorf("read authorization code: %w", err)
+	}
+	if used != 0 || time.Now().UTC().After(expiresAt) {
+		return AuthorizationCode{}, 0, ErrAuthorizationCode
+	}
+	res, err := tx.ExecContext(ctx,
+		`UPDATE oauth_authorization_codes SET used = 1 WHERE code = ? AND used = 0`, code)
+	if err != nil {
+		return AuthorizationCode{}, 0, fmt.Errorf("mark code used: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n != 1 {
+		return AuthorizationCode{}, 0, ErrAuthorizationCode
+	}
+	if err := tx.Commit(); err != nil {
+		return AuthorizationCode{}, 0, fmt.Errorf("commit: %w", err)
+	}
+	return out, out.UserDBID, nil
+}
+
+// randomToken returns prefix + 32 bytes of URL-safe random.
+func randomToken(prefix string) (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("read random: %w", err)
+	}
+	return prefix + base64.RawURLEncoding.EncodeToString(raw[:]), nil
+}


### PR DESCRIPTION
Closes umbrella #2 sub-issue **#9**. Replaces the manual "visit `/login`, copy your Bearer token" flow with the OAuth dance the MCP spec defines, so hosted clients like Claude.ai can add the server with a click and never see a token.

## Protocol surface

| Endpoint | RFC | Purpose |
| --- | --- | --- |
| `GET /.well-known/oauth-protected-resource` | 9728 | Tells MCP clients which AS issues tokens for `/mcp`. The `WWW-Authenticate` on the `/mcp` 401 now carries `resource_metadata="…"` pointing here — that single header bootstraps the whole flow. |
| `GET /.well-known/oauth-authorization-server` | 8414 | Declares `/authorize`, `/token`, `/register`; S256 PKCE only; public clients only; `authorization_code` grant only. |
| `POST /register` | 7591 | DCR: new MCP clients self-register and get a `ttd2cli_…` client_id. v1 public clients only (no `client_secret`). Validates redirect_uris — `https://` required; `http://localhost` allowed per RFC 8252 §7.3. |
| `GET /authorize` | 6749 §4.1 + 7636 | Validates inputs, stores an in-flight session, redirects to GitHub. The session_id doubles as GitHub's `state` — replaces the old cookie-based CSRF guard (which Firefox strict-mode broke for you yesterday). |
| `GET /auth/github/callback` | — (rewritten) | Consumes the session, exchanges the GitHub code, upserts the user, mints a one-shot authorization code bound to the original PKCE challenge, redirects to the MCP client's `redirect_uri`. |
| `POST /token` | 6749 §4.1.3 | Verifies PKCE S256, consumes the one-shot code, issues an opaque `ttd2_` access token via the existing `IssueAPIKey`. The Bearer middleware on `/mcp` accepts it unchanged. |

**Removed**: `/login` route + `writeKeyPage` HTML. The manual visit-the-server-to-fetch-a-token flow is gone — headless/CI use captures a token by driving the OAuth flow once and reusing it.

## Storage (authdb)

Three new tables:

- `oauth_clients` — dynamic client registrations
- `oauth_authorize_sessions` — 10-min TTL, single-use, consumed at the GitHub callback
- `oauth_authorization_codes` — 60-sec TTL, atomic `used=1` mark to prevent replay

## Tests

- **`TestOAuth_FullRoundTrip`** walks `/register → /authorize → /auth/github/callback` (mocked GitHub via `httptest`) `→ /token → /mcp` Bearer use. Same shape as Claude.ai's first connect.
- `TestOAuth_PKCEMismatch` — wrong `code_verifier` rejected at `/token`.
- `TestOAuth_Register_RejectsBadRedirectURI` — non-https, relative, empty, and confidential-client requests all 4xx.
- `TestOAuth_WellKnown` — discovery JSON matches `PublicURL`-derived endpoints.
- Existing Bearer-validation + `None`-backend tests untouched.

## Container smoke (AUTH=github)

```
/.well-known/oauth-protected-resource    → JSON, names this server
/.well-known/oauth-authorization-server  → endpoint catalogue with S256/public clients
/mcp (no Bearer)                          → 401 + WWW-Authenticate: Bearer realm=…,
                                            resource_metadata="…/oauth-protected-resource"
POST /register                            → ttd2cli_… client_id
/authorize with unknown client_id         → 400 (no trusted redirect_uri to bounce to)
```

`go vet` / `go test` / `golangci-lint` / `govulncheck` — all clean.

## After this merges, the operator UX in Claude.ai

> Add custom MCP server → paste `https://typst-d2-mcp.stormlantern.nl/mcp` → click sign-in → done.

No `Iv1.` to copy, no `ttd2_…` to paste. The same `Authorization: Bearer ttd2_…` flow still works for `curl` / CI use cases — just capture one once.

## Follow-ups already filed

- [#12](https://github.com/dlouwers/typst-d2-mcp/issues/12) — Migrate access tokens from opaque to JWT (deferred until multi-replica)
- [#13](https://github.com/dlouwers/typst-d2-mcp/issues/13) — Add refresh tokens (deferred until token-leak posture matters)

Refers #2