### PR TITLE
feat(auth): GitHub login allowlist; lock test env to the operator

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -46,8 +46,9 @@ const (
 	envAuth         = "TYPST_D2_MCP_AUTH"
 	envDB           = "TYPST_D2_MCP_DB"
 	envPublicURL    = "TYPST_D2_MCP_PUBLIC_URL"
-	envGitHubID     = "TYPST_D2_MCP_GITHUB_CLIENT_ID"
-	envGitHubSecret = "TYPST_D2_MCP_GITHUB_CLIENT_SECRET"
+	envGitHubID        = "TYPST_D2_MCP_GITHUB_CLIENT_ID"
+	envGitHubSecret    = "TYPST_D2_MCP_GITHUB_CLIENT_SECRET"
+	envGitHubAllowlist = "TYPST_D2_MCP_GITHUB_ALLOWLIST"
 	envQuotaPerDay  = "TYPST_D2_MCP_QUOTA_PER_DAY"
 	envLogLevel     = "TYPST_D2_MCP_LOG_LEVEL"
 	envLogFormat    = "TYPST_D2_MCP_LOG_FORMAT"
@@ -343,9 +344,10 @@ func selectAuth() (auth.Backend, *gitHubHandlers, *authdb.Store, func(), error) 
 		}
 		gh := &auth.GitHub{
 			Cfg: auth.GitHubConfig{
-				ClientID:     clientID,
-				ClientSecret: clientSecret,
-				PublicURL:    publicURL,
+				ClientID:      clientID,
+				ClientSecret:  clientSecret,
+				PublicURL:     publicURL,
+				AllowedLogins: parseAllowlist(os.Getenv(envGitHubAllowlist)),
 			},
 			Store: store,
 		}
@@ -361,6 +363,24 @@ func selectAuth() (auth.Backend, *gitHubHandlers, *authdb.Store, func(), error) 
 	default:
 		return nil, nil, nil, nil, fmt.Errorf("unknown %s=%q (expected none or github)", envAuth, mode)
 	}
