### PR TITLE
chore(dashboard): ship the dashboard from prod, not from the test overlay

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -11,7 +11,7 @@ deploy/k8s/
 ├── overlays/
 │   ├── prod/       # typst-d2-mcp.stormlantern.nl, pinned semver image
 │   └── test/       # test.typst-d2-mcp.stormlantern.nl, Flux-bumped tag
-└── dashboard/      # GrafanaDashboard CR + JSON, included by test only
+└── dashboard/      # GrafanaDashboard CR + JSON, included by prod only
 ```
 
 ## First-time setup
@@ -137,9 +137,13 @@ public by default. If you flip the package to private:
 - **Logs**: stdout/stderr only — JSON when `TYPST_D2_MCP_LOG_FORMAT=json`
   (image default). The cluster's log aggregator (Promtail/Loki or
   equivalent) picks them up automatically.
-- **Dashboards**: a single GrafanaDashboard CR ships from the test
+- **Dashboards**: a single GrafanaDashboard CR ships from the **prod**
   overlay and renders both namespaces side-by-side via the
-  `namespace` template variable. The JSON lives at
+  `namespace` template variable. One dashboard per service, environment
+  as a filter — not one dashboard per environment. It ships from prod
+  rather than test because the artifact must not outlive-or-die-with the
+  environment it does not describe; it was on test until
+  `dlouwers/experiments#290`. The JSON lives at
   `dashboard/dashboards/typst-d2-mcp-overview.json` — edit there,
   push, and grafana-operator picks it up within 5 min. It is filed in
   the cluster's **Applications** folder (`folderUID: applications`);

--- a/deploy/k8s/dashboard/grafanadashboard.yaml
+++ b/deploy/k8s/dashboard/grafanadashboard.yaml
@@ -20,7 +20,8 @@ metadata:
     app.kubernetes.io/name: typst-d2-mcp
 spec:
   # The Grafana CR lives in `monitoring`; this CR lives in
-  # `typst-d2-mcp-test`. grafana-operator defaults to
+  # `typst-d2-mcp` (the prod overlay's namespace — see
+  # kustomization.yaml). grafana-operator defaults to
   # same-namespace-only attachment — cross-namespace must be opted
   # in here AND the Grafana CR must allow the matching namespace via
   # its resourceSelector (already permissive in this cluster).
@@ -38,13 +39,19 @@ spec:
   # Not optional. With folderUID empty, grafana-operator's
   # GetOrCreateFolder invents a folder named after this CR's
   # *namespace* — so the moment the ConfigMap fix above makes this
-  # dashboard render, a folder called `typst-d2-mcp-test` would appear
+  # dashboard render, a folder called `typst-d2-mcp` would appear
   # in the cluster's sidebar next to Infra and Observability. That
   # exact failure, from node-exporter-full, is what
   # dlouwers/experiments#288 was opened to clean up.
   #
   # folderRef is the more idiomatic reference-by-name but resolves only
   # within the CR's own namespace, and the folder lives in `monitoring`.
+  #
+  # One dashboard, not one per environment: the `namespace` template
+  # variable in typst-d2-mcp-overview.json filters between prod and test.
+  # Splitting would double the JSON, guarantee drift, and lose the
+  # mid-incident comparison ("does test show it too?").
+  # dlouwers/experiments#290 settled this.
   folderUID: "applications"
   resyncPeriod: 5m
   configMapRef:

--- a/deploy/k8s/dashboard/kustomization.yaml
+++ b/deploy/k8s/dashboard/kustomization.yaml
@@ -1,10 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Single-instance dashboard slice. Pulled in by the test overlay only
-# (a single GrafanaDashboard CR renders both prod and test side-by-side
-# via the namespace template variable, so two CRs would just collide
-# on dashboard uid).
+# Single-instance dashboard slice. Pulled in by the **prod** overlay
+# only (a single GrafanaDashboard CR renders both prod and test
+# side-by-side via the namespace template variable, so two CRs would
+# just collide on dashboard uid).
+#
+# It was the test overlay until dlouwers/experiments#290: "exactly
+# once" was the right call, but hanging it off test made production's
+# dashboard a dependent of the test environment — suspend test and
+# prod loses its dashboard — and put the CR in `typst-d2-mcp-test`,
+# which reads to anyone inspecting the cluster as "prod has no
+# dashboard at all".
 
 resources:
   - grafanadashboard.yaml

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -10,6 +10,24 @@ kind: Kustomization
 namespace: typst-d2-mcp
 resources:
   - ../../base
