### PR TITLE
feat(mcp): capability-URL PDF download endpoint

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -52,8 +53,10 @@ const (
 
 	envMetricsAddr   = "TYPST_D2_MCP_METRICS_ADDR"
 	envMetricsBearer = "TYPST_D2_MCP_METRICS_BEARER"
+	envPDFLinkTTL    = "TYPST_D2_MCP_PDF_LINK_TTL"
 
 	defaultMetricsAddr = ":9090"
+	defaultPDFLinkTTL  = time.Hour
 
 	defaultAddr           = ":8080"
 	defaultPath           = "/mcp"
@@ -87,6 +90,14 @@ func maxInputBytes() int64 {
 // deployments stay unmetered.
 func quotaPerDay() int {
 	return int(int64Env(envQuotaPerDay, int64(defaultQuotaPerDay)))
+}
+
+// pdfLinkTTL is the lifetime of a capability URL minted by the compile
+// handler. The opaque token IS the credential; the URL itself is the
+// primary defence, so a tight TTL is the secondary defence in case the
+// URL leaks via chat history, server logs, etc.
+func pdfLinkTTL() time.Duration {
+	return durationEnv(envPDFLinkTTL, defaultPDFLinkTTL)
 }
 
 func durationEnv(key string, def time.Duration) time.Duration {
@@ -219,7 +230,7 @@ func main() {
 		"max_input_bytes", maxInputBytes(),
 	)
 
-	if err := serve(s, backend, ghHandlers); err != nil {
+	if err := serve(s, backend, ghHandlers, factory, store); err != nil {
 		slog.Error("server stopped", "err", err)
 		os.Exit(1)
 	}
@@ -356,7 +367,7 @@ func isHTTPTransport() bool {
 	return t == "http" || t == "streamable-http"
 }
 
-func serve(s *server.MCPServer, backend auth.Backend, gh *gitHubHandlers) error {
+func serve(s *server.MCPServer, backend auth.Backend, gh *gitHubHandlers, factory workspace.Factory, store *authdb.Store) error {
 	switch transport := strings.ToLower(os.Getenv(envTransport)); transport {
 	case "", "stdio":
 		// Stdio is always anonymous; the backend is irrelevant.
@@ -393,6 +404,11 @@ func serve(s *server.MCPServer, backend auth.Backend, gh *gitHubHandlers) error 
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		})
+		// /d/{token} — capability-URL download endpoint. NOT behind
+		// the Bearer middleware: the token IS the credential, by
+		// design. Handler short-circuits to 404 when store == nil
+		// (AUTH=none stdio/local deployments).
+		mux.Handle("/d/", handlePDFDownload(factory, store))
 		if gh != nil {
 			// MCP-spec OAuth Authorization Server endpoints. The
 			// callback URL stays at /auth/github/callback to match the
@@ -669,6 +685,34 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		duration := time.Since(start)
 		metrics.CompileTotal.WithLabelValues(metrics.ResultOK).Inc()
 		metrics.CompileDuration.Observe(duration.Seconds())
+
+		// Mint a capability URL for the PDF and append it to the
+		// result text. MCP clients that don't auto-follow
+		// resource_link blocks (Claude.ai web as of 2026-05) DO
+		// render plain https URLs as clickable links — the user
+		// opens the PDF in their browser, no bytes traverse the LLM
+		// context. Spec-conformant clients (Claude Code) still get
+		// the resource_link content block alongside.
+		//
+		// Requires a SQLite store (AUTH=github) and TYPST_D2_MCP_PUBLIC_URL.
+		// Anonymous / AUTH=none deployments skip the link silently;
+		// those operators have local filesystem access anyway.
+		if store != nil {
+			ttl := pdfLinkTTL()
+			token, mintErr := store.MintPDFLink(ctx, id.UserID, toolVisibleOut, ttl)
+			if mintErr == nil {
+				pub := strings.TrimRight(os.Getenv(envPublicURL), "/")
+				if pub != "" {
+					successMsg += fmt.Sprintf(
+						"\n\nDownload: %s/d/%s\n(expires in %s; share or open in a browser)",
+						pub, token, ttl,
+					)
+				}
+			} else {
+				log.Warn("mint pdf link failed", "err", mintErr)
+			}
+		}
+
 		log.Info("compile ok",
 			"output", toolVisibleOut,
 			"duration_ms", duration.Milliseconds(),
@@ -680,6 +724,61 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 			},
 		}, nil
 	}
+}
+
+// handlePDFDownload is the capability-URL endpoint mounted at /d/.
+// It reads the token, resolves it to (user, file_path) via the SQLite
+// store, recreates the workspace.Resolver for that user via the
+// factory, and streams the PDF bytes. There is intentionally no
+// Bearer/auth check: the random token IS the credential, by design
+// (RFC-7239 §1 capability URL pattern).
+func handlePDFDownload(factory workspace.Factory, store *authdb.Store) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.URL.Path, "/d/")
+		if token == "" || strings.Contains(token, "/") {
+			metrics.PDFDownloadTotal.WithLabelValues(metrics.ResultFail).Inc()
+			http.NotFound(w, r)
+			return
+		}
+		if store == nil {
+			metrics.PDFDownloadTotal.WithLabelValues(metrics.ResultFail).Inc()
+			http.NotFound(w, r)
+			return
+		}
+		link, err := store.LookupPDFLink(r.Context(), token)
+		if err != nil {
+			metrics.PDFDownloadTotal.WithLabelValues(metrics.ResultNotFound).Inc()
+			http.NotFound(w, r)
+			return
+		}
+		resolver, err := factory.Resolver(identity.Identity{UserID: link.UserID})
+		if err != nil {
+			metrics.PDFDownloadTotal.WithLabelValues(metrics.ResultFail).Inc()
+			slog.Error("pdf download: resolver", "err", err, "user", link.UserID)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		resolved, err := workspace.MustExist(resolver, link.FilePath)
+		if err != nil {
+			metrics.PDFDownloadTotal.WithLabelValues(metrics.ResultNotFound).Inc()
+			slog.Warn("pdf download: file missing", "user", link.UserID, "path", link.FilePath)
+			http.NotFound(w, r)
+			return
+		}
+		f, err := os.Open(resolved)
+		if err != nil {
+			metrics.PDFDownloadTotal.WithLabelValues(metrics.ResultFail).Inc()
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		defer f.Close()
+		w.Header().Set("Content-Type", "application/pdf")
+		w.Header().Set("Content-Disposition",
+			fmt.Sprintf(`inline; filename=%q`, filepath.Base(link.FilePath)))
+		w.Header().Set("Cache-Control", "private, max-age=300")
+		metrics.PDFDownloadTotal.WithLabelValues(metrics.ResultOK).Inc()
+		_, _ = io.Copy(w, f)
+	})
 }
 
 func handlePutFile(factory workspace.Factory) server.ToolHandlerFunc {

--- a/internal/authdb/oauth.go
+++ b/internal/authdb/oauth.go
@@ -47,6 +47,7 @@ var (
 	ErrSessionNotFound      = errors.New("authorize session not found or expired")
 	ErrAuthorizationCode    = errors.New("authorization code not found, expired, or already used")
 	ErrPKCEMismatch         = errors.New("pkce verifier does not match challenge")
+	ErrPDFLinkNotFound      = errors.New("pdf download link not found or expired")
 )
 
 // OAuthClient is the public-facing shape of a registered MCP client.
@@ -112,6 +113,13 @@ CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
   scope                 TEXT,
   used                  INTEGER NOT NULL DEFAULT 0,
   expires_at            TIMESTAMP NOT NULL
+);
+CREATE TABLE IF NOT EXISTS pdf_links (
+  token       TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,         -- identity.Identity.UserID (e.g. "gh:42")
+  file_path   TEXT NOT NULL,         -- workspace-relative path to the PDF
+  created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at  TIMESTAMP NOT NULL
 );
 `
 	if _, err := s.db.Exec(ddl); err != nil {

--- a/internal/authdb/pdflinks.go
+++ b/internal/authdb/pdflinks.go
@@ -1,0 +1,85 @@
+package authdb
+
+// PDF capability-URL store. A token is the only credential needed to
+// fetch the linked PDF — the random ID *is* the capability, so we don't
+// HMAC-sign anything. Tokens have a short TTL (operator-configurable;
+// default 1h at the caller boundary) and are scoped to one specific
+// user + file_path at mint time. The HTTP /d/{token} handler reads the
+// row, resolves the file through the active workspace for that user,
+// and streams the bytes. Anyone with the URL within the TTL can
+// download — exactly the property we need for clients that can't
+// follow MCP resource_link blocks but do render HTTPS links in chat.
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// PDFLink is the resolved view of a row in pdf_links.
+type PDFLink struct {
+	Token     string
+	UserID    string
+	FilePath  string
+	ExpiresAt time.Time
+}
+
+// MintPDFLink generates a fresh 32-byte URL-safe token and binds it
+// to (userID, filePath) for ttl. Returns the token; the caller
+// composes the public URL by joining it onto PublicURL+"/d/".
+func (s *Store) MintPDFLink(ctx context.Context, userID, filePath string, ttl time.Duration) (string, error) {
+	if userID == "" || filePath == "" {
+		return "", fmt.Errorf("userID and filePath are required")
+	}
+	if ttl <= 0 {
+		return "", fmt.Errorf("ttl must be positive")
+	}
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("read random: %w", err)
+	}
+	token := base64.RawURLEncoding.EncodeToString(raw[:])
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO pdf_links(token, user_id, file_path, expires_at)
+VALUES(?, ?, ?, ?)
+`, token, userID, filePath, time.Now().UTC().Add(ttl)); err != nil {
+		return "", fmt.Errorf("insert pdf link: %w", err)
+	}
+	return token, nil
+}
+
+// LookupPDFLink resolves a token to its bound (user_id, file_path).
+// Expired rows are pruned on access and reported as ErrPDFLinkNotFound,
+// which is also returned for unknown tokens — callers shouldn't be
+// able to distinguish "wrong token" from "valid but expired" to keep
+// the surface minimal for probing attackers.
+func (s *Store) LookupPDFLink(ctx context.Context, token string) (PDFLink, error) {
+	if token == "" {
+		return PDFLink{}, ErrPDFLinkNotFound
+	}
+	var (
+		link    PDFLink
+		expires time.Time
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT token, user_id, file_path, expires_at
+  FROM pdf_links WHERE token = ?
+`, token).Scan(&link.Token, &link.UserID, &link.FilePath, &expires)
+	if errors.Is(err, sql.ErrNoRows) {
+		return PDFLink{}, ErrPDFLinkNotFound
+	}
+	if err != nil {
+		return PDFLink{}, fmt.Errorf("lookup pdf link: %w", err)
+	}
+	if time.Now().UTC().After(expires) {
+		// Best-effort cleanup; ignore error.
+		_, _ = s.db.ExecContext(ctx, `DELETE FROM pdf_links WHERE token = ?`, token)
+		return PDFLink{}, ErrPDFLinkNotFound
+	}
+	link.ExpiresAt = expires
+	return link, nil
+}

--- a/internal/authdb/pdflinks_test.go
+++ b/internal/authdb/pdflinks_test.go
@@ -1,0 +1,85 @@
+package authdb
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestPDFLink_MintAndLookup(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	tok, err := s.MintPDFLink(ctx, "gh:42", "doc.pdf", time.Hour)
+	if err != nil {
+		t.Fatalf("MintPDFLink: %v", err)
+	}
+	if tok == "" || len(tok) < 32 {
+		t.Errorf("token looks too short: %q", tok)
+	}
+
+	link, err := s.LookupPDFLink(ctx, tok)
+	if err != nil {
+		t.Fatalf("LookupPDFLink: %v", err)
+	}
+	if link.UserID != "gh:42" || link.FilePath != "doc.pdf" {
+		t.Errorf("link fields off: %+v", link)
+	}
+	if time.Until(link.ExpiresAt) < 30*time.Minute {
+		t.Errorf("expires_at too close: %v", link.ExpiresAt)
+	}
+}
+
+func TestPDFLink_Lookup_Unknown(t *testing.T) {
+	s := newStore(t)
+	_, err := s.LookupPDFLink(context.Background(), "no-such-token")
+	if !errors.Is(err, ErrPDFLinkNotFound) {
+		t.Errorf("err = %v, want ErrPDFLinkNotFound", err)
+	}
+	_, err = s.LookupPDFLink(context.Background(), "")
+	if !errors.Is(err, ErrPDFLinkNotFound) {
+		t.Errorf("empty token err = %v, want ErrPDFLinkNotFound", err)
+	}
+}
+
+func TestPDFLink_Expired(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	// Mint with a positive TTL, then backdate the row past now via a
+	// direct UPDATE so we don't need to sleep.
+	tok, err := s.MintPDFLink(ctx, "gh:99", "old.pdf", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE pdf_links SET expires_at = ? WHERE token = ?`,
+		time.Now().UTC().Add(-time.Minute), tok); err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.LookupPDFLink(ctx, tok)
+	if !errors.Is(err, ErrPDFLinkNotFound) {
+		t.Errorf("expired link err = %v, want ErrPDFLinkNotFound", err)
+	}
+	// Expired row should be pruned on access.
+	var n int
+	_ = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM pdf_links WHERE token = ?`, tok).Scan(&n)
+	if n != 0 {
+		t.Errorf("expired row not pruned (count=%d)", n)
+	}
+}
+
+func TestPDFLink_BadInputs(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	if _, err := s.MintPDFLink(ctx, "", "doc.pdf", time.Hour); err == nil {
+		t.Errorf("empty userID should fail")
+	}
+	if _, err := s.MintPDFLink(ctx, "u", "", time.Hour); err == nil {
+		t.Errorf("empty filePath should fail")
+	}
+	if _, err := s.MintPDFLink(ctx, "u", "doc.pdf", 0); err == nil {
+		t.Errorf("zero ttl should fail")
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -14,9 +14,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// Result label values for the compile and put_file counters. Using
-// constants keeps the set closed so a typo in a handler turns into
-// a build failure rather than a quietly mis-attributed counter.
+// Result label values for the compile, put_file, and pdf-download
+// counters. Using constants keeps the set closed so a typo in a
+// handler turns into a build failure rather than a quietly
+// mis-attributed counter.
 const (
 	ResultOK            = "ok"
 	ResultFail          = "fail"
@@ -24,6 +25,7 @@ const (
 	ResultTimeout       = "timeout"
 	ResultTooLarge      = "too_large"
 	ResultDecodeError   = "decode_error"
+	ResultNotFound      = "not_found"
 )
 
 var (
@@ -72,4 +74,12 @@ var (
 		Name: "typst_d2_mcp_auth_rejected_total",
 		Help: "HTTP requests rejected by the Bearer-auth middleware.",
 	})
+
+	// PDFDownloadTotal counts GET /d/{token} attempts by result. The
+	// "not_found" label includes both unknown and expired tokens —
+	// they are indistinguishable on the wire by design.
+	PDFDownloadTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "typst_d2_mcp_pdf_download_total",
+		Help: "Capability-URL PDF download attempts by terminal result.",
+	}, []string{"result"})
 )


### PR DESCRIPTION
**Sub-issue #5 on umbrella [#2](https://github.com/dlouwers/typst-d2-mcp/issues/2). Supersedes the closed #17.**

Lets the compile tool ship a normal `https://` URL in the result text. MCP clients that don't auto-follow `resource_link` content blocks (Claude.ai web today) render the URL as a clickable link the user opens in their browser. **No PDF bytes traverse the LLM context** — loyal to the project's original "paths/URIs, not bytes" design.

## What changed

- **`internal/authdb`** — new `pdf_links(token PK, user_id, file_path, expires_at, created_at)` table. `MintPDFLink` generates 32 bytes of URL-safe random; the random ID itself IS the capability, no HMAC key to manage. `LookupPDFLink` prunes expired rows on access. Errors collapse "unknown" and "expired" into one `ErrPDFLinkNotFound` so probing attackers can't tell the difference.
- **Compile handler** — on success, mints a token for `(identity.UserID, workspace-relative PDF path)` with TTL `TYPST_D2_MCP_PDF_LINK_TTL` (default `1h`) and appends to the prose result:
  ```
  Download: <PublicURL>/d/<token>
  (expires in 1h; share or open in a browser)
  ```
- **New `/d/{token}` HTTP handler**, mounted *outside* the Bearer middleware — the token is the credential. Streams the PDF with `Content-Type: application/pdf` and `Content-Disposition: inline; filename="…"`. Uses the same `workspace.Factory` to re-derive the per-tenant resolver from the stored `user_id`, so the same path-confinement rules apply on the way out.
- **`resource_link` content block stays alongside** in the tool result, so spec-conformant clients (Claude Code) still work in-band via `resources/read`.
- **New metric** `typst_d2_mcp_pdf_download_total{result}` with `ok` / `not_found` / `fail` labels.

## Skipped paths

- AUTH=none / no SQLite store → no link minted (those operators have direct filesystem access).
- `TYPST_D2_MCP_PUBLIC_URL` unset → no link minted, warning logged.

## Tests

`authdb` covers mint/lookup happy, unknown token, expired token (prune-on-access verified), and bad-input rejection.

`go vet`, `go test`, `golangci-lint` — all clean.

## What this deliberately is NOT

The closed [#17](https://github.com/dlouwers/typst-d2-mcp/pull/17) embedded the PDF inline as base64 in the tool result. That trades token cost linearly with PDF size — a 100 KB doc burns ~30k tokens. The whole point of this project, going back to umbrella [#2](https://github.com/dlouwers/typst-d2-mcp/issues/2)'s opening goal, is to **not** do that.

## After merge

Flux rolls the test pod within ~5 min. The next Claude.ai compile should now show:

> *Successfully compiled to wars_report.pdf*
> *Download: https://test.typst-d2-mcp.stormlantern.nl/d/abc123…*
> *(expires in 1h; share or open in a browser)*

User clicks the link → browser shows the PDF. Zero base64 in the model's context.

Refers #2