### PR TITLE
refactor(preprocessor): replace regex extraction with Typst-aware scanner

### DIFF
--- a/internal/preprocessor/preprocessor.go
+++ b/internal/preprocessor/preprocessor.go
@@ -85,39 +85,12 @@ func Preprocess(ctx context.Context, r workspace.Resolver, inputPath string) (st
 	return content, nil
 }
 
-// extractD2Calls finds all #d2[...] or #d2(options)[...] blocks in the content.
+// extractD2Calls finds every #d2(...) and #d2[...] call site in the
+// content. Delegates to the Typst-aware scanner in scan.go; see the
+// commentary there for what we recognise and what we deliberately
+// don't.
 func extractD2Calls(content string) []D2Block {
-	// Pattern: #d2(key: value, ...)[code] or #d2[code]
-	// (?s) makes . match newlines
-	pattern := regexp.MustCompile(`(?s)#d2(?:\((.*?)\))?\[(.*?)\]`)
-	matches := pattern.FindAllStringSubmatchIndex(content, -1)
-
-	blocks := make([]D2Block, 0, len(matches))
-
-	for _, match := range matches {
-		// match[0], match[1] = full match start/end
-		// match[2], match[3] = options group start/end
-		// match[4], match[5] = code group start/end
-
-		var optionsStr string
-		if match[2] != -1 && match[3] != -1 {
-			optionsStr = content[match[2]:match[3]]
-		}
-
-		code := content[match[4]:match[5]]
-
-		// Parse options
-		options := parseOptions(optionsStr)
-
-		blocks = append(blocks, D2Block{
-			Start:   match[0],
-			End:     match[1],
-			Options: options,
-			Code:    code,
-		})
-	}
-
-	return blocks
+	return scanD2Calls(content)
 }
 
 // parseOptions extracts key-value pairs from the options string.