+  # Single-instance Grafana dashboard slice. Exactly one GrafanaDashboard CR
+  # exists for this app — the dashboard is a view and the environment is a
+  # filter, selected by the `namespace` template variable
+  # (`label_values(typst_d2_mcp_compile_total, namespace)`), so it renders
+  # prod and test side by side. Two CRs would collide on dashboard uid
+  # `typst-d2-mcp-overview`.
+  #
+  # It lives HERE, not in ../../base and not in overlays/test:
+  #   - base/ would ship it from both overlays → the uid collision above.
+  #   - overlays/test/ is where it used to be, which coupled production's
+  #     dashboard to the test environment's lifecycle. That is the defect
+  #     dlouwers/experiments#290 was opened to fix: observability follows
+  #     ownership, and prod is the environment that owns this.
+  #
+  # Consequence worth knowing: the CR and its ConfigMap now land in the
+  # `typst-d2-mcp` namespace. `allowCrossNamespaceImport: true` on the CR
+  # is what lets the Grafana CR in `monitoring` accept it, unchanged.
+  - ../../dashboard
   # Both sealed-*.yaml files are generated locally via `kubeseal`
   # against the cluster's controller key (see deploy/k8s/README.md).
   # They're committed only after sealing — never include the raw

--- a/deploy/k8s/overlays/test/kustomization.yaml
+++ b/deploy/k8s/overlays/test/kustomization.yaml
@@ -15,11 +15,13 @@ kind: Kustomization
 namespace: typst-d2-mcp-test
 resources:
   - ../../base
-  # Single-instance Grafana dashboard slice — included by test only
-  # so the GrafanaDashboard CR ships exactly once (avoids a uid
-  # collision with prod). The dashboard renders both namespaces side
-  # by side via the namespace template variable, so one CR is correct.
-  - ../../dashboard
+  # NO ../../dashboard here. "Ship the CR exactly once" was right; shipping
+  # it from *test* was not. The dashboard covers prod as much as test — the
+  # `namespace` template variable is what selects between them — so hanging
+  # its lifecycle off this overlay meant suspending or decommissioning test
+  # took production's dashboard with it, and left the CR sitting in
+  # `typst-d2-mcp-test`, which reads as "prod has no dashboard".
+  # It moved to overlays/prod/ (dlouwers/experiments#290).
   - sealed-secret.yaml
   # - sealed-ghcr-pull.yaml
 patches:


### PR DESCRIPTION
The `GrafanaDashboard` CR and its ConfigMap were pulled in by
`deploy/k8s/overlays/test/` only, so the dashboard that covers **production**
was owned by the **test** environment. Suspend, delete or decommission test and
prod loses its dashboard — for a reason nobody would think to look for. The CR's
namespace read `typst-d2-mcp-test` as well, which on the cluster looks like
"prod has no dashboard at all".

That misreading is not hypothetical for this repo: the same CR sat in
`InvalidSpec` from 19 May to 1 August without anyone noticing (#24). A namespace
that lies about who the artifact serves is the same class of quiet wrongness.

This moves `- ../../dashboard` from the test overlay to the prod overlay.

**What does not change:** it is still one dashboard, not one per environment.
The `namespace` template variable
(`label_values(typst_d2_mcp_compile_total, namespace)`) is what selects between
prod and test, so the dashboard renders both side by side — which is exactly the
comparison you want mid-incident. Panel JSON is untouched;
`dashboards/typst-d2-mcp-overview.json` does not appear in the diff.
`folderUID: applications` and `disableNameSuffixHash: true` are unchanged.

**Why not `base/`:** both overlays consume it, so shipping from there produces
two CRs writing the same dashboard uid (`typst-d2-mcp-overview`),
last-writer-wins. Prod is the only placement where the artifact's lifecycle
matches what it describes.

**Operator note — this needs one manual step.** `apps/typst-d2-mcp-test.yaml`
in `dlouwers/experiments` runs `prune: false`, so removing the CR from the test
overlay will **not** delete the existing objects in `typst-d2-mcp-test`. Left
alone, the old and new CRs will both exist and fight over the same dashboard
uid. After this merges and both Kustomizations reconcile:

```nu
kubectl -n typst-d2-mcp-test delete grafanadashboard typst-d2-mcp-overview
kubectl -n typst-d2-mcp-test delete configmap typst-d2-mcp-dashboard
```

Verified with `kustomize build` on both overlays: prod emits `GrafanaDashboard`
+ `ConfigMap` in `typst-d2-mcp`, test emits neither, and nothing else moved.

Refs dlouwers/experiments#290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmhZLRCgjQpZpHaWjbKvUf
