### PR TITLE
fix(compile): cap embedded SVG width + surface typst warnings on success

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -652,8 +653,18 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		// Output PDF sits next to the input .typ inside the workspace.
 		resolvedOut := strings.TrimSuffix(resolvedIn, ".typ") + ".pdf"
 
+		// Capture stdout + stderr separately. Typst exits 0 with
+		// warnings on stderr for things like "cannot place at top of
+		// page" or oversized images that overflow the column —
+		// silent on success would mean a half-rendered PDF gets
+		// reported as a clean compile. We surface warnings to the
+		// caller so the LLM/operator can act on them.
+		var stdoutBuf, stderrBuf bytes.Buffer
 		cmd := exec.CommandContext(ctx, "typst", "compile", tmpFile.Name(), resolvedOut)
-		output, err := cmd.CombinedOutput()
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+		err = cmd.Run()
+		stderrStr := strings.TrimSpace(stderrBuf.String())
 		if err != nil {
 			if ctx.Err() == context.DeadlineExceeded {
 				metrics.CompileTotal.WithLabelValues(metrics.ResultTimeout).Inc()
@@ -663,7 +674,8 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 				)), nil
 			}
 			metrics.CompileTotal.WithLabelValues(metrics.ResultFail).Inc()
-			errMsg := fmt.Sprintf("Typst compilation failed: %s\nOutput: %s", err.Error(), string(output))
+			combined := strings.TrimSpace(stdoutBuf.String() + "\n" + stderrStr)
+			errMsg := fmt.Sprintf("Typst compilation failed: %s\nOutput: %s", err.Error(), combined)
 			return mcp.NewToolResultError(errMsg), nil
 		}
 
@@ -681,6 +693,14 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		successMsg += "   - Split large diagrams into multiple focused diagrams\n"
 		successMsg += "   - Reduce number of nodes or simplify structure\n"
 		successMsg += "\nIf you cannot view the PDF yourself, inform the user to check the layout."
+
+		// Typst exits 0 with warnings on stderr. Surface them or
+		// they get silently dropped — and a "successful" compile
+		// with overflow warnings can produce a truncated PDF.
+		if stderrStr != "" {
+			log.Warn("typst compile produced warnings", "stderr", stderrStr)
+			successMsg += "\n\nTypst warnings (compile succeeded but check the PDF):\n" + stderrStr
+		}
 
 		duration := time.Since(start)
 		metrics.CompileTotal.WithLabelValues(metrics.ResultOK).Inc()

--- a/internal/preprocessor/preprocessor.go
+++ b/internal/preprocessor/preprocessor.go
@@ -145,15 +145,31 @@ func parseOptions(optionsStr string) d2.Options {
 	return options
 }
 
