### PR TITLE
feat(authdb): versioned schema migrations

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -98,6 +98,34 @@ The state volume at `/var/lib/typst-d2-mcp` holds:
 Both paths are derived from env vars at startup; override them if you
 prefer a different layout.
 
+### Schema migrations
+
+`auth.sqlite` carries a schema revision, recorded in its
+`schema_migrations` table. On startup the server applies any revisions
+the binary knows about and the database has not yet seen, each one in a
+single transaction.
+
+Two failure modes are deliberate, and both stop the process rather than
+letting it serve against a schema it does not understand:
+
+- **A migration fails.** That revision rolls back, startup aborts, and
+  the error names the revision. The pod will crashloop — correct, given
+  the alternative is writing against a half-applied schema.
+- **The database is newer than the binary.** Rolling an image back onto
+  a volume a newer build has already migrated is refused, with both
+  revisions in the message. Roll forward, or restore a backup taken
+  before the upgrade.
+
+**Back up the state volume before upgrading to a release that carries a
+migration.** `api_keys` stores sha256 hashes only, so a botched
+migration cannot be repaired by re-deriving keys — every user would have
+to re-authenticate.
+
+To add a migration, append an entry to `migrations` in
+`internal/authdb/migrate.go` with the next revision number. Never edit a
+revision that has shipped: databases that already applied it will not
+re-run it, so an edit silently diverges old deployments from new ones.
+
 ## Hardening notes
 
 These are **not** wired into the image today. They belong to the

--- a/internal/authdb/authdb.go
+++ b/internal/authdb/authdb.go
@@ -39,20 +39,18 @@ type Store struct {
 	db *sql.DB
 }
 
