### PR TITLE
fix(deploy): writable /tmp and $HOME under readOnlyRootFilesystem

### DIFF
--- a/deploy/k8s/base/deployment.yaml
+++ b/deploy/k8s/base/deployment.yaml
@@ -62,9 +62,23 @@ spec:
                 name: typst-d2-mcp-config
             - secretRef:
                 name: typst-d2-mcp-secrets
+          env:
+            # readOnlyRootFilesystem=true means /home/nonroot (the
+            # distroless default $HOME) isn't writable, which breaks
+            # typst's package cache for @preview/based and its font
+            # index. Point $HOME at a subdir of the persistent
+            # volume so the cache survives pod restarts.
+            - name: HOME
+              value: /var/lib/typst-d2-mcp/home
           volumeMounts:
             - name: data
               mountPath: /var/lib/typst-d2-mcp
+            # os.CreateTemp("", …) in the compile handler writes a
+            # staged .typ file under /tmp. An in-memory emptyDir
+            # gives us a small, fast scratch surface while keeping
+            # the root filesystem read-only.
+            - name: tmp
+              mountPath: /tmp
           # /healthz is a static 200 — fine for both probes.
           readinessProbe:
             httpGet:
@@ -98,3 +112,7 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: typst-d2-mcp-data
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi


### PR DESCRIPTION
Claude.ai's first real compile against the test env failed with a "read-only file system" error. Two paths the workload writes to that aren't writable when `readOnlyRootFilesystem: true`:

- **`/tmp`** — `os.CreateTemp("", "typst-d2-*.typ")` in the compile handler stages preprocessed Typst content there. Fixed with a **64Mi in-memory `emptyDir`** (small, fast, ephemeral — fits the per-compile scratch use case).
- **`$HOME=/home/nonroot`** — typst caches downloaded `@preview/*` packages and its font index under `$HOME/.cache/typst` and `$HOME/.local/share/typst`. Fixed by **repointing `$HOME` at `/var/lib/typst-d2-mcp/home`** (a subdir of the persistent volume), so the `@preview/based` download from the first compile survives pod restarts instead of being re-fetched every roll.

The container-level smoke tests we ran during development happened to use a writable rootfs (no `securityContext` flag), which is why this didn't surface until the first real Kubernetes deployment.

`kustomize build deploy/k8s/base/` clean. No code changes.

## After merge

Flux will pick up the new manifest, the pod rolls, and the next compile from Claude.ai should succeed. Worth re-trying the same prompt as a smoke.