### PR TITLE
TEMPORARY do-not-merge: prove the manifest check still goes red

### DIFF
--- a/deploy/k8s/dashboard/kustomization.yaml
+++ b/deploy/k8s/dashboard/kustomization.yaml
@@ -43,4 +43,3 @@ configMapGenerator:
     files:
       - dashboards/typst-d2-mcp-overview.json
     options:
-      disableNameSuffixHash: true


### PR DESCRIPTION
Throwaway. Reintroduces the 19 May `disableNameSuffixHash` defect to prove the relocated check still fails on it. Will be closed and the branch deleted as soon as the run reports. Refs dlouwers/experiments#300