-// Open returns a Store backed by the SQLite file at path. The schema is
-// created in place if missing; opening an existing file is idempotent.
-// Foreign keys are enabled for referential integrity on api_keys.
+// Open returns a Store backed by the SQLite file at path, migrated to
+// the schema revision this binary expects (see migrate.go). Opening an
+// existing file is idempotent; a database newer than this binary is
+// refused with ErrSchemaTooNew rather than served against. Foreign keys
+// are enabled for referential integrity on api_keys.
 func Open(path string) (*Store, error) {
 	db, err := sql.Open("sqlite", path+"?_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)")
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
 	s := &Store{db: db}
-	if err := s.migrate(); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	if err := s.migrateOAuth(); err != nil {
+	if err := s.runMigrations(); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -61,36 +59,6 @@ func Open(path string) (*Store, error) {
 
 // Close releases the underlying SQLite connection.
 func (s *Store) Close() error { return s.db.Close() }
-
-func (s *Store) migrate() error {
-	const ddl = `
-CREATE TABLE IF NOT EXISTS users (
-  id           INTEGER PRIMARY KEY AUTOINCREMENT,
-  github_id    INTEGER NOT NULL UNIQUE,
-  github_login TEXT    NOT NULL,
-  email        TEXT,
-  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS api_keys (
-  id           INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  key_hash     BLOB    NOT NULL UNIQUE,
-  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  last_used_at TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS compiles (
-  user_id  TEXT    NOT NULL,
-  utc_date TEXT    NOT NULL,
-  count    INTEGER NOT NULL,
-  PRIMARY KEY(user_id, utc_date)
-);
-`
-	_, err := s.db.Exec(ddl)
-	if err != nil {
-		return fmt.Errorf("migrate schema: %w", err)
-	}
-	return nil
-}
 
 // UpsertGitHubUser inserts or updates a user keyed by their GitHub
 // numeric ID and returns the local user.id. Login/email are refreshed

--- a/internal/authdb/migrate.go
+++ b/internal/authdb/migrate.go
@@ -1,0 +1,283 @@
+package authdb
+
+// Versioned schema migrations.
+//
+// The schema used to be two idempotent `CREATE TABLE IF NOT EXISTS`
+// blobs run on every Open. That could create a missing table but could
+// never alter an existing one — an ALTER expressed that way is a silent
+// no-op against a deployed database, which is a trap rather than a
+// limitation. Everything now moves through an ordered list of revisions
+// recorded in schema_migrations.
+//
+// Rules that keep this safe on a live volume, where api_keys holds
+// unrecoverable sha256 hashes:
+//
+//   - Each revision runs in its own transaction. A failure rolls that
+//     revision back and aborts Open, so the process never serves against
+//     a half-applied schema. A crashlooping pod is the correct outcome
+//     when the alternative is silent corruption.
+//   - A database recorded at a higher revision than this binary knows
+//     about is refused (ErrSchemaTooNew). An old binary against a new
+//     schema is undefined behaviour: it may read columns that moved or
+//     write rows violating constraints it has never heard of.
+//   - A pre-versioning database (tables present, no schema_migrations)
+//     is stamped at revision 1 rather than re-running revision 1's DDL.
+//
+// Adding a migration: append to `migrations` with the next revision
+// number and never edit a revision that has shipped — an already-migrated
+// database will not re-run it, so an edit silently diverges old
+// deployments from new ones.
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrSchemaTooNew reports a database written by a newer binary than
+// this one. Returned by Open; the caller is expected to exit rather
+// than continue.
+var ErrSchemaTooNew = errors.New("database schema is newer than this binary supports")
+
+// migration is one ordered, atomic schema revision. Statements run in
+// order inside a single transaction.
+type migration struct {
+	revision int
+	name     string
+	stmts    []string
+}
+
+// migrations is the ordered revision list. Revision 1 is the schema as
+// it stood before versioning existed, so pre-existing databases can be
+// stamped at 1 without re-running anything.
+var migrations = []migration{
+	{
+		revision: 1,
+		name:     "initial schema",
+		stmts: []string{
+			`CREATE TABLE IF NOT EXISTS users (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  github_id    INTEGER NOT NULL UNIQUE,
+  github_login TEXT    NOT NULL,
+  email        TEXT,
+  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`,
+			`CREATE TABLE IF NOT EXISTS api_keys (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  key_hash     BLOB    NOT NULL UNIQUE,
+  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_used_at TIMESTAMP
+)`,
+			`CREATE TABLE IF NOT EXISTS compiles (
+  user_id  TEXT    NOT NULL,
+  utc_date TEXT    NOT NULL,
+  count    INTEGER NOT NULL,
+  PRIMARY KEY(user_id, utc_date)
+)`,
+			`CREATE TABLE IF NOT EXISTS oauth_clients (
+  client_id                  TEXT PRIMARY KEY,
+  client_name                TEXT NOT NULL,
+  redirect_uris              TEXT NOT NULL,
+  token_endpoint_auth_method TEXT NOT NULL DEFAULT 'none',
+  created_at                 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`,
+			`CREATE TABLE IF NOT EXISTS oauth_authorize_sessions (
+  session_id            TEXT PRIMARY KEY,
+  client_id             TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
+  redirect_uri          TEXT NOT NULL,
+  code_challenge        TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL DEFAULT 'S256',
+  scope                 TEXT,
+  client_state          TEXT NOT NULL,
+  expires_at            TIMESTAMP NOT NULL
+)`,
+			`CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
+  code                  TEXT PRIMARY KEY,
+  user_id               INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  client_id             TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
+  redirect_uri          TEXT NOT NULL,
+  code_challenge        TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL DEFAULT 'S256',
+  scope                 TEXT,
+  used                  INTEGER NOT NULL DEFAULT 0,
+  expires_at            TIMESTAMP NOT NULL
+)`,
+			`CREATE TABLE IF NOT EXISTS pdf_links (
+  token       TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  file_path   TEXT NOT NULL,
+  created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at  TIMESTAMP NOT NULL
+)`,
+		},
+	},
+	{
+		revision: 2,
+		name:     "per-user quota override",
+		stmts: []string{
+			// NULL inherits the env default, 0 means unlimited (matching
+			// IncrementCompile's existing limit <= 0 path), N caps at N.
+			`ALTER TABLE users ADD COLUMN quota_per_day INTEGER NULL`,
+		},
+	},
+	{
+		revision: 3,
+		name:     "invites",
+		stmts: []string{
+			// Keyed by login, not user id: an invite necessarily exists
+			// before the person has ever signed in, when no github_id is
+			// known yet. Stored lowercase; see NormalizeLogin.
+			`CREATE TABLE IF NOT EXISTS invites (
+  github_login TEXT PRIMARY KEY,
+  invited_by   TEXT NOT NULL,
+  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`,
+		},
+	},
+	{
+		revision: 4,
+		name:     "admin audit log",
+		stmts: []string{
+			`CREATE TABLE IF NOT EXISTS admin_audit (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  actor_login  TEXT NOT NULL,
+  action       TEXT NOT NULL,
+  target_login TEXT NOT NULL,
+  detail       TEXT NOT NULL DEFAULT '',
+  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`,
+			`CREATE INDEX IF NOT EXISTS idx_admin_audit_created_at
+   ON admin_audit(created_at DESC)`,
+		},
+	},
+	{
+		revision: 5,
+		name:     "per-user workspace storage cache",
+		stmts: []string{
+			// Written by the workspace sweeper, read by the admin UI, so
+			// rendering the user list never walks the filesystem.
+			`CREATE TABLE IF NOT EXISTS workspace_usage (
+  user_id     TEXT PRIMARY KEY,
+  bytes       INTEGER NOT NULL,
+  computed_at TIMESTAMP NOT NULL
+)`,
+		},
+	},
+}
+
+// latestRevision is the highest revision this binary knows how to apply.
+func latestRevision() int {
+	if len(migrations) == 0 {
+		return 0
+	}
+	return migrations[len(migrations)-1].revision
+}
+
+// runMigrations brings the database up to latestRevision, or returns an
+// error explaining why it cannot. Safe to call on every Open: current
+// databases do no work.
+func (s *Store) runMigrations() error {
+	if _, err := s.db.Exec(`
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  revision   INTEGER PRIMARY KEY,
+  name       TEXT NOT NULL,
+  applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`); err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+
+	current, err := s.SchemaRevision()
+	if err != nil {
+		return err
+	}
+
+	// Pre-versioning database: the tables are already there from the old
+	// IF NOT EXISTS blobs, so revision 1 has effectively been applied.
+	// Stamp it rather than re-running the DDL, which would succeed but
+	// misrepresent history.
+	if current == 0 {
+		legacy, err := s.tableExists("users")
+		if err != nil {
+			return err
+		}
+		if legacy {
+			if _, err := s.db.Exec(
+				`INSERT INTO schema_migrations(revision, name) VALUES(1, ?)`,
+				"initial schema (baselined)",
+			); err != nil {
+				return fmt.Errorf("baseline pre-versioning database: %w", err)
+			}
+			current = 1
+		}
+	}
+
+	if latest := latestRevision(); current > latest {
+		return fmt.Errorf("%w: database is at revision %d, this binary supports %d — "+
+			"roll forward or restore a backup", ErrSchemaTooNew, current, latest)
+	}
+
+	for _, m := range migrations {
+		if m.revision <= current {
+			continue
+		}
+		if err := s.applyMigration(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyMigration runs one revision atomically: every statement plus the
+// schema_migrations bookkeeping row commit together, or nothing does.
+func (s *Store) applyMigration(m migration) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("migration %d (%s): begin: %w", m.revision, m.name, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for i, stmt := range m.stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("migration %d (%s): statement %d: %w",
+				m.revision, m.name, i+1, err)
+		}
+	}
+	if _, err := tx.Exec(
+		`INSERT INTO schema_migrations(revision, name) VALUES(?, ?)`,
+		m.revision, m.name,
+	); err != nil {
+		return fmt.Errorf("migration %d (%s): record revision: %w", m.revision, m.name, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("migration %d (%s): commit: %w", m.revision, m.name, err)
+	}
+	return nil
+}
+
+// SchemaRevision reports the highest applied revision, or 0 for a
+// database that has never been migrated.
+func (s *Store) SchemaRevision() (int, error) {
+	var rev sql.NullInt64
+	if err := s.db.QueryRow(`SELECT MAX(revision) FROM schema_migrations`).Scan(&rev); err != nil {
+		return 0, fmt.Errorf("read schema revision: %w", err)
+	}
+	if !rev.Valid {
+		return 0, nil
+	}
+	return int(rev.Int64), nil
+}
+
+func (s *Store) tableExists(name string) (bool, error) {
+	var found string
+	err := s.db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`, name,
+	).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check table %s: %w", name, err)
+	}
+	return true, nil
+}

--- a/internal/authdb/migrate_test.go
+++ b/internal/authdb/migrate_test.go
@@ -1,0 +1,330 @@
+package authdb
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withMigrations swaps the package migration list for the duration of a
+// test. Tests that need to exercise applying, ordering, or failing a
+// migration cannot use the real list — every shipped revision is already
+// applied by the time Open returns.
+func withMigrations(t *testing.T, list []migration) {
+	t.Helper()
+	saved := migrations
+	migrations = list
+	t.Cleanup(func() { migrations = saved })
+}
+
+// openRaw opens the SQLite file without running migrations, so tests can
+// inspect or corrupt schema state directly.
+func openRaw(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestMigrations_FreshDatabaseReachesLatest(t *testing.T) {
+	s := newStore(t)
+
+	rev, err := s.SchemaRevision()
+	if err != nil {
+		t.Fatalf("SchemaRevision: %v", err)
+	}
+	if want := latestRevision(); rev != want {
+		t.Errorf("revision = %d, want %d", rev, want)
+	}
+}
+
+// Every table the pre-versioning schema created must still exist after a
+// migration from empty, so revision 1 is a faithful transcription.
+func TestMigrations_CreatesAllLegacyTables(t *testing.T) {
+	s := newStore(t)
+
+	for _, table := range []string{
+		"users", "api_keys", "compiles",
+		"oauth_clients", "oauth_authorize_sessions", "oauth_authorization_codes",
+		"pdf_links",
+	} {
+		exists, err := s.tableExists(table)
+		if err != nil {
+			t.Fatalf("tableExists(%s): %v", table, err)
+		}
+		if !exists {
+			t.Errorf("table %q missing after migration from empty", table)
+		}
+	}
+}
+
+// The api_keys -> users cascade is load-bearing for user deletion, and a
+// transcription slip in revision 1 would silently drop it.
+func TestMigrations_ForeignKeyCascadePreserved(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+
+	uid, err := s.UpsertGitHubUser(ctx, 42, "octocat", "")
+	if err != nil {
+		t.Fatalf("UpsertGitHubUser: %v", err)
+	}
+	if _, err := s.IssueAPIKey(ctx, uid); err != nil {
+		t.Fatalf("IssueAPIKey: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM users WHERE id = ?`, uid); err != nil {
+		t.Fatalf("delete user: %v", err)
+	}
+
+	var keys int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM api_keys WHERE user_id = ?`, uid).Scan(&keys); err != nil {
+		t.Fatalf("count keys: %v", err)
+	}
+	if keys != 0 {
+		t.Errorf("api_keys rows after user delete = %d, want 0 (cascade lost)", keys)
+	}
+}
+
+func TestMigrations_ReopenIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.sqlite")
+
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	rev1, _ := first.SchemaRevision()
+	_ = first.Close()
+
+	second, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+	rev2, _ := second.SchemaRevision()
+
+	if rev1 != rev2 {
+		t.Errorf("revision changed across reopen: %d -> %d", rev1, rev2)
+	}
+
+	// Each revision must be recorded exactly once — a re-application
+	// would either fail on the primary key or duplicate history.
+	var rows int
+	if err := second.db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&rows); err != nil {
+		t.Fatalf("count schema_migrations: %v", err)
+	}
+	if rows != latestRevision() {
+		t.Errorf("schema_migrations rows = %d, want %d", rows, latestRevision())
+	}
+}
+
+// The upgrade path that matters in production: a volume written by the
+// old CREATE TABLE IF NOT EXISTS build, opened by this one.
+func TestMigrations_BaselinesPreVersioningDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.sqlite")
+
+	// Stand up the legacy schema by hand, including a user row that must
+	// survive, and deliberately no schema_migrations table.
+	raw := openRaw(t, path)
+	for _, stmt := range migrations[0].stmts {
+		if _, err := raw.Exec(stmt); err != nil {
+			t.Fatalf("legacy DDL: %v", err)
+		}
+	}
+	if _, err := raw.Exec(
+		`INSERT INTO users(github_id, github_login, email) VALUES(7, 'legacy', 'l@example.com')`,
+	); err != nil {
+		t.Fatalf("seed legacy user: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw: %v", err)
+	}
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open legacy database: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	rev, _ := s.SchemaRevision()
+	if want := latestRevision(); rev != want {
+		t.Errorf("revision = %d, want %d", rev, want)
+	}
+
+	// Revision 1 must be recorded as baselined, not re-run.
+	var name string
+	if err := s.db.QueryRow(
+		`SELECT name FROM schema_migrations WHERE revision = 1`).Scan(&name); err != nil {
+		t.Fatalf("read revision 1 row: %v", err)
+	}
+	if !strings.Contains(name, "baselined") {
+		t.Errorf("revision 1 name = %q, want it marked as baselined", name)
+	}
+
+	// The pre-existing row survives, and later revisions applied on top.
+	var login string
+	if err := s.db.QueryRow(
+		`SELECT github_login FROM users WHERE github_id = 7`).Scan(&login); err != nil {
+		t.Fatalf("legacy user lost: %v", err)
+	}
+	if login != "legacy" {
+		t.Errorf("github_login = %q, want %q", login, "legacy")
+	}
+	var quota sql.NullInt64
+	if err := s.db.QueryRow(
+		`SELECT quota_per_day FROM users WHERE github_id = 7`).Scan(&quota); err != nil {
+		t.Fatalf("quota_per_day column not applied to legacy database: %v", err)
+	}
+	if quota.Valid {
+		t.Errorf("quota_per_day = %v, want NULL for an untouched legacy user", quota.Int64)
+	}
+}
+
+// An ALTER on an existing database is exactly what the old DDL-blob
+// approach could not express, so it gets a direct test.
+func TestMigrations_AlterAppliesToExistingDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.sqlite")
+
+	base := []migration{{
+		revision: 1,
+		name:     "base",
+		stmts:    []string{`CREATE TABLE widgets (id INTEGER PRIMARY KEY)`},
+	}}
+	withMigrations(t, base)
+
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if _, err := first.db.Exec(`INSERT INTO widgets(id) VALUES(1)`); err != nil {
+		t.Fatalf("seed widgets: %v", err)
+	}
+	_ = first.Close()
+
+	// Second binary knows one more revision.
+	withMigrations(t, append(base, migration{
+		revision: 2,
+		name:     "add colour",
+		stmts:    []string{`ALTER TABLE widgets ADD COLUMN colour TEXT`},
+	}))
+
+	second, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+
+	if rev, _ := second.SchemaRevision(); rev != 2 {
+		t.Errorf("revision = %d, want 2", rev)
+	}
+	var colour sql.NullString
+	if err := second.db.QueryRow(`SELECT colour FROM widgets WHERE id = 1`).Scan(&colour); err != nil {
+		t.Fatalf("ALTER did not apply to existing row: %v", err)
+	}
+}
+
+// Revisions must be ascending and unique: applyMigration skips anything
+// <= current, so an out-of-order or duplicated entry would be silently
+// skipped rather than rejected.
+func TestMigrations_OrderedAndUnique(t *testing.T) {
+	seen := map[int]bool{}
+	prev := 0
+	for i, m := range migrations {
+		if m.revision <= prev {
+			t.Errorf("migrations[%d] revision %d is not greater than previous %d",
+				i, m.revision, prev)
+		}
+		if seen[m.revision] {
+			t.Errorf("duplicate revision %d", m.revision)
+		}
+		if m.name == "" {
+			t.Errorf("migrations[%d] (revision %d) has no name", i, m.revision)
+		}
+		if len(m.stmts) == 0 {
+			t.Errorf("migrations[%d] (revision %d) has no statements", i, m.revision)
+		}
+		seen[m.revision] = true
+		prev = m.revision
+	}
+}
+
+func TestMigrations_FailureRollsBackAndAbortsOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.sqlite")
+
+	withMigrations(t, []migration{
+		{revision: 1, name: "base", stmts: []string{`CREATE TABLE widgets (id INTEGER PRIMARY KEY)`}},
+		{revision: 2, name: "half broken", stmts: []string{
+			`CREATE TABLE gadgets (id INTEGER PRIMARY KEY)`, // valid, must be rolled back
+			`THIS IS NOT SQL`,                               // fails
+		}},
+	})
+
+	s, err := Open(path)
+	if err == nil {
+		_ = s.Close()
+		t.Fatal("Open succeeded despite a failing migration")
+	}
+	if s != nil {
+		t.Error("Open returned a non-nil Store alongside an error")
+	}
+	// The error must name the revision so an operator can find it.
+	if !strings.Contains(err.Error(), "migration 2") {
+		t.Errorf("error does not name the failing revision: %v", err)
+	}
+	if !strings.Contains(err.Error(), "half broken") {
+		t.Errorf("error does not name the failing migration: %v", err)
+	}
+
+	// Revision stays at 1 and the partial statement is gone.
+	raw := openRaw(t, path)
+	var rev sql.NullInt64
+	if err := raw.QueryRow(`SELECT MAX(revision) FROM schema_migrations`).Scan(&rev); err != nil {
+		t.Fatalf("read revision: %v", err)
+	}
+	if !rev.Valid || rev.Int64 != 1 {
+		t.Errorf("recorded revision = %v, want 1", rev)
+	}
+	var name string
+	err = raw.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='gadgets'`).Scan(&name)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("gadgets table survived a failed migration (rollback did not happen): %v", err)
+	}
+}
+
+func TestMigrations_RefusesNewerDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.sqlite")
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	future := latestRevision() + 1
+	if _, err := s.db.Exec(
+		`INSERT INTO schema_migrations(revision, name) VALUES(?, 'from the future')`, future,
+	); err != nil {
+		t.Fatalf("stamp future revision: %v", err)
+	}
+	_ = s.Close()
+
+	reopened, err := Open(path)
+	if err == nil {
+		_ = reopened.Close()
+		t.Fatal("Open succeeded against a newer-than-supported database")
+	}
+	if !errors.Is(err, ErrSchemaTooNew) {
+		t.Errorf("err = %v, want ErrSchemaTooNew", err)
+	}
+	// Both numbers belong in the message: the operator needs to know how
+	// far ahead the volume is before choosing to roll forward or restore.
+	for _, want := range []string{fmt.Sprint(future), fmt.Sprint(latestRevision())} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention revision %s", err.Error(), want)
+		}
+	}
+}

