### PR TITLE
fix(dashboard): make the ConfigMap reference resolve, and file it under Applications

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -141,7 +141,15 @@ public by default. If you flip the package to private:
   overlay and renders both namespaces side-by-side via the
   `namespace` template variable. The JSON lives at
   `dashboard/dashboards/typst-d2-mcp-overview.json` — edit there,
-  push, and grafana-operator picks it up within 5 min.
+  push, and grafana-operator picks it up within 5 min. It is filed in
+  the cluster's **Applications** folder (`folderUID: applications`);
+  the folder itself is declared in `dlouwers/experiments`
+  (`grafana-operator-cr/`, see its README for the taxonomy), never
+  from here. Two things that fail silently if you get them wrong:
+  omitting `folderUID` makes grafana-operator invent a folder named
+  after the namespace, and generating the dashboard ConfigMap without
+  `disableNameSuffixHash: true` leaves `configMapRef` pointing at a
+  name that does not exist.
 
 ## What this doesn't do (yet)
 

--- a/deploy/k8s/dashboard/grafanadashboard.yaml
+++ b/deploy/k8s/dashboard/grafanadashboard.yaml
@@ -5,9 +5,9 @@
 # Grafana instance in this cluster (matches investor-buddy).
 #
 # Dashboard JSON lives in a kustomize-generated ConfigMap (see
-# kustomization.yaml). Kustomize updates configMapRef.name with a
-# hash suffix automatically so updates don't fight in-place edits in
-# the Grafana UI.
+# kustomization.yaml, which now pins the generated name — kustomize
+# cannot rewrite configMapRef on a CRD it has no nameReference schema
+# for, and the mismatch kept this dashboard from ever rendering).
 #
 # resyncPeriod: 5m keeps iteration fast — change a panel, paste the
 # JSON into typst-d2-mcp-overview.json in this repo, push, see the
@@ -28,6 +28,24 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: "grafana"
+  # `applications` — the cluster's shared folder for every app
+  # dashboard, declared once cluster-side in dlouwers/experiments
+  # `grafana-operator-cr/folder-applications.yaml`. Do not declare a
+  # GrafanaFolder from this repo; folders are a cluster-wide concern
+  # and one shipped from an app repo is invisible to anyone reviewing
+  # the cluster.
+  #
+  # Not optional. With folderUID empty, grafana-operator's
+  # GetOrCreateFolder invents a folder named after this CR's
+  # *namespace* — so the moment the ConfigMap fix above makes this
+  # dashboard render, a folder called `typst-d2-mcp-test` would appear
+  # in the cluster's sidebar next to Infra and Observability. That
+  # exact failure, from node-exporter-full, is what
+  # dlouwers/experiments#288 was opened to clean up.
+  #
+  # folderRef is the more idiomatic reference-by-name but resolves only
+  # within the CR's own namespace, and the folder lives in `monitoring`.
+  folderUID: "applications"
   resyncPeriod: 5m
   configMapRef:
     name: typst-d2-mcp-dashboard

--- a/deploy/k8s/dashboard/kustomization.yaml
+++ b/deploy/k8s/dashboard/kustomization.yaml
@@ -9,12 +9,31 @@ kind: Kustomization
 resources:
   - grafanadashboard.yaml
 
-# configMapGenerator computes a hash suffix on the generated CM's name
-# so a dashboard JSON change propagates as a NEW ConfigMap, the
-# GrafanaDashboard's configMapRef.name is updated to match, and the
-# operator notices and reapplies. No in-place edits to the same
-# ConfigMap means no race with Grafana's UI changes.
+# disableNameSuffixHash is REQUIRED here, and its absence is why this
+# dashboard never once rendered between 2026-05-19 and now.
+#
+# The comment that used to sit here claimed kustomize rewrites the
+# GrafanaDashboard's configMapRef.name to match the hashed ConfigMap
+# name. It does not: kustomize only rewrites name references it knows
+# about, and GrafanaDashboard is a CRD absent from its nameReference
+# schema. So kustomize emitted `typst-d2-mcp-dashboard-c4bfhb2gmf`
+# while the CR kept asking for `typst-d2-mcp-dashboard`, and the CR sat
+# in the cluster for two and a half months with
+#
+#   status.conditions[InvalidSpec]:
+#     failed to fetch contents: configmaps "typst-d2-mcp-dashboard" not found
+#
+# — no event, no alert, just no dashboard. Turning the hash off makes
+# the generated name match the reference. The trade-off the old comment
+# was reaching for (a new ConfigMap name per JSON change, so the
+# operator is guaranteed to notice) is not needed: the operator re-reads
+# the ConfigMap every resyncPeriod, which is 5m here.
+#
+# investor-buddy hit exactly this and fixed it the same way; the pattern
+# is now documented in dlouwers/experiments `apps/README-metrics.md`.
 configMapGenerator:
   - name: typst-d2-mcp-dashboard
     files:
       - dashboards/typst-d2-mcp-overview.json
+    options:
+      disableNameSuffixHash: true


### PR DESCRIPTION
Two fixes to the same file set: one bug that has been silently live since
2026-05-19, and one that was about to become live the moment the first was
fixed.

## The dashboard has never rendered

Not "renders wrong" — it has not existed in Grafana at all:

```
status.conditions[InvalidSpec]:
  failed to fetch contents: configmaps "typst-d2-mcp-dashboard" not found
lastTransitionTime: 2026-05-19T14:22:17Z    # unmoved, 2.5 months
```

`configMapGenerator` had no `disableNameSuffixHash`, so it emitted
`typst-d2-mcp-dashboard-c4bfhb2gmf` (confirmed in-cluster) while the CR asked
for `typst-d2-mcp-dashboard`. The comment claiming kustomize rewrites
`configMapRef.name` to match was wrong: kustomize rewrites only the name
references in its nameReference schema, and `GrafanaDashboard` is a CRD absent
from it. The sibling `investor-buddy` repo hit the identical trap and fixed it
the same way.

Nothing surfaced this. The operator sets a status condition and moves on — no
event, no alert, no failing reconcile. Flux stayed green, the ServiceMonitor
worked, Prometheus had the metrics. Only the dashboard was missing, and only if
you went looking.

The property the hash was reaching for — a new ConfigMap name per JSON change,
guaranteeing the operator notices — is not needed: the operator re-reads the
ConfigMap every `resyncPeriod`, 5m here.

## And it had no folder

`folderUID` was unset, masked only by the CR being invalid. The moment the fix
above lands, grafana-operator's `GetOrCreateFolder` answers an empty `folderUID`
by creating a folder named after the CR's **namespace** — so `typst-d2-mcp-test`
would have appeared in the cluster's Grafana sidebar next to `Infra` and
`Observability`.

That is exactly the defect dlouwers/experiments#288 is cleaning up; a folder
called `monitoring` got there the same way. `Applications` is that repo's shared
folder for app dashboards, declared once cluster-side in `grafana-operator-cr/`.
App repos own the `folderUID`, never the `GrafanaFolder`.

Verified with `kubectl kustomize deploy/k8s/overlays/test`: the emitted
ConfigMap is now named `typst-d2-mcp-dashboard`, matching `configMapRef.name`,
and the `GrafanaDashboard` carries `folderUID: applications`.

Refs #23, dlouwers/experiments#288
