### PR TITLE
fix(preprocessor): match #d2(```code```) raw-string form and stop gobbling

### DIFF
--- a/internal/preprocessor/preprocessor.go
+++ b/internal/preprocessor/preprocessor.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/dlouwers/typst-d2-mcp/internal/d2"
@@ -85,37 +86,64 @@ func Preprocess(ctx context.Context, r workspace.Resolver, inputPath string) (st
 	return content, nil
 }
 
-// extractD2Calls finds all #d2[...] or #d2(options)[...] blocks in the content.
+// extractD2Calls finds all D2 blocks in the content. Two forms are
+// recognised, with LLM-generated documents in the wild using both:
+//
+//   1. #d2[code]                  — bracket-delimited code, no options
+//      #d2(opts)[code]            — bracket-delimited code, with options
+//
+//   2. #d2(```code```)            — Typst raw-string syntax inside the
+//      #d2(```d2\ncode\n```)        function call. The optional language
+//                                   tag (e.g. "d2") is stripped.
+//
+// Form 1 is what the tool description documents. Form 2 is what LLMs
+// commonly produce when they default to Typst's raw-block syntax for
+// embedded code. Previously only form 1 was matched, and a form-2
+// block in the document silently caused the bracket-form regex to
+// gobble everything between the first `#d2(` and the document's last
+// `]`, deleting ~90% of the source before typst saw it.
+//
+// The bracket-form regex's option group is constrained to characters
+// other than `)` and `` ` `` so it can't span across form-2 blocks or
+// nested parentheses in raw-string code.
 func extractD2Calls(content string) []D2Block {
-	// Pattern: #d2(key: value, ...)[code] or #d2[code]
-	// (?s) makes . match newlines
-	pattern := regexp.MustCompile(`(?s)#d2(?:\((.*?)\))?\[(.*?)\]`)
-	matches := pattern.FindAllStringSubmatchIndex(content, -1)
+	// Form 1: bracket-delimited code.
+	bracketRe := regexp.MustCompile("(?s)#d2(?:\\(([^)`]*)\\))?\\[(.*?)\\]")
+	// Form 2: raw-string code inside parens. Optional language tag,
+	// optional leading/trailing newline around the code.
+	rawRe := regexp.MustCompile("(?s)#d2\\(`{3}(?:\\w+)?\\n?(.*?)\\n?`{3}\\)")
 
-	blocks := make([]D2Block, 0, len(matches))
+	blocks := make([]D2Block, 0)
 
-	for _, match := range matches {
-		// match[0], match[1] = full match start/end
-		// match[2], match[3] = options group start/end
-		// match[4], match[5] = code group start/end
-
+	for _, m := range bracketRe.FindAllStringSubmatchIndex(content, -1) {
+		// m[0],m[1] = full; m[2],m[3] = options; m[4],m[5] = code.
 		var optionsStr string
-		if match[2] != -1 && match[3] != -1 {
-			optionsStr = content[match[2]:match[3]]
+		if m[2] != -1 && m[3] != -1 {
+			optionsStr = content[m[2]:m[3]]
 		}
-
-		code := content[match[4]:match[5]]
-
-		// Parse options
-		options := parseOptions(optionsStr)
-
 		blocks = append(blocks, D2Block{
-			Start:   match[0],
-			End:     match[1],
-			Options: options,
-			Code:    code,
+			Start:   m[0],
+			End:     m[1],
+			Options: parseOptions(optionsStr),
+			Code:    content[m[4]:m[5]],
 		})
 	}
+	for _, m := range rawRe.FindAllStringSubmatchIndex(content, -1) {
+		// m[0],m[1] = full; m[2],m[3] = code (no options in this form).
+		blocks = append(blocks, D2Block{
+			Start:   m[0],
+			End:     m[1],
+			Options: d2.Options{},
+			Code:    content[m[2]:m[3]],
+		})
+	}
+
+	// Sort by start offset so the reverse-order replacement in
+	// PreprocessFile preserves positions correctly when both forms
+	// appear in the same document.
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].Start < blocks[j].Start
+	})
 
 	return blocks
 }