--- a/internal/authdb/oauth.go
+++ b/internal/authdb/oauth.go
@@ -84,49 +84,9 @@ type AuthorizationCode struct {
 	Scope               string
 }
 
-func (s *Store) migrateOAuth() error {
-	const ddl = `
-CREATE TABLE IF NOT EXISTS oauth_clients (
-  client_id                  TEXT PRIMARY KEY,
-  client_name                TEXT NOT NULL,
-  redirect_uris              TEXT NOT NULL, -- JSON-encoded array
-  token_endpoint_auth_method TEXT NOT NULL DEFAULT 'none',
-  created_at                 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS oauth_authorize_sessions (
-  session_id            TEXT PRIMARY KEY,
-  client_id             TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
-  redirect_uri          TEXT NOT NULL,
-  code_challenge        TEXT NOT NULL,
-  code_challenge_method TEXT NOT NULL DEFAULT 'S256',
-  scope                 TEXT,
-  client_state          TEXT NOT NULL,
-  expires_at            TIMESTAMP NOT NULL
-);
-CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
-  code                  TEXT PRIMARY KEY,
-  user_id               INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  client_id             TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
-  redirect_uri          TEXT NOT NULL,
-  code_challenge        TEXT NOT NULL,
-  code_challenge_method TEXT NOT NULL DEFAULT 'S256',
-  scope                 TEXT,
-  used                  INTEGER NOT NULL DEFAULT 0,
-  expires_at            TIMESTAMP NOT NULL
-);
-CREATE TABLE IF NOT EXISTS pdf_links (
-  token       TEXT PRIMARY KEY,
-  user_id     TEXT NOT NULL,         -- identity.Identity.UserID (e.g. "gh:42")
-  file_path   TEXT NOT NULL,         -- workspace-relative path to the PDF
-  created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  expires_at  TIMESTAMP NOT NULL
-);
-`
-	if _, err := s.db.Exec(ddl); err != nil {
-		return fmt.Errorf("migrate oauth schema: %w", err)
-	}
-	return nil
-}
+// The oauth_clients, oauth_authorize_sessions, oauth_authorization_codes
+// and pdf_links tables are created by revision 1 in migrate.go, alongside
+// the rest of the schema.
 
 // RegisterClient persists a dynamic client registration and returns
 // the assigned client_id. Caller is responsible for validating the