--- a/internal/preprocessor/scan.go
+++ b/internal/preprocessor/scan.go
@@ -1,0 +1,330 @@
+package preprocessor
+
+// Typst-aware scanner for #d2 call sites.
+//
+// The previous regex approach kept hitting the same class of bugs: a
+// `#d2` substring could appear inside a comment, a string, or another
+// raw block — places where Typst itself would never evaluate it — and
+// any regex pattern that ignores those contexts will eventually be
+// surprised by a new edge case. We instead walk the source one byte at
+// a time tracking which lexical context we're in, and only consider
+// `#d2(...)` or `#d2[...]` as a real call when we encounter it in
+// normal markup.
+//
+// Lexical contexts we recognise (and ignore #d2 inside):
+//
+//   - // line comments              (until newline)
+//   - /* block comments */          (no nesting; matches Typst)
+//   - "..." double-quoted strings   (with \ escapes)
+//   - `...` short raw               (terminated by next ` )
+//   - ```...``` raw block           (triple backticks)
+//
+// Inside the argument of a recognised #d2 call we apply the same
+// context-tracking to count balanced ( ) or [ ] — so D2 code that
+// happens to contain a closing bracket inside a quoted label, or a
+// nested function call, is captured correctly instead of cutting the
+// match short or running on past it.
+//
+// What we deliberately don't do:
+//   - Parse Typst expressions, scopes, or `code-mode` semantics.
+//   - Distinguish markup mode from code mode (no need; markup-mode
+//     `#d2` is the only call shape LLMs emit in practice).
+//   - Support 4+ backtick raw fences (Typst allows them; LLMs rarely
+//     produce them, and adding the open-count tracking is easy to add
+//     later if it ever matters).
+
+import (
+	"strings"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/d2"
+)
+
+type scanner struct {
+	src string
+	i   int
+}
+
+// scanD2Calls returns every #d2 call site in src as a D2Block, in
+// source-order. Each block's Start / End span the full call (from `#`
+// through the final `)` or `]`); Code is the extracted D2 source.
+func scanD2Calls(src string) []D2Block {
+	s := &scanner{src: src}
+	var out []D2Block
+	for s.i < len(s.src) {
+		switch {
+		case s.peek("//"):
+			s.skipLineComment()
+		case s.peek("/*"):
+			s.skipBlockComment()
+		case s.cur() == '"':
+			s.skipString()
+		case s.peek("```"):
+			s.skipRawBlock()
+		case s.cur() == '`':
+			s.skipShortRaw()
+		case s.peek("#d2"):
+			if block, ok := s.tryD2(); ok {
+				out = append(out, block)
+			}
+			// tryD2 always advances at least past the `#d2` substring
+			// (whether it matched a real call or not), so we make
+			// monotonic progress.
+		default:
+			s.i++
+		}
+	}
+	return out
+}
+
+func (s *scanner) cur() byte {
+	if s.i >= len(s.src) {
+		return 0
+	}
+	return s.src[s.i]
+}
+
+func (s *scanner) peek(prefix string) bool {
+	return strings.HasPrefix(s.src[s.i:], prefix)
+}
+
+func (s *scanner) skipLineComment() {
+	s.i += 2 // past //
+	for s.i < len(s.src) && s.src[s.i] != '\n' {
+		s.i++
+	}
+}
+
+func (s *scanner) skipBlockComment() {
+	s.i += 2 // past /*
+	for s.i < len(s.src) {
+		if s.peek("*/") {
+			s.i += 2
+			return
+		}
+		s.i++
+	}
+}
+
+func (s *scanner) skipString() {
+	s.i++ // past opening "
+	for s.i < len(s.src) {
+		switch s.src[s.i] {
+		case '\\':
+			// Skip the escape and its target. Stops one short of EOF
+			// being valid, which is fine for malformed input.
+			s.i += 2
+		case '"':
+			s.i++
+			return
+		default:
+			s.i++
+		}
+	}
+}
+
+func (s *scanner) skipShortRaw() {
+	s.i++ // past opening `
+	for s.i < len(s.src) {
+		if s.src[s.i] == '`' {
+			s.i++
+			return
+		}
+		s.i++
+	}
+}
+
+func (s *scanner) skipRawBlock() {
+	s.i += 3 // past opening ```
+	for s.i < len(s.src) {
+		if s.peek("```") {
+			s.i += 3
+			return
+		}
+		s.i++
+	}
+}
+
+// tryD2 attempts to match a #d2 call starting at the current `#`
+// position. On success returns the parsed block and leaves s.i past
+// the end. On failure returns false and leaves s.i three past the `#`
+// (i.e. past the `#d2` substring) so the outer loop makes progress.
+func (s *scanner) tryD2() (D2Block, bool) {
+	start := s.i
+	s.i += 3 // past #d2
+
+	switch s.cur() {
+	case '(':
+		// Two sub-shapes inside parens:
+		//   #d2(```code```)              — raw-block-only args, no opts
+		//   #d2(opts)[code]              — opts then a content block
+		argsOpen := s.i + 1
+		if !s.skipBalancedParens() {
+			return D2Block{}, false
+		}
+		args := s.src[argsOpen : s.i-1]
+
+		if rawCode, ok := extractSingleRawBlock(args); ok {
+			return D2Block{
+				Start:   start,
+				End:     s.i,
+				Options: d2.Options{},
+				Code:    rawCode,
+			}, true
+		}
+
+		// Treat the args as options; require a content block to follow.
+		if s.cur() != '[' {
+			return D2Block{}, false
+		}
+		codeOpen := s.i + 1
+		if !s.skipBalancedBrackets() {
+			return D2Block{}, false
+		}
+		return D2Block{
+			Start:   start,
+			End:     s.i,
+			Options: parseOptions(args),
+			Code:    s.src[codeOpen : s.i-1],
+		}, true
+
+	case '[':
+		// #d2[code] — bracket-only form.
+		codeOpen := s.i + 1
+		if !s.skipBalancedBrackets() {
+			return D2Block{}, false
+		}
+		return D2Block{
+			Start:   start,
+			End:     s.i,
+			Options: d2.Options{},
+			Code:    s.src[codeOpen : s.i-1],
+		}, true
+
+	default:
+		// Not a #d2 call (could be #d2foo, or #d2 alone in prose).
+		return D2Block{}, false
+	}
+}
+
+// skipBalancedParens consumes a `(...)` starting at the current `(`,
+// counting nested parens and treating strings/raws/comments inside as
+// opaque. Returns true on a clean close, false if EOF is hit first.
+func (s *scanner) skipBalancedParens() bool {
+	if s.cur() != '(' {
+		return false
+	}
+	s.i++
+	depth := 1
+	for s.i < len(s.src) {
+		switch {
+		case s.peek("//"):
+			s.skipLineComment()
+		case s.peek("/*"):
+			s.skipBlockComment()
+		case s.cur() == '"':
+			s.skipString()
+		case s.peek("```"):
+			s.skipRawBlock()
+		case s.cur() == '`':
+			s.skipShortRaw()
+		case s.cur() == '(':
+			depth++
+			s.i++
+		case s.cur() == ')':
+			depth--
+			s.i++
+			if depth == 0 {
+				return true
+			}
+		default:
+			s.i++
+		}
+	}
+	return false
+}
+
+// skipBalancedBrackets is skipBalancedParens for `[...]`. Same shape,
+// different delimiters — kept as separate methods rather than param-
+// eterised so each one's hot path is a tight set of byte comparisons.
+func (s *scanner) skipBalancedBrackets() bool {
+	if s.cur() != '[' {
+		return false
+	}
+	s.i++
+	depth := 1
+	for s.i < len(s.src) {
+		switch {
+		case s.peek("//"):
+			s.skipLineComment()
+		case s.peek("/*"):
+			s.skipBlockComment()
+		case s.cur() == '"':
+			s.skipString()
+		case s.peek("```"):
+			s.skipRawBlock()
+		case s.cur() == '`':
+			s.skipShortRaw()
+		case s.cur() == '[':
+			depth++
+			s.i++
+		case s.cur() == ']':
+			depth--
+			s.i++
+			if depth == 0 {
+				return true
+			}
+		default:
+			s.i++
+		}
+	}
+	return false
+}
+
+// extractSingleRawBlock decides whether args (the text between the
+// parens of a #d2(...) call) is, ignoring surrounding whitespace, a
+// single ```...``` raw block. If so it returns the block's body with
+// the optional language tag (e.g. ```d2) and one leading/trailing
+// newline stripped. Otherwise it returns false, signalling "treat
+// args as key:value options instead".
+func extractSingleRawBlock(args string) (string, bool) {
+	trimmed := strings.TrimSpace(args)
+	if !strings.HasPrefix(trimmed, "```") || !strings.HasSuffix(trimmed, "```") || len(trimmed) < 6 {
+		return "", false
+	}
+	inner := trimmed[3 : len(trimmed)-3]
+	// Reject if the body itself contains a triple-backtick — that
+	// means args isn't ONE raw block; it's something more complex
+	// (e.g. two adjacent raws), which we don't classify here.
+	if strings.Contains(inner, "```") {
+		return "", false
+	}
+	// Strip a leading "first-line" segment in two cases that look
+	// the same to the user — a bare newline immediately after the
+	// opening ``` (no language tag), or a language tag followed by
+	// a newline. Anything else on that first line is real code.
+	if nl := strings.IndexByte(inner, '\n'); nl >= 0 {
+		first := strings.TrimSpace(inner[:nl])
+		if first == "" || isLanguageTag(first) {
+			inner = inner[nl+1:]
+		}
+	}
+	inner = strings.TrimSuffix(inner, "\n")
+	return inner, true
+}
+
+func isLanguageTag(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/preprocessor/scan_test.go
+++ b/internal/preprocessor/scan_test.go
@@ -1,0 +1,222 @@
+package preprocessor
+
+import (
+	"strings"
+	"testing"
+)
+
+// Each case is "an arbitrary chunk of Typst that contains zero or more
+// #d2 call sites we expect to extract". The wantCount/wantCodes pair
+// asserts both how many matched AND what each match's code body was.
+// The body assertion is what catches "matched the wrong span" bugs,
+// which is what the previous regex approach kept doing.
+func TestScanD2Calls(t *testing.T) {
+	cases := []struct {
+		name      string
+		src       string
+		wantCount int
+		wantCodes []string
+	}{
+		{
+			name:      "empty",
+			src:       "",
+			wantCount: 0,
+		},
+		{
+			name:      "no d2 calls",
+			src:       "= Heading\n\nSome prose with no diagrams.",
+			wantCount: 0,
+		},
+
+		// --- bracket form ---
+
+		{
+			name:      "single bracket-form",
+			src:       "#d2[a -> b]",
+			wantCount: 1,
+			wantCodes: []string{"a -> b"},
+		},
+		{
+			name:      "bracket-form with opts",
+			src:       `#d2(layout: "elk", theme: "0")[a -> b]`,
+			wantCount: 1,
+			wantCodes: []string{"a -> b"},
+		},
+		{
+			name:      "bracket-form with nested brackets in code",
+			src:       "#d2[user: User {\n  shape: person\n}]",
+			wantCount: 1,
+			wantCodes: []string{"user: User {\n  shape: person\n}"},
+		},
+		{
+			name:      "two bracket-form blocks",
+			src:       "#d2[a -> b]\n\nText.\n\n#d2[c -> d]",
+			wantCount: 2,
+			wantCodes: []string{"a -> b", "c -> d"},
+		},
+
+		// --- raw-string form ---
+
+		{
+			name:      "raw-string form",
+			src:       "#d2(```\ndirection: down\na -> b\n```)",
+			wantCount: 1,
+			wantCodes: []string{"direction: down\na -> b"},
+		},
+		{
+			name:      "raw-string with language tag",
+			src:       "#d2(```d2\nx -> y\n```)",
+			wantCount: 1,
+			wantCodes: []string{"x -> y"},
+		},
+		{
+			name:      "raw-string without trailing newline",
+			src:       "#d2(```a -> b```)",
+			wantCount: 1,
+			wantCodes: []string{"a -> b"},
+		},
+
+		// --- mixed forms ---
+
+		{
+			name:      "bracket then raw-string",
+			src:       "#d2[a -> b]\n\nbetween\n\n#d2(```\nc -> d\n```)",
+			wantCount: 2,
+			wantCodes: []string{"a -> b", "c -> d"},
+		},
+
+		// --- the gobble regression ---
+		// The previous regex matched ONE span from the first #d2(```
+		// to the document's last ] — eating the second block and the
+		// markup between. The scanner must keep them independent.
+		{
+			name: "two raw-string blocks with markup brackets between",
+			src: `Lead-in.
+
+#d2(` + "```" + `
+direction: down
+ukraine: "Russia–Ukraine War (year 5)"
+` + "```" + `)
+
+Middle markup with #text[a label] and [more bracket content].
+
+#d2(` + "```" + `
+direction: down
+iran: "Iran"
+` + "```" + `)
+
+Tail #text[footnote].`,
+			wantCount: 2,
+			wantCodes: []string{
+				"direction: down\nukraine: \"Russia–Ukraine War (year 5)\"",
+				"direction: down\niran: \"Iran\"",
+			},
+		},
+
+		// --- contexts where #d2 must be IGNORED ---
+
+		{
+			name:      "ignore inside line comment",
+			src:       "// #d2[ignored]\n#d2[real]",
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+		{
+			name:      "ignore inside block comment",
+			src:       "/* keep #d2[ignored] here */ #d2[real]",
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+		{
+			name:      "ignore inside string literal",
+			src:       `let x = "before #d2[ignored] after"; #d2[real]`,
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+		{
+			name:      "ignore inside short raw",
+			src:       "see `#d2[ignored]` for example; #d2[real]",
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+		{
+			name:      "ignore inside raw block",
+			src:       "```\n#d2[ignored]\n```\n#d2[real]",
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+		{
+			name:      "string escape doesn't end the string",
+			src:       `let x = "with \"#d2[ignored]\" inside"; #d2[real]`,
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+
+		// --- non-#d2 things starting with #d2 ---
+
+		{
+			name:      "#d2foo is not a #d2 call",
+			src:       "#d2foo[ignored]\n#d2[real]",
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+		{
+			name:      "#d2 with no following ( or [",
+			src:       "the value is #d2 itself; #d2[real]",
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks := scanD2Calls(tc.src)
+			if len(blocks) != tc.wantCount {
+				t.Fatalf("count=%d, want=%d (got %+v)", len(blocks), tc.wantCount, blocks)
+			}
+			for i, b := range blocks {
+				if i >= len(tc.wantCodes) {
+					break
+				}
+				if b.Code != tc.wantCodes[i] {
+					t.Errorf("blocks[%d].Code = %q, want %q", i, b.Code, tc.wantCodes[i])
+				}
+				// And the captured span MUST round-trip — i.e. the
+				// substring at [Start:End] starts with #d2 and ends
+				// with ) or ].
+				span := tc.src[b.Start:b.End]
+				if !strings.HasPrefix(span, "#d2") {
+					t.Errorf("blocks[%d] span doesn't start with #d2: %q", i, span)
+				}
+				last := span[len(span)-1]
+				if last != ')' && last != ']' {
+					t.Errorf("blocks[%d] span doesn't end with ) or ]: %q", i, span)
+				}
+			}
+		})
+	}
+}
+
+// Replacing #d2 calls in reverse order must leave the document with
+// the right structure: untouched prose between blocks, no overlap,
+// and the original number of blocks. This is the property that broke
+// in production — verify it directly.
+func TestScanD2Calls_ReplacementRoundTrip(t *testing.T) {
+	src := "intro #d2[A -> B] mid1 #d2(```\nC -> D\n```) mid2 #d2(layout: \"elk\")[E -> F] tail"
+	blocks := scanD2Calls(src)
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(blocks))
+	}
+
+	// Replace each with a placeholder, in reverse, the way Preprocess
+	// does. The non-d2 text MUST survive verbatim.
+	out := src
+	for i := len(blocks) - 1; i >= 0; i-- {
+		b := blocks[i]
+		out = out[:b.Start] + "<X>" + out[b.End:]
+	}
+	want := "intro <X> mid1 <X> mid2 <X> tail"
+	if out != want {
+		t.Errorf("reverse replace produced %q, want %q", out, want)
+	}
+}


### PR DESCRIPTION
**Supersedes the closed [#20](https://github.com/dlouwers/typst-d2-mcp/pull/20).** You asked whether the regex strategy was robust; honest answer was no, the right thing was a small scanner. This is that.

## The class of bug we keep hitting

The previous regex `(?s)#d2(?:\((.*?)\))?\[(.*?)\]` had two failure modes:

1. A literal `#d2` substring inside a comment, string, or raw block could be falsely matched as a call.
2. When the LLM emitted `#d2(\`\`\`…\`\`\`)` (raw-string form), the lazy `(.*?)` could gobble across a real match boundary and delete arbitrary spans of the document.

The wars_report incident was (2): one match spanned **9483 bytes** from the first `#d2(` to the document's last `]`, replacing 90% of the source with a single `#image(...)` before typst ever ran. No warning, exit 0, "Successfully compiled" — a silently truncated PDF.

Adding more regexes shrinks the surface but doesn't close it. A future weird construct will trip the next iteration.

## The scanner

~200 LoC in `internal/preprocessor/scan.go`. Walks the source byte-by-byte tracking which lexical context it's in:

| Context | Recognises `#d2`? |
|---|---|
| normal markup | ✅ yes |
| `// line comments` | ❌ ignore |
| `/* block comments */` | ❌ ignore |
| `"strings"` (with `\` escapes) | ❌ ignore |
| `` `short raw` `` | ❌ ignore |
| ` ```raw blocks``` ` | ❌ ignore |

Argument extraction uses balanced paren/bracket counting that **itself** respects strings/raws/comments inside the argument, so D2 code containing nested brackets or parenthesised label text (e.g. `"…(year 5)"`) is captured cleanly without truncation or runaway match.

Three `#d2` call shapes recognised:

```typst
#d2[code]
#d2(opts)[code]
#d2(```code```)            // optional language tag on the first line
```

## Deliberate scope limits

- No Typst code-mode `d2(...)` without the leading `#`. LLM documents are markup-style; YAGNI.
- Triple-backtick raw fences only. Typst spec allows 4+ but LLMs almost never emit those; easy to add when it actually matters.
- No nested block comments. Typst doesn't nest them either.
- Not a Typst parser. We don't try to understand `#raw(…)` content semantically — if an LLM writes a Typst tutorial that quotes a `#d2[...]` example inside a `#raw(…)` argument, we'd still match. Catching that needs a real evaluator, which we shouldn't have.

## Tests

`scan_test.go` covers the matrix:
- Each shape (bracket, opts+bracket, raw-string, with/without lang tag, with/without trailing newline)
- Mixed shapes in one document
- `#d2` inside every context that should be ignored — line comment, block comment, string (including with escapes), short raw, raw block
- `#d2foo` and bare `#d2` in prose — correctly **not** matched
- The wars_report regression: two raw-string blocks with `#text[…]` markup brackets between them
- Reverse-order replacement round-trip preserves all non-d2 text verbatim

Plus a one-off probe (not committed) ran the new scanner against the **actual `wars_report.typ`** pulled from the live test pod — 2 blocks of 1081 + 988 bytes, against the previous regex's 1 block of 9483.

`go vet`, `go test`, `golangci-lint`, `govulncheck` all clean.

## After merge

Flux rolls the test pod within ~5 min. Re-run the wars-report compile in Claude.ai — both diagrams should render, all regional sections should be present in the PDF, and the download link should resolve.

Refers #2