-// svgToTypstImage converts SVG content to a Typst image() call using base64 encoding.
+// svgToTypstImage converts SVG content to a Typst image() call using base64
+// encoding. The image is rendered at width: 100% by default so a wide D2
+// diagram scales to fit the page instead of overflowing horizontally —
+// without this cap, Typst emits placement warnings, drops subsequent
+// content, and produces a silently-truncated PDF (exit code 0 + warning
+// on stderr).
+//
+// An explicit "width" key in options overrides the default; "none" or
+// the literal "intrinsic" disables the constraint entirely so the SVG
+// renders at its natural size (rarely what you want, but supported for
+// callers who know).
 func svgToTypstImage(svgContent string, options d2.Options) string {
-	// Encode SVG as base64
 	b64 := base64.StdEncoding.EncodeToString([]byte(svgContent))
 
-	// Create Typst image call
-	typstCode := fmt.Sprintf(`#image(decode64("%s"), format: "svg")`, b64)
+	width, ok := options["width"]
+	if !ok {
+		width = "100%"
+	}
+	var typstCode string
+	if width == "none" || width == "intrinsic" {
+		typstCode = fmt.Sprintf(`#image(decode64("%s"), format: "svg")`, b64)
+	} else {
+		typstCode = fmt.Sprintf(`#image(decode64("%s"), format: "svg", width: %s)`, b64, width)
+	}
 
-	// Add padding if specified
 	if pad, ok := options["pad"]; ok && pad != "none" {
 		typstCode = fmt.Sprintf(`#pad(%s, %s)`, pad, typstCode)
 	}

--- a/internal/preprocessor/preprocessor_test.go
+++ b/internal/preprocessor/preprocessor_test.go
@@ -117,22 +117,37 @@ func TestSvgToTypstImage(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "simple svg",
+			// Default: cap at 100% width so wide D2 diagrams scale to
+			// fit the page instead of overflowing and silently
+			// truncating downstream Typst content.
+			name:    "default width is 100%",
 			svg:     "<svg>test</svg>",
 			options: d2.Options{},
+			want:    `#image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg", width: 100%)`,
+		},
+		{
+			name:    "explicit width override",
+			svg:     "<svg>test</svg>",
+			options: d2.Options{"width": "8cm"},
+			want:    `#image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg", width: 8cm)`,
+		},
+		{
+			name:    "width: none disables the cap (intrinsic size)",
+			svg:     "<svg>test</svg>",
+			options: d2.Options{"width": "none"},
 			want:    `#image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg")`,
 		},
 		{
 			name:    "svg with padding",
 			svg:     "<svg>test</svg>",
 			options: d2.Options{"pad": "10pt"},
-			want:    `#pad(10pt, #image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg"))`,
+			want:    `#pad(10pt, #image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg", width: 100%))`,
 		},
 		{
 			name:    "svg with none padding",
 			svg:     "<svg>test</svg>",
 			options: d2.Options{"pad": "none"},
-			want:    `#image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg")`,
+			want:    `#image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg", width: 100%)`,
 		},
 	}
 


### PR DESCRIPTION
Real bug surfaced by Claude.ai's first long-document compile: report came back *"Successfully compiled"* but the PDF was missing ~90% of the content. Page 1 cut off mid-Executive-Summary, before the first D2 block was even reached.

## What was actually happening

Two adjacent bugs in the compile path:

### 1. Embedded SVG had no width constraint

`preprocessor.svgToTypstImage` emitted:

```typst
#image(decode64("..."), format: "svg")
```

That renders the SVG at its **intrinsic width**. Wide D2 diagrams (nested containers, horizontal flows) overflow the page column. Typst then emits a placement warning on stderr, drops the offending image and *everything that should have followed it*, and exits 0 with a one-page truncated PDF.

**Fix:** default to `width: 100%` so the SVG scales to fit the column.

```typst
#image(decode64("..."), format: "svg", width: 100%)
```

`options["width"]` overrides; `"none"` / `"intrinsic"` restores the old behaviour for callers who know they want raw size.

### 2. Typst stderr was discarded on success

The compile handler did `cmd.CombinedOutput()` and only inspected the bytes when `err != nil`. Typst exits **0 with warnings on stderr** — exactly the case in (1). So the LLM got "Successfully compiled", the prose `NEXT STEPS` section, and a download link to a half-rendered PDF.

**Fix:** separate `stdout` and `stderr`, log warnings via slog on success, and append them to the tool result text so the LLM/operator sees them:

```
Successfully compiled to wars_report.pdf

...

Typst warnings (compile succeeded but check the PDF):
warning: cannot place at top of page
warning: ...
```

Future overflow-style bugs now surface immediately instead of silently shipping broken PDFs.

## Note on Claude.ai's analysis

Claude.ai hypothesised *"the compile step might not be checking typst's exit code"* — that part was **wrong** (the `err` return IS checked), but the *stderr capture* was the right adjacent fix. The width-constraint hypothesis was spot on.

## Tests

`TestSvgToTypstImage` updated to cover default `width: 100%`, explicit override, `width: none` disabling the cap, and the pad+image combination at the new shape.

`go vet`, `go test`, `golangci-lint` all clean.

## After merge

Flux rolls the test pod within ~5 min. Re-running the same long-document compile from Claude.ai should now produce a complete PDF (with the download link), or emit visible warnings if something else is wrong.

Refers #2