### PR TITLE
fix(mcp): embed compiled PDF inline for clients that don't follow resource_link

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -52,8 +52,12 @@ const (
 
 	envMetricsAddr   = "TYPST_D2_MCP_METRICS_ADDR"
 	envMetricsBearer = "TYPST_D2_MCP_METRICS_BEARER"
+	envMaxEmbedBytes = "TYPST_D2_MCP_MAX_EMBED_BYTES"
 
-	defaultMetricsAddr = ":9090"
+	defaultMetricsAddr   = ":9090"
+	defaultMaxEmbedBytes = int64(512 << 10) // 512 KiB — below this the PDF
+	// is base64-embedded inline so MCP clients that don't follow
+	// resource_link (Claude.ai as of 2026-05) still get the bytes.
 
 	defaultAddr           = ":8080"
 	defaultPath           = "/mcp"
@@ -87,6 +91,16 @@ func maxInputBytes() int64 {
 // deployments stay unmetered.
 func quotaPerDay() int {
 	return int(int64Env(envQuotaPerDay, int64(defaultQuotaPerDay)))
+}
+
+// maxEmbedBytes is the size cutoff above which the compiled PDF is
+// returned as a resource_link only (clients fetch via resources/read)
+// instead of being base64-embedded in the tool result. Inlining
+// avoids the link-doesn't-resolve trap on clients that don't auto-
+// follow resource_link (today: Claude.ai), but burns tokens linearly
+// in PDF size — hence the cap. 0 disables embedding entirely.
+func maxEmbedBytes() int64 {
+	return int64Env(envMaxEmbedBytes, defaultMaxEmbedBytes)
 }
 
 func durationEnv(key string, def time.Duration) time.Duration {
@@ -669,9 +683,42 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		duration := time.Since(start)
 		metrics.CompileTotal.WithLabelValues(metrics.ResultOK).Inc()
 		metrics.CompileDuration.Observe(duration.Seconds())
+
+		// Decide between inline-embedded PDF and resource_link based
+		// on size. Clients that auto-follow resource_link (the spec'd
+		// behavior) work either way; clients that don't (Claude.ai
+		// today) need the bytes inline to display anything.
+		pdfURI := pdfURIPrefix + url.PathEscape(toolVisibleOut)
+		pdfInfo, _ := os.Stat(resolvedOut)
+		limit := maxEmbedBytes()
+		if limit > 0 && pdfInfo != nil && pdfInfo.Size() <= limit {
+			pdfBytes, err := os.ReadFile(resolvedOut)
+			if err == nil {
+				log.Info("compile ok",
+					"output", toolVisibleOut,
+					"duration_ms", duration.Milliseconds(),
+					"pdf_bytes", len(pdfBytes),
+					"embedded", true,
+				)
+				return mcp.NewToolResultResource(successMsg, mcp.BlobResourceContents{
+					URI:      pdfURI,
+					MIMEType: "application/pdf",
+					Blob:     base64.StdEncoding.EncodeToString(pdfBytes),
+				}), nil
+			}
+			// Fall through to link if read failed.
+			log.Warn("read pdf for inline embed failed; falling back to resource_link", "err", err)
+		}
+		if pdfInfo != nil && limit > 0 {
+			successMsg += fmt.Sprintf(
+				"\n\n(PDF is %d bytes — over the %d-byte inline limit. Use resources/read on the link below, or raise %s.)",
+				pdfInfo.Size(), limit, envMaxEmbedBytes,
+			)
+		}
 		log.Info("compile ok",
 			"output", toolVisibleOut,
 			"duration_ms", duration.Milliseconds(),
+			"embedded", false,
 		)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{


### PR DESCRIPTION
Claude.ai's MCP client reports *"resource links aren't currently supported in this client"* after a successful compile. The pipeline ran end-to-end (the PDF is on disk in the workspace) but the `resource_link` is decorative for that client — the user gets the prose result but never sees the file.

This adds inline base64 embedding when the PDF is small enough, without breaking the previous `resource_link` behavior for larger outputs or clients that prefer to fetch via `resources/read`.

## Behaviour

| PDF size | Tool result content | Token cost |
|---|---|---|
| `≤ TYPST_D2_MCP_MAX_EMBED_BYTES` (default **512 KiB**) | `text` + `EmbeddedResource` (base64 PDF, MIME `application/pdf`) | linear in PDF size (~4/3× bytes) |
| `>` the cap | `text` + `resource_link` (previous behaviour), with the prose explaining how to fetch via `resources/read` or raise the limit | unchanged |

A 14 KB PDF embeds at ~5k tokens; a 200 KB PDF at ~75k. The 512 KiB ceiling is a deliberate guardrail — multi-page reports fall back to `resource_link` until [#5](https://github.com/dlouwers/typst-d2-mcp/issues/2) (signed URLs) lands. Operators can:

- raise the cap with `TYPST_D2_MCP_MAX_EMBED_BYTES=<bytes>`
- disable embedding entirely with `TYPST_D2_MCP_MAX_EMBED_BYTES=0` (everything via resource_link)

## Validation

`go vet`, `go test`, `golangci-lint`, `govulncheck` — all clean. Single-handler change in `cmd/typst-d2-mcp/main.go`; the resource template + `resources/read` handler are untouched, so clients that *do* follow `resource_link` (per spec) still get bytes that way.

After merge, Flux rolls the test pod within ~5 min and the next Claude.ai compile should return a PDF the model can show the user directly.

Refers #2