+}
+
+// parseAllowlist turns a comma-separated TYPST_D2_MCP_GITHUB_ALLOWLIST
+// value into a lowercased set of permitted GitHub logins. An empty or
+// whitespace-only value yields nil — meaning "no restriction", the
+// public free-tier posture.
+func parseAllowlist(raw string) map[string]bool {
+	set := map[string]bool{}
+	for _, part := range strings.Split(raw, ",") {
+		login := strings.ToLower(strings.TrimSpace(part))
+		if login != "" {
+			set[login] = true
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
 }
 
 func isHTTPTransport() bool {

--- a/deploy/k8s/overlays/test/configmap-patch.yaml
+++ b/deploy/k8s/overlays/test/configmap-patch.yaml
@@ -1,14 +1,19 @@
-# Test overlay: point TYPST_D2_MCP_PUBLIC_URL at the test hostname so
-# the GitHub OAuth callback URL matches. The corresponding test
-# OAuth app must be registered with the same callback URL.
+# Test overlay config. The test environment is locked to the operator's
+# own GitHub account and runs unmetered — it's a staging surface, not a
+# public free tier.
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: typst-d2-mcp-config
   namespace: typst-d2-mcp
 data:
+  # Callback URL must match the test OAuth app's registration.
   TYPST_D2_MCP_PUBLIC_URL: "https://test.typst-d2-mcp.stormlantern.nl"
-  # Generous quota in test — lets you exercise the metered path
-  # repeatedly without waiting for UTC midnight.
-  TYPST_D2_MCP_QUOTA_PER_DAY: "20"
+  # Allowlist: only this GitHub login can authenticate. Any other
+  # account is turned away at OAuth callback time and on every
+  # request. Comma-separate to add more.
+  TYPST_D2_MCP_GITHUB_ALLOWLIST: "dlouwers"
+  # Quota disabled. Since the allowlist restricts the whole env to
+  # one operator, "0 = unlimited" is effectively "unlimited for me".
+  TYPST_D2_MCP_QUOTA_PER_DAY: "0"
   TYPST_D2_MCP_LOG_LEVEL: "debug"

--- a/internal/auth/github.go
+++ b/internal/auth/github.go
@@ -20,6 +20,12 @@ import (
 // endpoint omits the Authorization: Bearer header.
 var ErrMissingBearer = errors.New("missing or malformed Authorization header")
 
+// ErrNotAllowlisted is returned when a valid token belongs to a
+// GitHub account that is not on the configured AllowedLogins set.
+// Enforced on every request, so removing someone from the allowlist
+// invalidates their existing tokens immediately.
+var ErrNotAllowlisted = errors.New("github account not on the allowlist")
+
 // GitHubConfig holds the deployment-specific values needed for the
 // OAuth dance. Endpoints default to GitHub's production URLs and can
 // be overridden for testing.
@@ -42,6 +48,23 @@ type GitHubConfig struct {
 	// user endpoints. Nil means http.DefaultClient with a 10s
 	// timeout.
 	HTTPClient *http.Client
+
+	// AllowedLogins, when non-empty, restricts the server to the
+	// listed GitHub logins (case-insensitive). Any other account is
+	// turned away both at OAuth callback time and on every /mcp
+	// request. Empty means open to any GitHub account — the public
+	// free-tier posture. Used to lock the test environment to the
+	// operator only.
+	AllowedLogins map[string]bool
+}
+
+// loginAllowed reports whether the GitHub login may use this server.
+// An empty AllowedLogins set means "no restriction".
+func (c GitHubConfig) loginAllowed(login string) bool {
+	if len(c.AllowedLogins) == 0 {
+		return true
+	}
+	return c.AllowedLogins[strings.ToLower(strings.TrimSpace(login))]
 }
 
 func (c GitHubConfig) authorizeURL() string {
@@ -88,7 +111,16 @@ func (g *GitHub) IdentifyFromRequest(r *http.Request) (identity.Identity, error)
 	if token == "" {
 		return identity.Identity{}, ErrMissingBearer
 	}
-	return g.Store.IdentityForKey(r.Context(), token)
+	id, err := g.Store.IdentityForKey(r.Context(), token)
+	if err != nil {
+		return identity.Identity{}, err
+	}
+	// Allowlist is authoritative on every request — a token minted
+	// before the allowlist was tightened stops working at once.
+	if !g.Cfg.loginAllowed(id.GitHubLogin) {
+		return identity.Identity{}, ErrNotAllowlisted
+	}
+	return id, nil
 }
 
 // Name returns the backend's startup label.
@@ -128,6 +160,16 @@ func (g *GitHub) ServeCallback(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		redirectOAuthError(w, r, session.RedirectURI, session.ClientState,
 			"server_error", "github user fetch failed")
+		return
+	}
+	// Reject non-allowlisted accounts at sign-in time with a clean
+	// OAuth access_denied — they never get a token. The check is
+	// repeated on every request in IdentifyFromRequest, so this is
+	// the friendly early gate rather than the authoritative one.
+	if !g.Cfg.loginAllowed(gu.Login) {
+		slog.Warn("oauth login rejected: not allowlisted", "login", gu.Login, "github_id", gu.ID)
+		redirectOAuthError(w, r, session.RedirectURI, session.ClientState,
+			"access_denied", "this GitHub account is not authorised for this server")
 		return
 	}
 	userDBID, err := g.Store.UpsertGitHubUser(r.Context(), gu.ID, gu.Login, gu.Email)

--- a/internal/auth/github_test.go
+++ b/internal/auth/github_test.go
@@ -96,6 +96,89 @@ func TestNone_AlwaysAnonymous(t *testing.T) {
 	}
 }
 
+func TestGitHubConfig_loginAllowed(t *testing.T) {
+	open := GitHubConfig{}
+	if !open.loginAllowed("anyone") {
+		t.Error("empty allowlist should permit any login")
+	}
+
+	restricted := GitHubConfig{AllowedLogins: map[string]bool{"dlouwers": true}}
+	if !restricted.loginAllowed("dlouwers") {
+		t.Error("allowlisted login should be permitted")
+	}
+	if !restricted.loginAllowed("DLOUWERS") {
+		t.Error("allowlist match must be case-insensitive")
+	}
+	if !restricted.loginAllowed("  dlouwers ") {
+		t.Error("allowlist match must tolerate surrounding whitespace")
+	}
+	if restricted.loginAllowed("octocat") {
+		t.Error("non-allowlisted login must be rejected")
+	}
+}
+
+// A token belonging to a non-allowlisted account must be rejected on
+// every request, even though the token itself is valid in the store.
+func TestGitHub_IdentifyFromRequest_Allowlist(t *testing.T) {
+	g := newGitHubBackend(t, "")
+	g.Cfg.AllowedLogins = map[string]bool{"dlouwers": true}
+	ctx := t.Context()
+
+	// Mint a key for an allowlisted user and a non-allowlisted one.
+	okUID, _ := g.Store.UpsertGitHubUser(ctx, 1, "dlouwers", "d@example.com")
+	okKey, _ := g.Store.IssueAPIKey(ctx, okUID)
+	badUID, _ := g.Store.UpsertGitHubUser(ctx, 2, "octocat", "o@example.com")
+	badKey, _ := g.Store.IssueAPIKey(ctx, badUID)
+
+	okReq := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	okReq.Header.Set("Authorization", "Bearer "+okKey)
+	if _, err := g.IdentifyFromRequest(okReq); err != nil {
+		t.Errorf("allowlisted user rejected: %v", err)
+	}
+
+	badReq := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	badReq.Header.Set("Authorization", "Bearer "+badKey)
+	if _, err := g.IdentifyFromRequest(badReq); !errors.Is(err, ErrNotAllowlisted) {
+		t.Errorf("non-allowlisted user err = %v, want ErrNotAllowlisted", err)
+	}
+}
+
+// A non-allowlisted account that completes GitHub sign-in must be
+// bounced back to the MCP client with OAuth error=access_denied,
+// never reaching the token-mint step.
+func TestGitHub_Callback_AllowlistRejection(t *testing.T) {
+	ts := fakeGitHub(t, "code-xyz", "gh-token", "octocat", 42, "o@example.com")
+	defer ts.Close()
+	g := newGitHubBackend(t, ts.URL)
+	g.Cfg.AllowedLogins = map[string]bool{"dlouwers": true}
+
+	c, _ := g.Store.RegisterClient(t.Context(), "x", []string{"https://localhost/cb"}, "none")
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", c.ClientID)
+	q.Set("redirect_uri", "https://localhost/cb")
+	q.Set("state", "cs")
+	q.Set("code_challenge", "irrelevant-for-this-test")
+	q.Set("code_challenge_method", "S256")
+	azResp := httptest.NewRecorder()
+	g.ServeAuthorize(azResp, httptest.NewRequest(http.MethodGet, pathAuthorize+"?"+q.Encode(), nil))
+	loc, _ := url.Parse(azResp.Header().Get("Location"))
+	sid := loc.Query().Get("state")
+
+	cbResp := httptest.NewRecorder()
+	g.ServeCallback(cbResp, httptest.NewRequest(http.MethodGet, pathGitHubCallback+"?code=code-xyz&state="+sid, nil))
+	if cbResp.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, want 302", cbResp.Code)
+	}
+	cbLoc, _ := url.Parse(cbResp.Header().Get("Location"))
+	if got := cbLoc.Query().Get("error"); got != "access_denied" {
+		t.Errorf("callback error = %q, want access_denied", got)
+	}
+	if cbLoc.Query().Get("code") != "" {
+		t.Error("non-allowlisted user must not receive an authorization code")
+	}
+}
+
 // TestOAuth_FullRoundTrip walks the full MCP-spec OAuth dance against
 // a mocked GitHub: register → authorize → GitHub callback → token →
 // /mcp Bearer use. It's the closest unit-level coverage we have of


### PR DESCRIPTION
The test environment is currently reachable by anyone with a GitHub account. It's a staging surface, not a public tier — it should be the operator's alone, with no quota.

## What's added

`TYPST_D2_MCP_GITHUB_ALLOWLIST` — comma-separated GitHub logins.

| Value | Behaviour |
|---|---|
| empty (default — what prod uses) | open to any GitHub account; the public free-tier posture |
| `dlouwers` / `a,b,c` | only those logins authenticate; matched case-insensitively |

Enforced in **two** places:

- **`ServeCallback`** — a non-allowlisted account that completes GitHub sign-in is bounced straight back to the MCP client with OAuth `error=access_denied`, never reaching the token-mint step. Friendly early gate.
- **`IdentifyFromRequest`** — the allowlist is re-checked on **every `/mcp` request** against the token's bound GitHub login. Authoritative gate: tightening the allowlist invalidates already-issued tokens immediately, no waiting for expiry.

## Test overlay config

```yaml
TYPST_D2_MCP_GITHUB_ALLOWLIST: "dlouwers"   # only the operator
TYPST_D2_MCP_QUOTA_PER_DAY:    "0"          # quota disabled
```

Because the allowlist restricts the whole env to one account, `0 = unlimited` is effectively "unlimited for the operator" — no per-user quota-exemption machinery needed.

**Prod is untouched**: empty allowlist (open to the public), quota still 1/day. If you later want operator-unlimited on *prod* too (public gets 1/day, you get unlimited), that's a separate per-user quota-exemption feature — say the word and I'll file it.

## Tests

- `loginAllowed` — empty=open, case-insensitive, whitespace-tolerant, rejects others
- `IdentifyFromRequest` rejects a valid token for a non-allowlisted account with `ErrNotAllowlisted`
- `ServeCallback` bounces a non-allowlisted sign-in with `access_denied` and mints no authorization code

`go vet`, `go test`, `golangci-lint` clean.

## After merge

Flux rolls test within ~5 min. Any GitHub account other than `dlouwers` then gets `access_denied` at sign-in; your account compiles with no quota ceiling.

Refers #2