### PR TITLE
ci: pin every action by commit SHA and enrol Dependabot (refs dlouwers/experiments#301)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Every `uses:` in .github/workflows/ is pinned to a full commit SHA rather
+# than a tag, because a tag is a mutable pointer its owner can move — which is
+# how tj-actions/changed-files leaked secrets from thousands of repositories in
+# March 2025. See dlouwers/experiments#301.
+#
+# This file is what stops that from becoming slow rot. Dependabot's
+# github-actions ecosystem understands SHA pins and rewrites the SHA and the
+# trailing version comment together; without it, a SHA pin is a pin that never
+# moves again, which is a different way of running old code.
+#
+# `directory: "/"` is correct and is not a stand-in for "/.github/workflows":
+# the ecosystem is anchored at the repository root and locates the workflow
+# directory itself. Pointing it at the literal workflow path is the classic way
+# to end up with a config Dependabot accepts and then never opens a PR from.
+#
+# This also covers the `uses:` in manifests.yml pointing at
+# dlouwers/ci-workflows — a called reusable workflow is third-party code in
+# this repository's context just as much as an action is, and the same
+# reasoning about mutable refs applies to it.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci(actions)"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "build(deps)"
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
           cache: true
@@ -50,7 +50,7 @@ jobs:
         # binary that ships with Go 1.24 and refuses to lint a Go-1.25
         # module. `goinstall` recompiles the linter with the runner's
         # toolchain (set above to 1.25), avoiding the version mismatch.
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           version: latest
           install-mode: goinstall

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -33,13 +33,13 @@ jobs:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Compute image tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -79,7 +79,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build & push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.23'
           cache: true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Every `uses:` here was pinned by **tag**. A tag is a mutable pointer: whoever
controls the upstream repository can move `v5` at any time and the next run
silently executes whatever it points at now. That is how
`tj-actions/changed-files` was compromised in March 2025 — existing tags
repointed at code that leaked secrets from thousands of repositories, all of
which had pinned by tag because that is the documented-looking thing to do.

Not abstract here: `release.yml` and `image.yml` hold `packages: write` and a
registry credential.

## The pins

Each resolved from its tag with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`
rather than copied from anywhere — a SHA is opaque, so a wrong-but-real one
reads as fine and is worse than the tag it replaced.

| action | tag | commit | version |
|---|---|---|---|
| `actions/checkout` | v4 | `11d5960a326750d5838078e36cf38b85af677262` | v4.4.0 |
| `actions/checkout` | v5 | `fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09` | v5.1.0 |
| `actions/setup-go` | v5 | `40f1582b2485089dde7abd97c1529aa768e1baff` | v5.6.0 |
| `goreleaser/goreleaser-action` | v6 | `e435ccd777264be153ace6237001ef4d979d3a7a` | v6.4.0 |
| `golangci/golangci-lint-action` | v6 | `55c2c1448f86e01eaae002a5a3a9624417608d84` | v6.5.2 |
| `docker/setup-buildx-action` | v3 | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` | v3.12.0 |
| `docker/login-action` | v3 | `c94ce9fb468520275223c153574b00df6fe4bcc9` | v3.7.0 |
| `docker/metadata-action` | v5 | `c299e40c65443455700f0fdfc63efafe5b349051` | v5.10.0 |
| `docker/build-push-action` | v6 | `10e90e3645eae34f1e60eeb005ba3a3d33f178e8` | v6.19.2 |

All nine were on **major** tags, which upstream repoints on every minor and
patch release by design — mutable not as a risk but as a documented feature.
Versions are unchanged; each SHA is what its tag pointed at today. Note
`actions/checkout` was on v4 in two workflows and v5 in a third; that
inconsistency is preserved rather than quietly fixed, so this PR is a pinning
change and nothing else. Dependabot will offer the v4→v5 bump.

## The other half: `.github/dependabot.yml`

This repo had none. That is not an extra — a SHA pin with no Dependabot is a pin
that never moves again, which is just a different way of running old code.
Dependabot understands SHA pins and rewrites the SHA and the trailing version
comment together, which is what makes tag-pinning indefensible rather than
merely imperfect: the usual argument for tags is convenience, and this removes
it.

It also covers the `uses:` pointing at `dlouwers/ci-workflows` — a called
reusable workflow is third-party code in this repository's context just as much
as an action is. The `gomod` ecosystem is enrolled at the same time; nothing was
watching it either.

Refs dlouwers/experiments#301