### PR DESCRIPTION
The schema was applied as two idempotent `CREATE TABLE IF NOT EXISTS`
blobs run on every `Open`. That can create a missing table but can never
alter an existing one — an `ALTER` expressed that way is a silent no-op
against a deployed database, so the code would expect a column the live
DB does not have. Nothing recorded which schema version a file actually
was, either.

Replaces both blobs with an ordered revision list recorded in a
`schema_migrations` table.

- **Revision 1 is the pre-existing schema verbatim.** A database that
  already has the tables is *stamped* at revision 1 rather than
  re-running the DDL, so deployed volumes upgrade without a rewrite.
- **Revisions 2–5** add what the two follow-up branches need:
  `users.quota_per_day`, `invites`, `admin_audit`, `workspace_usage`.
- **Each revision applies in its own transaction.** A failure rolls that
  revision back and aborts startup rather than serving against a
  half-applied schema — a crashlooping pod is the right outcome when the
  alternative is silent corruption.
- **A newer-than-supported database is refused** (`ErrSchemaTooNew`),
  naming both revisions. An old binary against a new schema may read
  columns that moved or violate constraints it has never heard of. The
  cost is accepted: rolling an image back onto an already-migrated
  volume will crashloop until you roll forward or restore a backup.

Both failure modes are deliberate because the data is not
reconstructible: `api_keys` stores sha256 hashes only, so a botched
migration cannot be repaired by re-deriving keys.

`DEPLOYMENT.md` gains a section on the two failure modes, the advice to
back up the state volume before an upgrade carrying a migration, and the
rule that a shipped revision is never edited.

Refers #39
