### PR TITLE
ci: validate the manifests Flux pulls from this repo (refs dlouwers/experiments#290, #300)

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -1,0 +1,67 @@
+# Validation of what Flux actually pulls out of this repo, run by the cluster
+# that pulls it. See dlouwers/experiments#290.
+#
+# BLOCKED — DO NOT MERGE YET. GitHub does not let a workflow in a PUBLIC
+# repository call a reusable workflow stored in a PRIVATE one. This repo is
+# public and dlouwers/experiments is private, so the `uses:` below cannot
+# resolve: the run fails in 0s with "This run likely failed because of a
+# workflow file issue" and no job is created. Verified at
+# https://github.com/dlouwers/typst-d2-mcp/actions/runs/30714033146, against
+# the same workflow that runs green on the private sibling repo
+# (https://github.com/dlouwers/investor-buddy/actions/runs/30714188883).
+# Granting Actions access on the private repo (already done) does not lift it;
+# that setting governs which repositories may be granted access, not this
+# restriction. Options are tracked as dlouwers/experiments#300 — merge this
+# once one of them lands.
+#
+# Why it is worth unblocking: this repo is autonomous by design. It ships its
+# own Deployment, ServiceMonitor and GrafanaDashboard, and Flux reconciles them
+# straight from here. Nothing looked at them before the cluster did, and it
+# showed: typst-d2-mcp-overview sat in git, valid, rendering nowhere, from
+# 19 May to 1 August, because the dashboard configMapGenerator lacked
+# `disableNameSuffixHash` and kustomize emitted
+# `typst-d2-mcp-dashboard-c4bfhb2gmf` while the GrafanaDashboard kept asking
+# for `typst-d2-mcp-dashboard`. Both halves individually valid; only the
+# relationship between them broken, which every schema check in existence
+# passes. On that exact build, kubeconform -strict reports "Valid: 13,
+# Invalid: 0" and the resolver below fails, naming the hash and the remedy.
+#
+# The called workflow builds every kustomize overlay (discovered, not listed)
+# and runs:
+#   - kubeconform -strict against the CRDs the cluster actually installs, at
+#     the chart versions it pins — so a ServiceMonitor field that only exists
+#     in a newer prometheus-operator fails here, not silently on apply;
+#   - promtool over any PrometheusRule. This repo ships none today, which is
+#     why require-prometheus-rules is left unset;
+#   - a name-reference resolver: every configMapRef, referenced key,
+#     ServiceMonitor port and dashboard folderUID checked against what the
+#     build emits.
+#
+# Its own file rather than a job in ci.yml, deliberately, and doubly so while
+# it is blocked: a `uses:` that cannot resolve fails the whole workflow file it
+# sits in, before any job starts. In ci.yml that would take the Go build, tests
+# and linter down with it.
+name: manifests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# A second push to a PR makes the in-flight run irrelevant; don't pay for it.
+concurrency:
+  group: manifests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # require-dashboard: this repo is supposed to ship one. If the overlay
+  # carrying it is ever dropped again — it was shipped from the test overlay
+  # until dlouwers/experiments#290 — that becomes a failure rather than a
+  # silence.
+  validate:
+    uses: dlouwers/experiments/.github/workflows/validate-app-manifests.yaml@main
+    with:
+      require-dashboard: true

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -1,30 +1,29 @@
-# Validation of what Flux actually pulls out of this repo, run by the cluster
-# that pulls it. See dlouwers/experiments#290.
+# Validation of what Flux actually pulls out of this repo. See
+# dlouwers/experiments#290.
 #
-# BLOCKED — DO NOT MERGE YET. GitHub does not let a workflow in a PUBLIC
-# repository call a reusable workflow stored in a PRIVATE one. This repo is
-# public and dlouwers/experiments is private, so the `uses:` below cannot
-# resolve: the run fails in 0s with "This run likely failed because of a
-# workflow file issue" and no job is created. Verified at
-# https://github.com/dlouwers/typst-d2-mcp/actions/runs/30714033146, against
-# the same workflow that runs green on the private sibling repo
-# (https://github.com/dlouwers/investor-buddy/actions/runs/30714188883).
-# Granting Actions access on the private repo (already done) does not lift it;
-# that setting governs which repositories may be granted access, not this
-# restriction. Options are tracked as dlouwers/experiments#300 — merge this
-# once one of them lands.
-#
-# Why it is worth unblocking: this repo is autonomous by design. It ships its
-# own Deployment, ServiceMonitor and GrafanaDashboard, and Flux reconciles them
-# straight from here. Nothing looked at them before the cluster did, and it
-# showed: typst-d2-mcp-overview sat in git, valid, rendering nowhere, from
-# 19 May to 1 August, because the dashboard configMapGenerator lacked
+# This repo is autonomous by design. It ships its own Deployment,
+# ServiceMonitor and GrafanaDashboard, and Flux reconciles them straight from
+# here. Nothing looked at them before the cluster did, and it showed:
+# typst-d2-mcp-overview sat in git, valid, rendering nowhere, from 19 May to
+# 1 August, because the dashboard configMapGenerator lacked
 # `disableNameSuffixHash` and kustomize emitted
 # `typst-d2-mcp-dashboard-c4bfhb2gmf` while the GrafanaDashboard kept asking
 # for `typst-d2-mcp-dashboard`. Both halves individually valid; only the
 # relationship between them broken, which every schema check in existence
 # passes. On that exact build, kubeconform -strict reports "Valid: 13,
 # Invalid: 0" and the resolver below fails, naming the hash and the remedy.
+#
+# Why the workflow lives in dlouwers/ci-workflows and not in the platform repo
+# it was written in: GitHub does not let a workflow in a PUBLIC repository call
+# a reusable workflow stored in a PRIVATE one. The `uses:` cannot resolve, the
+# run fails in 0s with "This run likely failed because of a workflow file
+# issue", and no job is created — a red tick that looks like a failing check
+# and is in fact a check that never ran. This repo is public and
+# dlouwers/experiments is private, so this repo, the one the guardrail was
+# written for, was the one it could not cover. Granting Actions access on the
+# private repo does not lift it; that setting governs which repositories may be
+# granted access, not this restriction. Moving the workflow to a public
+# repository of its own is what lifts it. See dlouwers/experiments#300.
 #
 # The called workflow builds every kustomize overlay (discovered, not listed)
 # and runs:
@@ -35,12 +34,14 @@
 #     why require-prometheus-rules is left unset;
 #   - a name-reference resolver: every configMapRef, referenced key,
 #     ServiceMonitor port and dashboard folderUID checked against what the
-#     build emits.
+#     build emits. That is the check that catches the class of defect above,
+#     and the only one that does.
 #
-# Its own file rather than a job in ci.yml, deliberately, and doubly so while
-# it is blocked: a `uses:` that cannot resolve fails the whole workflow file it
-# sits in, before any job starts. In ci.yml that would take the Go build, tests
-# and linter down with it.
+# Its own file rather than a job in ci.yml, deliberately. A `uses:` that cannot
+# resolve — the workflow repo unreachable, the ref renamed or force-pushed away
+# — fails the whole workflow file it sits in, before any job starts. In ci.yml
+# that would take the Go build, tests and linter down with it, which is a bad
+# trade for a check that gates a different thing.
 name: manifests
 
 on:
@@ -57,11 +58,35 @@ permissions:
   contents: read
 
 jobs:
-  # require-dashboard: this repo is supposed to ship one. If the overlay
-  # carrying it is ever dropped again — it was shipped from the test overlay
-  # until dlouwers/experiments#290 — that becomes a failure rather than a
-  # silence.
   validate:
-    uses: dlouwers/experiments/.github/workflows/validate-app-manifests.yaml@main
+    # Pinned to a commit, never `@main`. A branch ref means any push to the
+    # workflow repository immediately changes what runs in this repository's
+    # CI — the same mutable-reference problem as a tag-pinned action, one level
+    # up. Bump it deliberately, after reading the diff. See
+    # dlouwers/experiments#301.
+    uses: dlouwers/ci-workflows/.github/workflows/validate-app-manifests.yaml@d441846849064cb5f39a04096ddc2ea2e4f2aba6 # v1.0.0
     with:
+      # The two cluster facts the workflow cannot know. It lives in a public
+      # repository of its own and states no cluster's facts, so these travel
+      # from the caller.
+      #
+      # The chart versions must be the ones the cluster actually installs
+      # (dlouwers/experiments bootstrap/): validating a ServiceMonitor against
+      # a newer prometheus-operator's CRD passes fields that are dropped on
+      # apply, and against an older one fails fields that are fine. Move them
+      # in the same PR as the chart bump over there.
+      crd-charts: |
+        https://prometheus-community.github.io/helm-charts|kube-prometheus-stack|84.5.0
+        oci://ghcr.io/grafana/helm-charts|grafana-operator|5.22.2
+        https://traefik.github.io/charts|traefik|39.0.7
+        https://bitnami.github.io/sealed-secrets|sealed-secrets|2.16.2
+      # The folders the platform publishes (its grafana-operator-cr/). A UID
+      # not in this list does not error at runtime — grafana-operator invents a
+      # folder named after the CR — so this list is the only thing that catches
+      # it.
+      grafana-folder-uids: applications,gameservers,infra,observability,platform
+      # require-dashboard: this repo is supposed to ship one. If the overlay
+      # carrying it is ever dropped again — it was shipped from the test
+      # overlay until dlouwers/experiments#290 — that becomes a failure rather
+      # than a silence.
       require-dashboard: true


### PR DESCRIPTION
Wires this repo into the reusable manifest-validation workflow, now living in
the public [`dlouwers/ci-workflows`](https://github.com/dlouwers/ci-workflows).

## No longer blocked

This PR sat blocked because GitHub does not let a workflow in a **public**
repository call a reusable workflow stored in a **private** one. The `uses:`
could not resolve: the run failed in 0s with "This run likely failed because of
a workflow file issue" and **no job was created** — a red tick that looks like a
failing check and is in fact a check that never ran. Granting Actions access on
the private repo did not lift it; that setting governs which repositories *may*
be granted access, not the public-caller restriction.

dlouwers/experiments#300 resolved it by moving the workflow to a public
repository of its own. The `uses:` here now points there, pinned to the commit
`v1.0.0` points at rather than `@main` — a branch ref would mean any push to the
workflow repo immediately changes what runs here (dlouwers/experiments#301).

## Proof it actually runs, and actually fails

A green tick was never the thing to check; a job existing was.

| | before | now |
|---|---|---|
| run | [30714348877](https://github.com/dlouwers/typst-d2-mcp/actions/runs/30714348877) | [30716486578](https://github.com/dlouwers/typst-d2-mcp/actions/runs/30716486578) |
| jobs created | **0** (`createdAt == updatedAt`) | **1**, 11 steps executed |
| result | failure in 0s, nothing ran | green |

And it still goes red on the defect it was written for. The
`disableNameSuffixHash` line was removed on a throwaway branch (since closed and
deleted) and the run
[failed](https://github.com/dlouwers/typst-d2-mcp/actions/runs/30716614279) at
exactly the right step:

```
kubeconform: Summary: 24 resources found in 2 files - Valid: 24, Invalid: 0

##[error]GrafanaDashboard typst-d2-mcp/typst-d2-mcp-overview: spec.configMapRef
points at ConfigMap 'typst-d2-mcp-dashboard', but this build emits
'typst-d2-mcp-dashboard-c4bfhb2gmf' — kustomize appended a name-suffix hash and
cannot rewrite this reference, so the object it names does not exist.
```

Every schema check passing while the dashboard renders nowhere is the whole
point: both halves are individually valid and only the relationship between them
is broken. That is why `typst-d2-mcp-overview` sat in git, valid, **rendering
nowhere from 19 May to 1 August**. This repo is the one the guardrail was
written for, and until now it was the one repo the guardrail could not reach.

## What it runs

A `.github/workflows/manifests.yml` — its own file rather than a job in
`ci.yml`, deliberately: a `uses:` that cannot resolve fails the whole workflow
file it sits in before any job starts, and in `ci.yml` that would take the Go
build, tests and linter down with it. The called workflow builds every kustomize
overlay (discovered, not listed) and runs:

* **`kubeconform -strict`** against the CRDs the cluster actually installs, at
  the chart versions it pins — a ServiceMonitor field from a newer
  prometheus-operator fails here rather than being dropped on apply.
* **`promtool check rules`** over any PrometheusRule. This repo ships none
  today, which is why `require-prometheus-rules` is left unset.
* **a name-reference resolver** — `configMapRef`, referenced key, ServiceMonitor
  port, dashboard `folderUID`, each checked against what the build emits.

## Two inputs travel from here

The workflow lives in a public repository and states no cluster's facts, so
`crd-charts` (the chart versions the cluster installs) and
`grafana-folder-uids` (the folder set the platform publishes) are passed in.
Both carry the values the workflow held as literals before, and both must move
in the same change as the corresponding one in `dlouwers/experiments`.

Refs dlouwers/experiments#290, dlouwers/experiments#300, dlouwers/experiments#301