--- a/internal/preprocessor/preprocessor_test.go
+++ b/internal/preprocessor/preprocessor_test.go
@@ -235,6 +235,77 @@ Suffix text`
 	}
 }
 
+// Form 2: Typst raw-string-inside-parens. Common when LLMs default to
+// Typst's `#raw(...)` idiom for embedded code. Previously broke the
+// preprocessor entirely.
+func TestExtractD2Calls_RawStringForm(t *testing.T) {
+	content := "before\n#d2(```\ndirection: down\na -> b\n```)\nafter"
+	blocks := extractD2Calls(content)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	wantCode := "direction: down\na -> b"
+	if blocks[0].Code != wantCode {
+		t.Errorf("code = %q, want %q", blocks[0].Code, wantCode)
+	}
+}
+
+// Form 2 with a language tag (```d2 ...```) — the tag is dropped.
+func TestExtractD2Calls_RawStringWithLang(t *testing.T) {
+	content := "#d2(```d2\nx -> y\n```)"
+	blocks := extractD2Calls(content)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].Code != "x -> y" {
+		t.Errorf("code = %q, want %q", blocks[0].Code, "x -> y")
+	}
+}
+
+// Regression for the wars_report.typ bug. Two raw-string d2 blocks
+// plus a `[...]` bracket-content block from typst markup elsewhere in
+// the document. Previously the bracket-form regex matched one
+// monstrous span from the first `#d2(` to the document's last `]`,
+// deleting ~90% of the source. Now each d2 block is matched
+// independently and the markup brackets are left alone.
+func TestExtractD2Calls_DoesNotGobbleAcrossBlocks(t *testing.T) {
+	content := `Some markup with #text(weight: "bold")[a label] here.
+
+#d2(` + "```" + `
+direction: down
+ukraine: "Russia–Ukraine War (year 5)"
+` + "```" + `)
+
+Middle paragraph with [some bracket content] inline.
+
+#d2(` + "```" + `
+direction: down
+iran: "Iran"
+israel: "Israel"
+` + "```" + `)
+
+Trailing markup #text[footnote here].`
+
+	blocks := extractD2Calls(content)
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 d2 blocks, got %d", len(blocks))
+	}
+	// They must be ordered by Start position.
+	if blocks[0].Start >= blocks[1].Start {
+		t.Errorf("blocks not sorted by position: %d vs %d", blocks[0].Start, blocks[1].Start)
+	}
+	// And neither match can span across the other.
+	if blocks[0].End >= blocks[1].Start {
+		t.Errorf("block 0 (end=%d) overlaps block 1 (start=%d)", blocks[0].End, blocks[1].Start)
+	}
+	if !strings.Contains(blocks[0].Code, "Russia") || strings.Contains(blocks[0].Code, "Iran") {
+		t.Errorf("block 0 code wrong: %q", blocks[0].Code)
+	}
+	if !strings.Contains(blocks[1].Code, "Iran") || strings.Contains(blocks[1].Code, "Russia") {
+		t.Errorf("block 1 code wrong: %q", blocks[1].Code)
+	}
+}
+
 func TestExtractD2CallsWithNestedBrackets(t *testing.T) {
 	// D2 code can contain nested braces
 	content := `#d2[


### PR DESCRIPTION
Real-world bug surfaced when Claude.ai compiled its first long document against the test env. The LLM generated:

```typst
#d2(```
direction: down
world: "Major Active Conflicts (2026)" {
  ...
}
```)
```

Two of those blocks in the document. Our preprocessor's single regex assumed square-bracket-delimited D2 code:

```
(?s)#d2(?:\((.*?)\))?\[(.*?)\]
```

For raw-string-form blocks, the lazy `(.*?)` in `\((.*?)\)` matched the *entire first D2 code* (containing an inner `)` from `"... (2026)"`) as the "options" group, then `\[(.*?)\]` matched a `[...]` block much later in the document — usually the last `]` it could find.

**Result:** ONE regex match spanning 9483 bytes — first `#d2(` through the document's tail. The replacement deleted ~90% of the source, including the second D2 block and every regional section. Typst then compiled the truncated remnant into a clean one-page PDF, no warnings, exit 0. We "Successfully compiled" a broken document.

## Fix

Two regexes, one per form:

| Form | Pattern | What it matches |
|---|---|---|
| 1 | `(?s)#d2(?:\(([^)\`]*)\))?\[(.*?)\]` | `#d2[code]` and `#d2(opts)[code]`. Option chars tightened to exclude `)` and `` ` `` so it can't span across raw-string code or nested parens. |
| 2 | <code>(?s)#d2\\(\`{3}(?:\\w+)?\\n?(.*?)\\n?\`{3}\\)</code> | `` #d2(```code```) `` and `` #d2(```d2\ncode\n```) ``. Optional language tag is stripped. |

Results merged and sorted by `Start` so the existing reverse-order replacement in `PreprocessFile` keeps positions stable when both forms appear in the same document.

## Tests

- `TestExtractD2Calls_RawStringForm` — basic raw-string form
- `TestExtractD2Calls_RawStringWithLang` — `` ```d2 `` language tag stripped
- `TestExtractD2Calls_DoesNotGobbleAcrossBlocks` — regression: two raw-string blocks with `#text[...]` markup brackets between them. Pre-fix this collapsed into one 9483-byte gobble; post-fix it's two ~1 KB blocks matched independently.

Verified against the actual `wars_report.typ` pulled from the live test pod: matches now report 2 blocks of 988 and 1081 bytes respectively (was 1 block of 9483 bytes before).

`go vet`, `go test`, `golangci-lint` all clean.

## After merge

Flux rolls test within ~5 min. Re-run the wars-report compile from Claude.ai — both diagrams should render and the regional sections should be present in the PDF.

Refers #2