### PR TITLE
feat(gc): sweep expired links, purge aged workspace files, serve PDFs with ServeContent

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -55,6 +55,8 @@ The OAuth scope requested is `read:user user:email` — read-only.
 | `TYPST_D2_MCP_GITHUB_CLIENT_SECRET` | _required for github_ | OAuth Client secret. |
 | `TYPST_D2_MCP_QUOTA_PER_DAY` | `1` | Compiles per UTC day per non-anonymous user. `0` disables. |
 | `TYPST_D2_MCP_COMPILE_TIMEOUT` | `30s` | Per-compile budget (parses Go duration strings). `0` defers to caller. |
+| `TYPST_D2_MCP_WORKSPACE_TTL` | `168h` (7d) | Age after which workspace files are purged. `0` disables the purge; sizes are still measured. |
+| `TYPST_D2_MCP_SWEEP_INTERVAL` | `1h` | Gap between garbage-collection passes. |
 | `TYPST_D2_MCP_MAX_INPUT_BYTES` | `1048576` (1 MiB) | Cap on `put_file` and compile input sizes. |
 | `TYPST_D2_MCP_LOG_LEVEL` | `info` | `debug`/`info`/`warn`/`error`. |
 | `TYPST_D2_MCP_LOG_FORMAT` | `json` in http, `text` in stdio | `json` or `text`. |
@@ -88,12 +90,29 @@ the callback URL is `https://...`. Bearer tokens must travel over TLS.
 The state volume at `/var/lib/typst-d2-mcp` holds:
 
 - `workspaces/<user_id>/` — each authenticated user's sandboxed working
-  tree, including compiled PDFs. Files do **not** auto-expire today
-  (sub-issue [#5](https://github.com/dlouwers/typst-d2-mcp/issues/2)
-  will add TTL purge); operators should mount this on a volume with
-  reasonable size limits and periodically prune.
+  tree, including compiled PDFs. Treated as scratch space: files are
+  purged once they pass `TYPST_D2_MCP_WORKSPACE_TTL` (7 days by
+  default), since everything in them is reproducible from a re-upload
+  and recompile. A file with an unexpired download link is kept however
+  old it is, so a URL already in someone's hands never breaks.
 - `auth.sqlite` — users, hashed API keys, and the per-day compile
   counter. Losing this file logs everyone out and resets quota.
+
+### Garbage collection
+
+A background sweeper runs every `TYPST_D2_MCP_SWEEP_INTERVAL` and:
+
+- deletes `pdf_links` rows past their expiry. (Fetching an expired link
+  already deletes its row, but a link that is minted and never clicked
+  is never read, so nothing would otherwise collect it.)
+- purges workspace files older than the TTL, skipping any that a live
+  download link still points at, and removes directories the purge
+  leaves empty;
+- records each user's total workspace size, which the admin UI reads
+  instead of walking the filesystem on page load.
+
+Setting `TYPST_D2_MCP_WORKSPACE_TTL=0` disables only the file purge —
+link sweeping and size measurement still run.
 
 Both paths are derived from env vars at startup; override them if you
 prefer a different layout.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -98,6 +98,34 @@ The state volume at `/var/lib/typst-d2-mcp` holds:
 Both paths are derived from env vars at startup; override them if you
 prefer a different layout.
 
+### Schema migrations
+
+`auth.sqlite` carries a schema revision, recorded in its
+`schema_migrations` table. On startup the server applies any revisions
+the binary knows about and the database has not yet seen, each one in a
+single transaction.
+
+Two failure modes are deliberate, and both stop the process rather than
+letting it serve against a schema it does not understand:
+
+- **A migration fails.** That revision rolls back, startup aborts, and
+  the error names the revision. The pod will crashloop — correct, given
+  the alternative is writing against a half-applied schema.
+- **The database is newer than the binary.** Rolling an image back onto
+  a volume a newer build has already migrated is refused, with both
+  revisions in the message. Roll forward, or restore a backup taken
+  before the upgrade.
+
+**Back up the state volume before upgrading to a release that carries a
+migration.** `api_keys` stores sha256 hashes only, so a botched
+migration cannot be repaired by re-deriving keys — every user would have
+to re-authenticate.
+
+To add a migration, append an entry to `migrations` in
+`internal/authdb/migrate.go` with the next revision number. Never edit a
+revision that has shipped: databases that already applied it will not
+re-run it, so an edit silently diverges old deployments from new ones.
+
 ## Hardening notes
 
 These are **not** wired into the image today. They belong to the

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -22,6 +21,7 @@ import (
 	"github.com/dlouwers/typst-d2-mcp/internal/identity"
 	"github.com/dlouwers/typst-d2-mcp/internal/metrics"
 	"github.com/dlouwers/typst-d2-mcp/internal/preprocessor"
+	"github.com/dlouwers/typst-d2-mcp/internal/sweeper"
 	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -57,8 +57,17 @@ const (
 	envMetricsBearer = "TYPST_D2_MCP_METRICS_BEARER"
 	envPDFLinkTTL    = "TYPST_D2_MCP_PDF_LINK_TTL"
 
+	envWorkspaceTTL  = "TYPST_D2_MCP_WORKSPACE_TTL"
+	envSweepInterval = "TYPST_D2_MCP_SWEEP_INTERVAL"
+
 	defaultMetricsAddr = ":9090"
 	defaultPDFLinkTTL  = time.Hour
+
+	// A week is comfortably longer than any PDF link TTL, so nothing in
+	// flight is ever at risk, while still bounding the data volume.
+	// Workspaces are scratch space: their contents are reproducible.
+	defaultWorkspaceTTL  = 168 * time.Hour
+	defaultSweepInterval = time.Hour
 
 	defaultAddr           = ":8080"
 	defaultPath           = "/mcp"
@@ -100,6 +109,24 @@ func quotaPerDay() int {
 // URL leaks via chat history, server logs, etc.
 func pdfLinkTTL() time.Duration {
 	return durationEnv(envPDFLinkTTL, defaultPDFLinkTTL)
+}
+
+// workspaceTTL is how long a workspace file survives after its last
+// modification. Zero disables the purge; sizes are still measured, so
+// the admin UI's storage column keeps working with purging off.
+func workspaceTTL() time.Duration {
+	return durationEnv(envWorkspaceTTL, defaultWorkspaceTTL)
+}
+
+// sweepInterval is the gap between garbage-collection passes.
+func sweepInterval() time.Duration {
+	d := durationEnv(envSweepInterval, defaultSweepInterval)
+	if d <= 0 {
+		slog.Warn("sweep interval must be positive, using default",
+			"env", envSweepInterval, "default", defaultSweepInterval.String())
+		return defaultSweepInterval
+	}
+	return d
 }
 
 func durationEnv(key string, def time.Duration) time.Duration {
@@ -450,11 +477,37 @@ func serve(s *server.MCPServer, backend auth.Backend, gh *gitHubHandlers, factor
 		// the monitoring namespace only.
 		startMetricsListener()
 
+		// Garbage collection needs the database (expired links) and, for
+		// the file purge, a server-owned workspace root. AUTH=none has
+		// no store, and LocalFactory deployments do not own the
+		// filesystem, so both are skipped rather than guessed at.
+		if store != nil {
+			startSweeper(store, factory)
+		}
+
 		slog.Info("listening", "addr", addr, "path", path)
 		return http.ListenAndServe(addr, mux) //nolint:gosec // intentional plain HTTP; TLS is terminated upstream.
 	default:
 		return fmt.Errorf("unknown %s=%q (expected stdio or http)", envTransport, transport)
 	}
+}
+
+// startSweeper launches periodic garbage collection in the background:
+// expired pdf_links rows always, plus aged-out workspace files and
+// per-user size measurement when the server owns a tenant workspace
+// root. Only TenantFactory has a root to sweep — LocalFS resolves to
+// paths the client owns, which are not ours to delete.
+func startSweeper(store *authdb.Store, factory workspace.Factory) {
+	var root string
+	if tf, ok := factory.(workspace.TenantFactory); ok {
+		root = tf.Root
+	}
+	sw := sweeper.New(store, sweeper.Config{
+		Root:     root,
+		FileTTL:  workspaceTTL(),
+		Interval: sweepInterval(),
+	})
+	go sw.Run(context.Background())
 }
 
 // startMetricsListener serves Prometheus metrics on a separate port
@@ -812,12 +865,25 @@ func handlePDFDownload(factory workspace.Factory, store *authdb.Store) http.Hand
 			return
 		}
 		defer f.Close()
+		info, err := f.Stat()
+		if err != nil {
+			metrics.PDFDownloadTotal.WithLabelValues(metrics.ResultFail).Inc()
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		name := filepath.Base(link.FilePath)
 		w.Header().Set("Content-Type", "application/pdf")
-		w.Header().Set("Content-Disposition",
-			fmt.Sprintf(`inline; filename=%q`, filepath.Base(link.FilePath)))
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename=%q`, name))
 		w.Header().Set("Cache-Control", "private, max-age=300")
+		// ServeContent honours a caller-set ETag but never invents one,
+		// and a compiled PDF is fully described by (mtime, size) — a
+		// recompile changes both. With it set, conditional GETs and
+		// Range requests are handled for us.
+		w.Header().Set("ETag", fmt.Sprintf(`"%x-%x"`, info.ModTime().UnixNano(), info.Size()))
 		metrics.PDFDownloadTotal.WithLabelValues(metrics.ResultOK).Inc()
-		_, _ = io.Copy(w, f)
+		// Replaces io.Copy: gives Range (resumable downloads) and
+		// If-None-Match / If-Modified-Since handling.
+		http.ServeContent(w, r, name, info.ModTime(), f)
 	})
 }
 

--- a/cmd/typst-d2-mcp/pdfdownload_test.go
+++ b/cmd/typst-d2-mcp/pdfdownload_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+)
+
+// pdfBody is long enough that a Range request returns a recognisable
+// slice rather than the whole thing.
+const pdfBody = "%PDF-1.7 pretend this is a compiled document"
+
+// newDownloadFixture stands up a store, a tenant workspace containing
+// one PDF for gh:1, and the /d/ handler wired to both.
+func newDownloadFixture(t *testing.T) (http.Handler, *authdb.Store, string) {
+	t.Helper()
+
+	store, err := authdb.Open(filepath.Join(t.TempDir(), "auth.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	root := t.TempDir()
+	userDir := filepath.Join(root, "gh:1")
+	if err := os.MkdirAll(userDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(userDir, "out.pdf"), []byte(pdfBody), 0o600); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+
+	factory := workspace.TenantFactory{Root: root}
+	token, err := store.MintPDFLink(t.Context(), "gh:1", "out.pdf", time.Hour)
+	if err != nil {
+		t.Fatalf("MintPDFLink: %v", err)
+	}
+	return handlePDFDownload(factory, store), store, token
+}
+
+func TestPDFDownload_FullBody(t *testing.T) {
+	h, _, token := newDownloadFixture(t)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/d/"+token, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != pdfBody {
+		t.Errorf("body = %q, want %q", got, pdfBody)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/pdf" {
+		t.Errorf("Content-Type = %q, want application/pdf", got)
+	}
+	if got := rec.Header().Get("Content-Disposition"); !strings.Contains(got, `"out.pdf"`) {
+		t.Errorf("Content-Disposition = %q, want the filename in it", got)
+	}
+	if rec.Header().Get("ETag") == "" {
+		t.Error("no ETag set; conditional requests cannot work")
+	}
+}
+
+// Range support is the practical win of ServeContent over io.Copy:
+// large PDFs become resumable.
+func TestPDFDownload_RangeRequest(t *testing.T) {
+	h, _, token := newDownloadFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/d/"+token, nil)
+	req.Header.Set("Range", "bytes=0-7")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", rec.Code)
+	}
+	if got, want := rec.Body.String(), pdfBody[0:8]; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+	if got := rec.Header().Get("Content-Range"); got == "" {
+		t.Error("no Content-Range on a 206 response")
+	}
+}
+
+func TestPDFDownload_ConditionalGet(t *testing.T) {
+	h, _, token := newDownloadFixture(t)
+
+	first := httptest.NewRecorder()
+	h.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "/d/"+token, nil))
+	etag := first.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("no ETag on the first response")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/d/"+token, nil)
+	req.Header.Set("If-None-Match", etag)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("status = %d, want 304", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("304 carried a body of %d bytes", rec.Body.Len())
+	}
+}
+
+func TestPDFDownload_UnknownAndExpiredTokensAre404(t *testing.T) {
+	h, store, _ := newDownloadFixture(t)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/d/nosuchtoken", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown token status = %d, want 404", rec.Code)
+	}
+
+	// Expired tokens must be indistinguishable from unknown ones, so
+	// probing cannot tell a real token from a guess.
+	expired, err := store.MintPDFLink(t.Context(), "gh:1", "out.pdf", time.Nanosecond)
+	if err != nil {
+		t.Fatalf("MintPDFLink: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/d/"+expired, nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expired token status = %d, want 404", rec.Code)
+	}
+}
+
+// A token whose file has been swept away must 404 rather than 500.
+func TestPDFDownload_MissingFileIs404(t *testing.T) {
+	h, store, _ := newDownloadFixture(t)
+
+	token, err := store.MintPDFLink(t.Context(), "gh:1", "gone.pdf", time.Hour)
+	if err != nil {
+		t.Fatalf("MintPDFLink: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/d/"+token, nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+// The token is scoped to one user's workspace; a path escaping it must
+// not resolve even though the link row itself is valid.
+func TestPDFDownload_LinkCannotEscapeTenantRoot(t *testing.T) {
+	h, store, _ := newDownloadFixture(t)
+
+	token, err := store.MintPDFLink(t.Context(), "gh:1", "../gh:2/secret.pdf", time.Hour)
+	if err != nil {
+		t.Fatalf("MintPDFLink: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/d/"+token, nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for a traversing path", rec.Code)
+	}
+}

--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -20,5 +20,10 @@ data:
   TYPST_D2_MCP_QUOTA_PER_DAY: "1"
   TYPST_D2_MCP_COMPILE_TIMEOUT: "30s"
   TYPST_D2_MCP_MAX_INPUT_BYTES: "1048576"
+  # Workspaces are scratch space: a week is far longer than any PDF link
+  # TTL, so nothing in flight is at risk, and it bounds the 2Gi PVC.
+  # "0" would disable the file purge (sizes are still measured).
+  TYPST_D2_MCP_WORKSPACE_TTL: "168h"
+  TYPST_D2_MCP_SWEEP_INTERVAL: "1h"
   TYPST_D2_MCP_LOG_FORMAT: "json"
   TYPST_D2_MCP_LOG_LEVEL: "info"

--- a/internal/authdb/authdb.go
+++ b/internal/authdb/authdb.go
@@ -39,20 +39,18 @@ type Store struct {
 	db *sql.DB
 }
 
-// Open returns a Store backed by the SQLite file at path. The schema is
-// created in place if missing; opening an existing file is idempotent.
-// Foreign keys are enabled for referential integrity on api_keys.
+// Open returns a Store backed by the SQLite file at path, migrated to
+// the schema revision this binary expects (see migrate.go). Opening an
+// existing file is idempotent; a database newer than this binary is
+// refused with ErrSchemaTooNew rather than served against. Foreign keys
+// are enabled for referential integrity on api_keys.
 func Open(path string) (*Store, error) {
 	db, err := sql.Open("sqlite", path+"?_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)")
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
 	s := &Store{db: db}
-	if err := s.migrate(); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	if err := s.migrateOAuth(); err != nil {
+	if err := s.runMigrations(); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -61,36 +59,6 @@ func Open(path string) (*Store, error) {
 
 // Close releases the underlying SQLite connection.
 func (s *Store) Close() error { return s.db.Close() }
-
-func (s *Store) migrate() error {
-	const ddl = `
-CREATE TABLE IF NOT EXISTS users (
-  id           INTEGER PRIMARY KEY AUTOINCREMENT,
-  github_id    INTEGER NOT NULL UNIQUE,
-  github_login TEXT    NOT NULL,
-  email        TEXT,
-  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS api_keys (
-  id           INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  key_hash     BLOB    NOT NULL UNIQUE,
-  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  last_used_at TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS compiles (
-  user_id  TEXT    NOT NULL,
-  utc_date TEXT    NOT NULL,
-  count    INTEGER NOT NULL,
-  PRIMARY KEY(user_id, utc_date)
-);
-`
-	_, err := s.db.Exec(ddl)
-	if err != nil {
-		return fmt.Errorf("migrate schema: %w", err)
-	}
-	return nil
-}
 
 // UpsertGitHubUser inserts or updates a user keyed by their GitHub
 // numeric ID and returns the local user.id. Login/email are refreshed

--- a/internal/authdb/gc.go
+++ b/internal/authdb/gc.go
@@ -1,0 +1,119 @@
+package authdb
+
+// Garbage-collection queries backing the background sweeper, plus the
+// per-user workspace usage cache it populates.
+//
+// LookupPDFLink already prunes an expired row when someone fetches that
+// token, but a link that is minted and never clicked is never read, so
+// nothing ever deletes it. DeleteExpiredPDFLinks is the pass that
+// catches those.
+//
+// Callers pass `now` explicitly rather than having these read the clock,
+// matching IncrementCompile's utcDate parameter: it lets tests cover
+// expiry without sleeping.
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+)
+
+// WorkspaceUsage is a cached measurement of one user's workspace size.
+// The admin UI reads these rather than walking the filesystem on page
+// load; ComputedAt is rendered alongside so a stale number reads as
+// stale rather than as truth.
+type WorkspaceUsage struct {
+	UserID     string
+	Bytes      int64
+	ComputedAt time.Time
+}
+
+// DeleteExpiredPDFLinks removes every link whose expires_at has passed,
+// returning the number deleted. Safe to run concurrently with
+// LookupPDFLink's opportunistic delete of the same row — both are
+// single-statement DELETEs against the primary key, so the loser simply
+// affects zero rows.
+func (s *Store) DeleteExpiredPDFLinks(ctx context.Context, now time.Time) (int64, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM pdf_links WHERE expires_at < ?`, now.UTC())
+	if err != nil {
+		return 0, fmt.Errorf("delete expired pdf links: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, nil // driver did not report; the delete still happened
+	}
+	return n, nil
+}
+
+// LivePersistedPaths returns, per user id, the set of workspace-relative
+// file paths that still have an unexpired download link. The file purge
+// consults this so a PDF someone is about to fetch is never deleted out
+// from under a live URL, however old the file is.
+//
+// Paths are cleaned so comparisons against walked filesystem paths are
+// exact ("./out.pdf" and "out.pdf" are the same file).
+func (s *Store) LivePersistedPaths(ctx context.Context, now time.Time) (map[string]map[string]bool, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT user_id, file_path FROM pdf_links WHERE expires_at >= ?`, now.UTC())
+	if err != nil {
+		return nil, fmt.Errorf("query live pdf links: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	live := make(map[string]map[string]bool)
+	for rows.Next() {
+		var userID, path string
+		if err := rows.Scan(&userID, &path); err != nil {
+			return nil, fmt.Errorf("scan live pdf link: %w", err)
+		}
+		if live[userID] == nil {
+			live[userID] = make(map[string]bool)
+		}
+		live[userID][filepath.Clean(path)] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate live pdf links: %w", err)
+	}
+	return live, nil
+}
+
+// RecordWorkspaceUsage upserts the cached size for one user.
+func (s *Store) RecordWorkspaceUsage(ctx context.Context, userID string, bytes int64, at time.Time) error {
+	if userID == "" {
+		return fmt.Errorf("userID is required")
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO workspace_usage(user_id, bytes, computed_at) VALUES(?, ?, ?)
+ON CONFLICT(user_id) DO UPDATE SET bytes = excluded.bytes, computed_at = excluded.computed_at
+`, userID, bytes, at.UTC()); err != nil {
+		return fmt.Errorf("record workspace usage: %w", err)
+	}
+	return nil
+}
+
+// WorkspaceUsageByUser returns every cached measurement, keyed by user
+// id. A user absent from the map has not been measured yet — the admin
+// UI renders that as "not yet computed" rather than as zero.
+func (s *Store) WorkspaceUsageByUser(ctx context.Context) (map[string]WorkspaceUsage, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT user_id, bytes, computed_at FROM workspace_usage`)
+	if err != nil {
+		return nil, fmt.Errorf("query workspace usage: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]WorkspaceUsage)
+	for rows.Next() {
+		var u WorkspaceUsage
+		if err := rows.Scan(&u.UserID, &u.Bytes, &u.ComputedAt); err != nil {
+			return nil, fmt.Errorf("scan workspace usage: %w", err)
+		}
+		out[u.UserID] = u
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspace usage: %w", err)
+	}
+	return out, nil
+}

--- a/internal/authdb/gc_test.go
+++ b/internal/authdb/gc_test.go
@@ -1,0 +1,185 @@
+package authdb
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDeleteExpiredPDFLinks_OnlyExpired(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+
+	// Both live now; the sweep runs with a clock two hours ahead, by
+	// which point only the long-lived one survives.
+	short, err := s.MintPDFLink(ctx, "gh:1", "short.pdf", time.Hour)
+	if err != nil {
+		t.Fatalf("mint short: %v", err)
+	}
+	long, err := s.MintPDFLink(ctx, "gh:1", "long.pdf", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("mint long: %v", err)
+	}
+
+	n, err := s.DeleteExpiredPDFLinks(ctx, time.Now().UTC().Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("DeleteExpiredPDFLinks: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("deleted = %d, want 1", n)
+	}
+
+	if _, err := s.LookupPDFLink(ctx, short); !errors.Is(err, ErrPDFLinkNotFound) {
+		t.Errorf("short link err = %v, want ErrPDFLinkNotFound", err)
+	}
+	if _, err := s.LookupPDFLink(ctx, long); err != nil {
+		t.Errorf("long link should have survived: %v", err)
+	}
+}
+
+func TestDeleteExpiredPDFLinks_EmptyTable(t *testing.T) {
+	s := newStore(t)
+	n, err := s.DeleteExpiredPDFLinks(t.Context(), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("DeleteExpiredPDFLinks on empty table: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("deleted = %d, want 0", n)
+	}
+}
+
+// The sweeper's DELETE and LookupPDFLink's opportunistic delete can race
+// on the same expired row. Neither may error, and the row must end up
+// gone either way.
+func TestDeleteExpiredPDFLinks_RacesWithLookup(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+
+	// 1ns TTL: expired by the time the insert has round-tripped.
+	token, err := s.MintPDFLink(ctx, "gh:1", "out.pdf", time.Nanosecond)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	var (
+		wg              sync.WaitGroup
+		sweepErr, lookErr error
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, sweepErr = s.DeleteExpiredPDFLinks(ctx, time.Now().UTC())
+	}()
+	go func() {
+		defer wg.Done()
+		_, lookErr = s.LookupPDFLink(ctx, token)
+	}()
+	wg.Wait()
+
+	if sweepErr != nil {
+		t.Errorf("sweep errored during race: %v", sweepErr)
+	}
+	if lookErr != nil && !errors.Is(lookErr, ErrPDFLinkNotFound) {
+		t.Errorf("lookup errored during race: %v", lookErr)
+	}
+	if _, err := s.LookupPDFLink(ctx, token); !errors.Is(err, ErrPDFLinkNotFound) {
+		t.Errorf("expired row survived the race: %v", err)
+	}
+}
+
+func TestLivePersistedPaths_GroupsAndCleans(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+	// A minute ahead: past the 1ns link below, well short of the hour-long
+	// ones. Reading the clock before minting would leave the 1ns link
+	// still nominally live.
+	now := time.Now().UTC().Add(time.Minute)
+
+	if _, err := s.MintPDFLink(ctx, "gh:1", "./out.pdf", time.Hour); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if _, err := s.MintPDFLink(ctx, "gh:1", "sub/deep.pdf", time.Hour); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if _, err := s.MintPDFLink(ctx, "gh:2", "other.pdf", time.Hour); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	// Expired: must not appear in the live set.
+	if _, err := s.MintPDFLink(ctx, "gh:1", "stale.pdf", time.Nanosecond); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	live, err := s.LivePersistedPaths(ctx, now)
+	if err != nil {
+		t.Fatalf("LivePersistedPaths: %v", err)
+	}
+
+	// "./out.pdf" must come back cleaned so it compares equal to a
+	// walked path of "out.pdf".
+	if !live["gh:1"]["out.pdf"] {
+		t.Errorf("gh:1 live set missing cleaned out.pdf: %v", live["gh:1"])
+	}
+	if !live["gh:1"]["sub/deep.pdf"] {
+		t.Errorf("gh:1 live set missing sub/deep.pdf: %v", live["gh:1"])
+	}
+	if live["gh:1"]["stale.pdf"] {
+		t.Error("expired link appeared in the live set")
+	}
+	if !live["gh:2"]["other.pdf"] {
+		t.Errorf("gh:2 live set wrong: %v", live["gh:2"])
+	}
+	if len(live["gh:1"]) != 2 {
+		t.Errorf("gh:1 live set size = %d, want 2", len(live["gh:1"]))
+	}
+}
+
+func TestWorkspaceUsage_UpsertAndRead(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+	first := time.Now().UTC().Truncate(time.Second)
+
+	if err := s.RecordWorkspaceUsage(ctx, "gh:1", 1024, first); err != nil {
+		t.Fatalf("RecordWorkspaceUsage: %v", err)
+	}
+	usage, err := s.WorkspaceUsageByUser(ctx)
+	if err != nil {
+		t.Fatalf("WorkspaceUsageByUser: %v", err)
+	}
+	if got := usage["gh:1"].Bytes; got != 1024 {
+		t.Errorf("bytes = %d, want 1024", got)
+	}
+
+	// Second pass overwrites rather than duplicating.
+	second := first.Add(time.Hour)
+	if err := s.RecordWorkspaceUsage(ctx, "gh:1", 2048, second); err != nil {
+		t.Fatalf("second RecordWorkspaceUsage: %v", err)
+	}
+	usage, err = s.WorkspaceUsageByUser(ctx)
+	if err != nil {
+		t.Fatalf("WorkspaceUsageByUser: %v", err)
+	}
+	if len(usage) != 1 {
+		t.Errorf("usage rows = %d, want 1 (upsert duplicated)", len(usage))
+	}
+	if got := usage["gh:1"].Bytes; got != 2048 {
+		t.Errorf("bytes = %d, want 2048", got)
+	}
+	if !usage["gh:1"].ComputedAt.After(first) {
+		t.Errorf("computed_at did not advance: %v not after %v",
+			usage["gh:1"].ComputedAt, first)
+	}
+}
+
+// An unmeasured user must be absent rather than zero, so the admin UI
+// can tell "empty workspace" from "not yet swept".
+func TestWorkspaceUsage_UnmeasuredUserAbsent(t *testing.T) {
+	s := newStore(t)
+	usage, err := s.WorkspaceUsageByUser(t.Context())
+	if err != nil {
+		t.Fatalf("WorkspaceUsageByUser: %v", err)
+	}
+	if _, ok := usage["gh:never"]; ok {
+		t.Error("unmeasured user present in usage map")
+	}
+}

--- a/internal/authdb/migrate.go
+++ b/internal/authdb/migrate.go
@@ -1,0 +1,283 @@
+package authdb
+
+// Versioned schema migrations.
+//
+// The schema used to be two idempotent `CREATE TABLE IF NOT EXISTS`
+// blobs run on every Open. That could create a missing table but could
+// never alter an existing one — an ALTER expressed that way is a silent
+// no-op against a deployed database, which is a trap rather than a
+// limitation. Everything now moves through an ordered list of revisions
+// recorded in schema_migrations.
+//
+// Rules that keep this safe on a live volume, where api_keys holds
+// unrecoverable sha256 hashes:
+//
+//   - Each revision runs in its own transaction. A failure rolls that
+//     revision back and aborts Open, so the process never serves against
+//     a half-applied schema. A crashlooping pod is the correct outcome
+//     when the alternative is silent corruption.
+//   - A database recorded at a higher revision than this binary knows
+//     about is refused (ErrSchemaTooNew). An old binary against a new
+//     schema is undefined behaviour: it may read columns that moved or
+//     write rows violating constraints it has never heard of.
+//   - A pre-versioning database (tables present, no schema_migrations)
+//     is stamped at revision 1 rather than re-running revision 1's DDL.
+//
+// Adding a migration: append to `migrations` with the next revision
+// number and never edit a revision that has shipped — an already-migrated
+// database will not re-run it, so an edit silently diverges old
+// deployments from new ones.
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrSchemaTooNew reports a database written by a newer binary than
+// this one. Returned by Open; the caller is expected to exit rather
+// than continue.
+var ErrSchemaTooNew = errors.New("database schema is newer than this binary supports")
+
+// migration is one ordered, atomic schema revision. Statements run in
+// order inside a single transaction.
+type migration struct {
+	revision int
+	name     string
+	stmts    []string
+}
+
+// migrations is the ordered revision list. Revision 1 is the schema as
+// it stood before versioning existed, so pre-existing databases can be
+// stamped at 1 without re-running anything.
+var migrations = []migration{
+	{
+		revision: 1,
+		name:     "initial schema",
+		stmts: []string{
+			`CREATE TABLE IF NOT EXISTS users (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  github_id    INTEGER NOT NULL UNIQUE,
+  github_login TEXT    NOT NULL,
+  email        TEXT,
+  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`,
+			`CREATE TABLE IF NOT EXISTS api_keys (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  key_hash     BLOB    NOT NULL UNIQUE,
+  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_used_at TIMESTAMP
+)`,
+			`CREATE TABLE IF NOT EXISTS compiles (
+  user_id  TEXT    NOT NULL,
+  utc_date TEXT    NOT NULL,
+  count    INTEGER NOT NULL,
+  PRIMARY KEY(user_id, utc_date)
+)`,
+			`CREATE TABLE IF NOT EXISTS oauth_clients (
+  client_id                  TEXT PRIMARY KEY,
+  client_name                TEXT NOT NULL,
+  redirect_uris              TEXT NOT NULL,
+  token_endpoint_auth_method TEXT NOT NULL DEFAULT 'none',
+  created_at                 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`,
+			`CREATE TABLE IF NOT EXISTS oauth_authorize_sessions (
+  session_id            TEXT PRIMARY KEY,
+  client_id             TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
+  redirect_uri          TEXT NOT NULL,
+  code_challenge        TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL DEFAULT 'S256',
+  scope                 TEXT,
+  client_state          TEXT NOT NULL,
+  expires_at            TIMESTAMP NOT NULL
+)`,
+			`CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
+  code                  TEXT PRIMARY KEY,
+  user_id               INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  client_id             TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
+  redirect_uri          TEXT NOT NULL,
+  code_challenge        TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL DEFAULT 'S256',
+  scope                 TEXT,
+  used                  INTEGER NOT NULL DEFAULT 0,
+  expires_at            TIMESTAMP NOT NULL
+)`,
+			`CREATE TABLE IF NOT EXISTS pdf_links (
+  token       TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  file_path   TEXT NOT NULL,
+  created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at  TIMESTAMP NOT NULL
+)`,
+		},
+	},
+	{
+		revision: 2,
+		name:     "per-user quota override",
+		stmts: []string{
+			// NULL inherits the env default, 0 means unlimited (matching
+			// IncrementCompile's existing limit <= 0 path), N caps at N.
+			`ALTER TABLE users ADD COLUMN quota_per_day INTEGER NULL`,
+		},
+	},
+	{
+		revision: 3,
+		name:     "invites",
+		stmts: []string{
+			// Keyed by login, not user id: an invite necessarily exists
+			// before the person has ever signed in, when no github_id is
+			// known yet. Stored lowercase; see NormalizeLogin.
+			`CREATE TABLE IF NOT EXISTS invites (
+  github_login TEXT PRIMARY KEY,
+  invited_by   TEXT NOT NULL,
+  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`,
+		},
+	},
+	{
+		revision: 4,
+		name:     "admin audit log",
+		stmts: []string{
+			`CREATE TABLE IF NOT EXISTS admin_audit (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  actor_login  TEXT NOT NULL,
+  action       TEXT NOT NULL,
+  target_login TEXT NOT NULL,
+  detail       TEXT NOT NULL DEFAULT '',
+  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`,
+			`CREATE INDEX IF NOT EXISTS idx_admin_audit_created_at
+   ON admin_audit(created_at DESC)`,
+		},
+	},
+	{
+		revision: 5,
+		name:     "per-user workspace storage cache",
+		stmts: []string{
+			// Written by the workspace sweeper, read by the admin UI, so
+			// rendering the user list never walks the filesystem.
+			`CREATE TABLE IF NOT EXISTS workspace_usage (
+  user_id     TEXT PRIMARY KEY,
+  bytes       INTEGER NOT NULL,
+  computed_at TIMESTAMP NOT NULL
+)`,
+		},
+	},
+}
+
+// latestRevision is the highest revision this binary knows how to apply.
+func latestRevision() int {
+	if len(migrations) == 0 {
+		return 0
+	}
+	return migrations[len(migrations)-1].revision
+}
+
+// runMigrations brings the database up to latestRevision, or returns an
+// error explaining why it cannot. Safe to call on every Open: current
+// databases do no work.
+func (s *Store) runMigrations() error {
+	if _, err := s.db.Exec(`
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  revision   INTEGER PRIMARY KEY,
+  name       TEXT NOT NULL,
+  applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`); err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+
+	current, err := s.SchemaRevision()
+	if err != nil {
+		return err
+	}
+
+	// Pre-versioning database: the tables are already there from the old
+	// IF NOT EXISTS blobs, so revision 1 has effectively been applied.
+	// Stamp it rather than re-running the DDL, which would succeed but
+	// misrepresent history.
+	if current == 0 {
+		legacy, err := s.tableExists("users")
+		if err != nil {
+			return err
+		}
+		if legacy {
+			if _, err := s.db.Exec(
+				`INSERT INTO schema_migrations(revision, name) VALUES(1, ?)`,
+				"initial schema (baselined)",
+			); err != nil {
+				return fmt.Errorf("baseline pre-versioning database: %w", err)
+			}
+			current = 1
+		}
+	}
+
+	if latest := latestRevision(); current > latest {
+		return fmt.Errorf("%w: database is at revision %d, this binary supports %d — "+
+			"roll forward or restore a backup", ErrSchemaTooNew, current, latest)
+	}
+
+	for _, m := range migrations {
+		if m.revision <= current {
+			continue
+		}
+		if err := s.applyMigration(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyMigration runs one revision atomically: every statement plus the
+// schema_migrations bookkeeping row commit together, or nothing does.
+func (s *Store) applyMigration(m migration) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("migration %d (%s): begin: %w", m.revision, m.name, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for i, stmt := range m.stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("migration %d (%s): statement %d: %w",
+				m.revision, m.name, i+1, err)
+		}
+	}
+	if _, err := tx.Exec(
+		`INSERT INTO schema_migrations(revision, name) VALUES(?, ?)`,
+		m.revision, m.name,
+	); err != nil {
+		return fmt.Errorf("migration %d (%s): record revision: %w", m.revision, m.name, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("migration %d (%s): commit: %w", m.revision, m.name, err)
+	}
+	return nil
+}
+
+// SchemaRevision reports the highest applied revision, or 0 for a
+// database that has never been migrated.
+func (s *Store) SchemaRevision() (int, error) {
+	var rev sql.NullInt64
+	if err := s.db.QueryRow(`SELECT MAX(revision) FROM schema_migrations`).Scan(&rev); err != nil {
+		return 0, fmt.Errorf("read schema revision: %w", err)
+	}
+	if !rev.Valid {
+		return 0, nil
+	}
+	return int(rev.Int64), nil
+}
+
+func (s *Store) tableExists(name string) (bool, error) {
+	var found string
+	err := s.db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`, name,
+	).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check table %s: %w", name, err)
+	}
+	return true, nil
+}

--- a/internal/authdb/migrate_test.go
+++ b/internal/authdb/migrate_test.go
@@ -1,0 +1,330 @@
+package authdb
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withMigrations swaps the package migration list for the duration of a
+// test. Tests that need to exercise applying, ordering, or failing a
+// migration cannot use the real list — every shipped revision is already
+// applied by the time Open returns.
+func withMigrations(t *testing.T, list []migration) {
+	t.Helper()
+	saved := migrations
+	migrations = list
+	t.Cleanup(func() { migrations = saved })
+}
+
+// openRaw opens the SQLite file without running migrations, so tests can
+// inspect or corrupt schema state directly.
+func openRaw(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestMigrations_FreshDatabaseReachesLatest(t *testing.T) {
+	s := newStore(t)
+
+	rev, err := s.SchemaRevision()
+	if err != nil {
+		t.Fatalf("SchemaRevision: %v", err)
+	}
+	if want := latestRevision(); rev != want {
+		t.Errorf("revision = %d, want %d", rev, want)
+	}
+}
+
+// Every table the pre-versioning schema created must still exist after a
+// migration from empty, so revision 1 is a faithful transcription.
+func TestMigrations_CreatesAllLegacyTables(t *testing.T) {
+	s := newStore(t)
+
+	for _, table := range []string{
+		"users", "api_keys", "compiles",
+		"oauth_clients", "oauth_authorize_sessions", "oauth_authorization_codes",
+		"pdf_links",
+	} {
+		exists, err := s.tableExists(table)
+		if err != nil {
+			t.Fatalf("tableExists(%s): %v", table, err)
+		}
+		if !exists {
+			t.Errorf("table %q missing after migration from empty", table)
+		}
+	}
+}
+
+// The api_keys -> users cascade is load-bearing for user deletion, and a
+// transcription slip in revision 1 would silently drop it.
+func TestMigrations_ForeignKeyCascadePreserved(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+
+	uid, err := s.UpsertGitHubUser(ctx, 42, "octocat", "")
+	if err != nil {
+		t.Fatalf("UpsertGitHubUser: %v", err)
+	}
+	if _, err := s.IssueAPIKey(ctx, uid); err != nil {
+		t.Fatalf("IssueAPIKey: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM users WHERE id = ?`, uid); err != nil {
+		t.Fatalf("delete user: %v", err)
+	}
+
+	var keys int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM api_keys WHERE user_id = ?`, uid).Scan(&keys); err != nil {
+		t.Fatalf("count keys: %v", err)
+	}
+	if keys != 0 {
+		t.Errorf("api_keys rows after user delete = %d, want 0 (cascade lost)", keys)
+	}
+}
+
+func TestMigrations_ReopenIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.sqlite")
+
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	rev1, _ := first.SchemaRevision()
+	_ = first.Close()
+
+	second, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+	rev2, _ := second.SchemaRevision()
+
+	if rev1 != rev2 {
+		t.Errorf("revision changed across reopen: %d -> %d", rev1, rev2)
+	}
+
+	// Each revision must be recorded exactly once — a re-application
+	// would either fail on the primary key or duplicate history.
+	var rows int
+	if err := second.db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&rows); err != nil {
+		t.Fatalf("count schema_migrations: %v", err)
+	}
+	if rows != latestRevision() {
+		t.Errorf("schema_migrations rows = %d, want %d", rows, latestRevision())
+	}
+}
+
+// The upgrade path that matters in production: a volume written by the
+// old CREATE TABLE IF NOT EXISTS build, opened by this one.
+func TestMigrations_BaselinesPreVersioningDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.sqlite")
+
+	// Stand up the legacy schema by hand, including a user row that must
+	// survive, and deliberately no schema_migrations table.
+	raw := openRaw(t, path)
+	for _, stmt := range migrations[0].stmts {
+		if _, err := raw.Exec(stmt); err != nil {
+			t.Fatalf("legacy DDL: %v", err)
+		}
+	}
+	if _, err := raw.Exec(
+		`INSERT INTO users(github_id, github_login, email) VALUES(7, 'legacy', 'l@example.com')`,
+	); err != nil {
+		t.Fatalf("seed legacy user: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw: %v", err)
+	}
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open legacy database: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	rev, _ := s.SchemaRevision()
+	if want := latestRevision(); rev != want {
+		t.Errorf("revision = %d, want %d", rev, want)
+	}
+
+	// Revision 1 must be recorded as baselined, not re-run.
+	var name string
+	if err := s.db.QueryRow(
+		`SELECT name FROM schema_migrations WHERE revision = 1`).Scan(&name); err != nil {
+		t.Fatalf("read revision 1 row: %v", err)
+	}
+	if !strings.Contains(name, "baselined") {
+		t.Errorf("revision 1 name = %q, want it marked as baselined", name)
+	}
+
+	// The pre-existing row survives, and later revisions applied on top.
+	var login string
+	if err := s.db.QueryRow(
+		`SELECT github_login FROM users WHERE github_id = 7`).Scan(&login); err != nil {
+		t.Fatalf("legacy user lost: %v", err)
+	}
+	if login != "legacy" {
+		t.Errorf("github_login = %q, want %q", login, "legacy")
+	}
+	var quota sql.NullInt64
+	if err := s.db.QueryRow(
+		`SELECT quota_per_day FROM users WHERE github_id = 7`).Scan(&quota); err != nil {
+		t.Fatalf("quota_per_day column not applied to legacy database: %v", err)
+	}
+	if quota.Valid {
+		t.Errorf("quota_per_day = %v, want NULL for an untouched legacy user", quota.Int64)
+	}
+}
+
+// An ALTER on an existing database is exactly what the old DDL-blob
+// approach could not express, so it gets a direct test.
+func TestMigrations_AlterAppliesToExistingDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.sqlite")
+
+	base := []migration{{
+		revision: 1,
+		name:     "base",
+		stmts:    []string{`CREATE TABLE widgets (id INTEGER PRIMARY KEY)`},
+	}}
+	withMigrations(t, base)
+
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if _, err := first.db.Exec(`INSERT INTO widgets(id) VALUES(1)`); err != nil {
+		t.Fatalf("seed widgets: %v", err)
+	}
+	_ = first.Close()
+
+	// Second binary knows one more revision.
+	withMigrations(t, append(base, migration{
+		revision: 2,
+		name:     "add colour",
+		stmts:    []string{`ALTER TABLE widgets ADD COLUMN colour TEXT`},
+	}))
+
+	second, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+
+	if rev, _ := second.SchemaRevision(); rev != 2 {
+		t.Errorf("revision = %d, want 2", rev)
+	}
+	var colour sql.NullString
+	if err := second.db.QueryRow(`SELECT colour FROM widgets WHERE id = 1`).Scan(&colour); err != nil {
+		t.Fatalf("ALTER did not apply to existing row: %v", err)
+	}
+}
+
+// Revisions must be ascending and unique: applyMigration skips anything
+// <= current, so an out-of-order or duplicated entry would be silently
+// skipped rather than rejected.
+func TestMigrations_OrderedAndUnique(t *testing.T) {
+	seen := map[int]bool{}
+	prev := 0
+	for i, m := range migrations {
+		if m.revision <= prev {
+			t.Errorf("migrations[%d] revision %d is not greater than previous %d",
+				i, m.revision, prev)
+		}
+		if seen[m.revision] {
+			t.Errorf("duplicate revision %d", m.revision)
+		}
+		if m.name == "" {
+			t.Errorf("migrations[%d] (revision %d) has no name", i, m.revision)
+		}
+		if len(m.stmts) == 0 {
+			t.Errorf("migrations[%d] (revision %d) has no statements", i, m.revision)
+		}
+		seen[m.revision] = true
+		prev = m.revision
+	}
+}
+
+func TestMigrations_FailureRollsBackAndAbortsOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.sqlite")
+
+	withMigrations(t, []migration{
+		{revision: 1, name: "base", stmts: []string{`CREATE TABLE widgets (id INTEGER PRIMARY KEY)`}},
+		{revision: 2, name: "half broken", stmts: []string{
+			`CREATE TABLE gadgets (id INTEGER PRIMARY KEY)`, // valid, must be rolled back
+			`THIS IS NOT SQL`,                               // fails
+		}},
+	})
+
+	s, err := Open(path)
+	if err == nil {
+		_ = s.Close()
+		t.Fatal("Open succeeded despite a failing migration")
+	}
+	if s != nil {
+		t.Error("Open returned a non-nil Store alongside an error")
+	}
+	// The error must name the revision so an operator can find it.
+	if !strings.Contains(err.Error(), "migration 2") {
+		t.Errorf("error does not name the failing revision: %v", err)
+	}
+	if !strings.Contains(err.Error(), "half broken") {
+		t.Errorf("error does not name the failing migration: %v", err)
+	}
+
+	// Revision stays at 1 and the partial statement is gone.
+	raw := openRaw(t, path)
+	var rev sql.NullInt64
+	if err := raw.QueryRow(`SELECT MAX(revision) FROM schema_migrations`).Scan(&rev); err != nil {
+		t.Fatalf("read revision: %v", err)
+	}
+	if !rev.Valid || rev.Int64 != 1 {
+		t.Errorf("recorded revision = %v, want 1", rev)
+	}
+	var name string
+	err = raw.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='gadgets'`).Scan(&name)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("gadgets table survived a failed migration (rollback did not happen): %v", err)
+	}
+}
+
+func TestMigrations_RefusesNewerDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.sqlite")
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	future := latestRevision() + 1
+	if _, err := s.db.Exec(
+		`INSERT INTO schema_migrations(revision, name) VALUES(?, 'from the future')`, future,
+	); err != nil {
+		t.Fatalf("stamp future revision: %v", err)
+	}
+	_ = s.Close()
+
+	reopened, err := Open(path)
+	if err == nil {
+		_ = reopened.Close()
+		t.Fatal("Open succeeded against a newer-than-supported database")
+	}
+	if !errors.Is(err, ErrSchemaTooNew) {
+		t.Errorf("err = %v, want ErrSchemaTooNew", err)
+	}
+	// Both numbers belong in the message: the operator needs to know how
+	// far ahead the volume is before choosing to roll forward or restore.
+	for _, want := range []string{fmt.Sprint(future), fmt.Sprint(latestRevision())} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention revision %s", err.Error(), want)
+		}
+	}
+}

--- a/internal/authdb/oauth.go
+++ b/internal/authdb/oauth.go
@@ -84,49 +84,9 @@ type AuthorizationCode struct {
 	Scope               string
 }
 
-func (s *Store) migrateOAuth() error {
-	const ddl = `
-CREATE TABLE IF NOT EXISTS oauth_clients (
-  client_id                  TEXT PRIMARY KEY,
-  client_name                TEXT NOT NULL,
-  redirect_uris              TEXT NOT NULL, -- JSON-encoded array
-  token_endpoint_auth_method TEXT NOT NULL DEFAULT 'none',
-  created_at                 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE IF NOT EXISTS oauth_authorize_sessions (
-  session_id            TEXT PRIMARY KEY,
-  client_id             TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
-  redirect_uri          TEXT NOT NULL,
-  code_challenge        TEXT NOT NULL,
-  code_challenge_method TEXT NOT NULL DEFAULT 'S256',
-  scope                 TEXT,
-  client_state          TEXT NOT NULL,
-  expires_at            TIMESTAMP NOT NULL
-);
-CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
-  code                  TEXT PRIMARY KEY,
-  user_id               INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  client_id             TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
-  redirect_uri          TEXT NOT NULL,
-  code_challenge        TEXT NOT NULL,
-  code_challenge_method TEXT NOT NULL DEFAULT 'S256',
-  scope                 TEXT,
-  used                  INTEGER NOT NULL DEFAULT 0,
-  expires_at            TIMESTAMP NOT NULL
-);
-CREATE TABLE IF NOT EXISTS pdf_links (
-  token       TEXT PRIMARY KEY,
-  user_id     TEXT NOT NULL,         -- identity.Identity.UserID (e.g. "gh:42")
-  file_path   TEXT NOT NULL,         -- workspace-relative path to the PDF
-  created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  expires_at  TIMESTAMP NOT NULL
-);
-`
-	if _, err := s.db.Exec(ddl); err != nil {
-		return fmt.Errorf("migrate oauth schema: %w", err)
-	}
-	return nil
-}
+// The oauth_clients, oauth_authorize_sessions, oauth_authorization_codes
+// and pdf_links tables are created by revision 1 in migrate.go, alongside
+// the rest of the schema.
 
 // RegisterClient persists a dynamic client registration and returns
 // the assigned client_id. Caller is responsible for validating the

--- a/internal/sweeper/sweeper.go
+++ b/internal/sweeper/sweeper.go
@@ -1,0 +1,247 @@
+// Package sweeper reclaims state that would otherwise grow without
+// bound on the server's data volume: expired PDF download links, and
+// aged-out files in per-user workspaces.
+//
+// Workspaces are treated as scratch space. Everything in them is
+// reproducible — the source can be re-uploaded and recompiled — so files
+// are purged on age alone, with no distinction between put_file uploads
+// and generated PDFs. The one exception is a file with an unexpired
+// download link pointing at it: those are kept however old they are, so
+// a URL already in someone's hands never breaks.
+//
+// The same pass records each user's total workspace size. The walk is
+// already happening, and caching the result means the admin UI never
+// does disk I/O to render a page.
+package sweeper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Store is the subset of authdb.Store the sweeper needs.
+type Store interface {
+	DeleteExpiredPDFLinks(ctx context.Context, now time.Time) (int64, error)
+	LivePersistedPaths(ctx context.Context, now time.Time) (map[string]map[string]bool, error)
+	RecordWorkspaceUsage(ctx context.Context, userID string, bytes int64, at time.Time) error
+}
+
+// Config controls one sweeper instance.
+type Config struct {
+	// Root is the tenant workspace root, whose immediate children are
+	// per-user directories. Empty disables all filesystem work, leaving
+	// only link sweeping — the case for LocalFactory deployments where
+	// the server does not own the filesystem.
+	Root string
+
+	// FileTTL is how long a workspace file survives after its last
+	// modification. Zero disables the purge; usage is still measured and
+	// recorded, so the admin UI works even with purging off.
+	FileTTL time.Duration
+
+	// Interval is the gap between passes.
+	Interval time.Duration
+}
+
+// Result reports what one pass did.
+type Result struct {
+	LinksDeleted  int64
+	FilesDeleted  int
+	BytesDeleted  int64
+	UsersMeasured int
+}
+
+// Sweeper runs periodic garbage collection.
+type Sweeper struct {
+	store Store
+	cfg   Config
+}
+
+// New returns a Sweeper. store must be non-nil; cfg.Root may be empty.
+func New(store Store, cfg Config) *Sweeper {
+	return &Sweeper{store: store, cfg: cfg}
+}
+
+// Run sweeps once immediately, then on every tick until ctx is done.
+// Intended to be started in a goroutine. A failing pass is logged and
+// the loop continues: transient database or filesystem trouble should
+// not silently stop garbage collection for the life of the process.
+func (s *Sweeper) Run(ctx context.Context) {
+	slog.Info("sweeper started",
+		"interval", s.cfg.Interval.String(),
+		"file_ttl", s.cfg.FileTTL.String(),
+		"purge_enabled", s.cfg.FileTTL > 0,
+		"root", s.cfg.Root,
+	)
+	ticker := time.NewTicker(s.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		res, err := s.SweepOnce(ctx, time.Now().UTC())
+		if err != nil {
+			slog.Error("sweep failed", "err", err)
+		} else if res.LinksDeleted > 0 || res.FilesDeleted > 0 {
+			slog.Info("sweep complete",
+				"links_deleted", res.LinksDeleted,
+				"files_deleted", res.FilesDeleted,
+				"bytes_deleted", res.BytesDeleted,
+				"users_measured", res.UsersMeasured,
+			)
+		}
+		select {
+		case <-ctx.Done():
+			slog.Info("sweeper stopped")
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// SweepOnce runs a single pass. Exported so tests can drive it without a
+// clock, and so `now` stays explicit rather than read from inside.
+func (s *Sweeper) SweepOnce(ctx context.Context, now time.Time) (Result, error) {
+	var res Result
+
+	deleted, err := s.store.DeleteExpiredPDFLinks(ctx, now)
+	if err != nil {
+		return res, fmt.Errorf("sweep links: %w", err)
+	}
+	res.LinksDeleted = deleted
+
+	if s.cfg.Root == "" {
+		return res, nil
+	}
+
+	// Read the live set *after* deleting expired rows: anything still
+	// present is genuinely unexpired, so a file is only ever protected
+	// by a link that would actually resolve.
+	live, err := s.store.LivePersistedPaths(ctx, now)
+	if err != nil {
+		return res, fmt.Errorf("read live links: %w", err)
+	}
+
+	entries, err := os.ReadDir(s.cfg.Root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return res, nil // nothing compiled yet
+		}
+		return res, fmt.Errorf("read workspace root: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		userID := entry.Name()
+		userRes, err := s.sweepUser(ctx, userID, live[userID], now)
+		if err != nil {
+			// One user's trouble must not stop the others from being
+			// swept or measured.
+			slog.Error("sweep user workspace failed", "user", userID, "err", err)
+			continue
+		}
+		res.FilesDeleted += userRes.FilesDeleted
+		res.BytesDeleted += userRes.BytesDeleted
+		res.UsersMeasured++
+	}
+	return res, nil
+}
+
+// sweepUser purges and measures one user's workspace. Paths are walked
+// from the user's own directory down, and symlinks are never followed
+// (fs.WalkDir does not), so the pass cannot reach outside the tenant
+// root even if a symlink inside it points elsewhere.
+func (s *Sweeper) sweepUser(ctx context.Context, userID string, protected map[string]bool, now time.Time) (Result, error) {
+	var (
+		res        Result
+		totalBytes int64
+	)
+	userRoot := filepath.Join(s.cfg.Root, userID)
+	cutoff := now.Add(-s.cfg.FileTTL)
+
+	err := filepath.WalkDir(userRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil // vanished mid-walk; nothing to do
+			}
+			return err
+		}
+		// Irregular entries (symlinks, sockets) are neither measured nor
+		// purged: their size is meaningless and deleting them is not the
+		// sweeper's job.
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(userRoot, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.Clean(rel)
+
+		if s.cfg.FileTTL > 0 && info.ModTime().Before(cutoff) && !protected[rel] {
+			size := info.Size()
+			if err := os.Remove(path); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return nil
+				}
+				return fmt.Errorf("remove %s: %w", rel, err)
+			}
+			res.FilesDeleted++
+			res.BytesDeleted += size
+			return nil
+		}
+		// Survivor: counts toward the size we report for this user.
+		totalBytes += info.Size()
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return res, nil
+		}
+		return res, err
+	}
+
+	pruneEmptyDirs(userRoot)
+
+	if err := s.store.RecordWorkspaceUsage(ctx, userID, totalBytes, now); err != nil {
+		return res, fmt.Errorf("record usage: %w", err)
+	}
+	return res, nil
+}
+
+// pruneEmptyDirs removes directories left empty by the purge, deepest
+// first. The user's own root is kept: its absence would be
+// indistinguishable from a user who has never compiled, and the
+// workspace factory would just recreate it on the next request.
+// Failures are ignored — an empty directory is untidy, not harmful.
+func pruneEmptyDirs(root string) {
+	var dirs []string
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() && path != root {
+			dirs = append(dirs, path)
+		}
+		return nil
+	})
+	// Deepest first, so a directory containing only empty directories
+	// becomes empty in time to be removed itself.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		_ = os.Remove(dirs[i]) // fails harmlessly when not empty
+	}
+}

--- a/internal/sweeper/sweeper_test.go
+++ b/internal/sweeper/sweeper_test.go
@@ -1,0 +1,307 @@
+package sweeper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+)
+
+// The sweeper runs against the real store rather than a fake: the
+// interesting behaviour is the interaction between live links in SQLite
+// and files on disk, which a fake would define away.
+func newStore(t *testing.T) *authdb.Store {
+	t.Helper()
+	s, err := authdb.Open(filepath.Join(t.TempDir(), "test.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// writeFile creates a file under the tenant root with a chosen age.
+func writeFile(t *testing.T, root, userID, rel string, age time.Duration) string {
+	t.Helper()
+	path := filepath.Join(root, userID, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("pdf bytes"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	when := time.Now().Add(-age)
+	if err := os.Chtimes(path, when, when); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	return path
+}
+
+func exists(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func TestSweepOnce_PurgesOldKeepsNew(t *testing.T) {
+	store := newStore(t)
+	root := t.TempDir()
+
+	old := writeFile(t, root, "gh:1", "old.pdf", 48*time.Hour)
+	fresh := writeFile(t, root, "gh:1", "fresh.pdf", time.Minute)
+
+	sw := New(store, Config{Root: root, FileTTL: 24 * time.Hour, Interval: time.Hour})
+	res, err := sw.SweepOnce(t.Context(), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if exists(t, old) {
+		t.Error("file older than the TTL survived")
+	}
+	if !exists(t, fresh) {
+		t.Error("file newer than the TTL was deleted")
+	}
+	if res.FilesDeleted != 1 {
+		t.Errorf("FilesDeleted = %d, want 1", res.FilesDeleted)
+	}
+}
+
+// A file with an unexpired download link is kept however old it is:
+// a URL already in someone's hands must not break.
+func TestSweepOnce_KeepsFileWithLiveLink(t *testing.T) {
+	store := newStore(t)
+	root := t.TempDir()
+	ctx := t.Context()
+
+	linked := writeFile(t, root, "gh:1", "linked.pdf", 48*time.Hour)
+	unlinked := writeFile(t, root, "gh:1", "unlinked.pdf", 48*time.Hour)
+
+	if _, err := store.MintPDFLink(ctx, "gh:1", "linked.pdf", time.Hour); err != nil {
+		t.Fatalf("MintPDFLink: %v", err)
+	}
+
+	sw := New(store, Config{Root: root, FileTTL: 24 * time.Hour, Interval: time.Hour})
+	if _, err := sw.SweepOnce(ctx, time.Now().UTC()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if !exists(t, linked) {
+		t.Error("file with a live download link was deleted")
+	}
+	if exists(t, unlinked) {
+		t.Error("unprotected aged file survived")
+	}
+}
+
+// Once the link expires, the same file becomes collectable — the
+// protection is the live link, not the file.
+func TestSweepOnce_CollectsAfterLinkExpires(t *testing.T) {
+	store := newStore(t)
+	root := t.TempDir()
+	ctx := t.Context()
+
+	linked := writeFile(t, root, "gh:1", "linked.pdf", 48*time.Hour)
+	if _, err := store.MintPDFLink(ctx, "gh:1", "linked.pdf", time.Hour); err != nil {
+		t.Fatalf("MintPDFLink: %v", err)
+	}
+
+	sw := New(store, Config{Root: root, FileTTL: 24 * time.Hour, Interval: time.Hour})
+	// Two hours on: the link has expired, so the sweep deletes the row
+	// first and the file is no longer protected.
+	if _, err := sw.SweepOnce(ctx, time.Now().UTC().Add(2*time.Hour)); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	if exists(t, linked) {
+		t.Error("file survived after its link expired")
+	}
+}
+
+func TestSweepOnce_TTLZeroDisablesPurgeButStillSweepsLinks(t *testing.T) {
+	store := newStore(t)
+	root := t.TempDir()
+	ctx := t.Context()
+
+	old := writeFile(t, root, "gh:1", "ancient.pdf", 10000*time.Hour)
+	token, err := store.MintPDFLink(ctx, "gh:1", "ancient.pdf", time.Hour)
+	if err != nil {
+		t.Fatalf("MintPDFLink: %v", err)
+	}
+
+	sw := New(store, Config{Root: root, FileTTL: 0, Interval: time.Hour})
+	res, err := sw.SweepOnce(ctx, time.Now().UTC().Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if !exists(t, old) {
+		t.Error("TTL=0 should disable the file purge entirely")
+	}
+	if res.LinksDeleted != 1 {
+		t.Errorf("LinksDeleted = %d, want 1 — link sweeping must run regardless of TTL", res.LinksDeleted)
+	}
+	if _, err := store.LookupPDFLink(ctx, token); err == nil {
+		t.Error("expired link survived a TTL=0 sweep")
+	}
+
+	// Usage is still measured with purging off, so the admin UI works.
+	usage, err := store.WorkspaceUsageByUser(ctx)
+	if err != nil {
+		t.Fatalf("WorkspaceUsageByUser: %v", err)
+	}
+	if usage["gh:1"].Bytes == 0 {
+		t.Error("usage not recorded when TTL=0")
+	}
+}
+
+func TestSweepOnce_RecordsPerUserUsage(t *testing.T) {
+	store := newStore(t)
+	root := t.TempDir()
+	ctx := t.Context()
+
+	// 9 bytes each ("pdf bytes"), all fresh so none are purged.
+	writeFile(t, root, "gh:1", "a.pdf", time.Minute)
+	writeFile(t, root, "gh:1", "sub/b.pdf", time.Minute)
+	writeFile(t, root, "gh:2", "c.pdf", time.Minute)
+
+	sw := New(store, Config{Root: root, FileTTL: 24 * time.Hour, Interval: time.Hour})
+	res, err := sw.SweepOnce(ctx, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	if res.UsersMeasured != 2 {
+		t.Errorf("UsersMeasured = %d, want 2", res.UsersMeasured)
+	}
+
+	usage, err := store.WorkspaceUsageByUser(ctx)
+	if err != nil {
+		t.Fatalf("WorkspaceUsageByUser: %v", err)
+	}
+	if got, want := usage["gh:1"].Bytes, int64(len("pdf bytes")*2); got != want {
+		t.Errorf("gh:1 bytes = %d, want %d", got, want)
+	}
+	if got, want := usage["gh:2"].Bytes, int64(len("pdf bytes")); got != want {
+		t.Errorf("gh:2 bytes = %d, want %d", got, want)
+	}
+}
+
+// A user whose files were all purged is measured at zero, not skipped —
+// otherwise the admin UI would keep showing their pre-purge size.
+func TestSweepOnce_EmptiedWorkspaceRecordsZero(t *testing.T) {
+	store := newStore(t)
+	root := t.TempDir()
+	ctx := t.Context()
+
+	writeFile(t, root, "gh:1", "old.pdf", 48*time.Hour)
+
+	sw := New(store, Config{Root: root, FileTTL: 24 * time.Hour, Interval: time.Hour})
+	if _, err := sw.SweepOnce(ctx, time.Now().UTC()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	usage, err := store.WorkspaceUsageByUser(ctx)
+	if err != nil {
+		t.Fatalf("WorkspaceUsageByUser: %v", err)
+	}
+	u, ok := usage["gh:1"]
+	if !ok {
+		t.Fatal("emptied workspace was not measured at all")
+	}
+	if u.Bytes != 0 {
+		t.Errorf("bytes = %d, want 0", u.Bytes)
+	}
+}
+
+func TestSweepOnce_RemovesEmptiedSubdirsKeepsUserRoot(t *testing.T) {
+	store := newStore(t)
+	root := t.TempDir()
+
+	writeFile(t, root, "gh:1", "nested/deep/old.pdf", 48*time.Hour)
+
+	sw := New(store, Config{Root: root, FileTTL: 24 * time.Hour, Interval: time.Hour})
+	if _, err := sw.SweepOnce(t.Context(), time.Now().UTC()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if exists(t, filepath.Join(root, "gh:1", "nested")) {
+		t.Error("emptied subdirectory was not pruned")
+	}
+	if !exists(t, filepath.Join(root, "gh:1")) {
+		t.Error("user root was removed; it should be kept")
+	}
+}
+
+// The purge must not follow a symlink out of the tenant root. WalkDir
+// does not follow symlinks, so the link itself is seen as an irregular
+// file and skipped, and the target is untouched.
+func TestSweepOnce_DoesNotEscapeViaSymlink(t *testing.T) {
+	store := newStore(t)
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	victim := filepath.Join(outside, "precious.pdf")
+	if err := os.WriteFile(victim, []byte("do not delete"), 0o600); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(victim, old, old); err != nil {
+		t.Fatalf("chtimes victim: %v", err)
+	}
+
+	userRoot := filepath.Join(root, "gh:1")
+	if err := os.MkdirAll(userRoot, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Both a file symlink and a directory symlink pointing outside.
+	if err := os.Symlink(victim, filepath.Join(userRoot, "link.pdf")); err != nil {
+		t.Fatalf("symlink file: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(userRoot, "escape")); err != nil {
+		t.Fatalf("symlink dir: %v", err)
+	}
+
+	sw := New(store, Config{Root: root, FileTTL: 24 * time.Hour, Interval: time.Hour})
+	if _, err := sw.SweepOnce(t.Context(), time.Now().UTC()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if !exists(t, victim) {
+		t.Error("sweeper deleted a file outside the tenant root via a symlink")
+	}
+}
+
+func TestSweepOnce_NoRootSkipsFilesystemWork(t *testing.T) {
+	store := newStore(t)
+	ctx := t.Context()
+
+	if _, err := store.MintPDFLink(ctx, "gh:1", "out.pdf", time.Hour); err != nil {
+		t.Fatalf("MintPDFLink: %v", err)
+	}
+
+	sw := New(store, Config{Root: "", FileTTL: 24 * time.Hour, Interval: time.Hour})
+	res, err := sw.SweepOnce(ctx, time.Now().UTC().Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("SweepOnce with no root: %v", err)
+	}
+	if res.LinksDeleted != 1 {
+		t.Errorf("LinksDeleted = %d, want 1", res.LinksDeleted)
+	}
+	if res.UsersMeasured != 0 {
+		t.Errorf("UsersMeasured = %d, want 0 when no root is configured", res.UsersMeasured)
+	}
+}
+
+// A missing root is the normal state before anyone has compiled.
+func TestSweepOnce_MissingRootIsNotAnError(t *testing.T) {
+	store := newStore(t)
+	sw := New(store, Config{
+		Root:     filepath.Join(t.TempDir(), "does-not-exist"),
+		FileTTL:  24 * time.Hour,
+		Interval: time.Hour,
+	})
+	if _, err := sw.SweepOnce(t.Context(), time.Now().UTC()); err != nil {
+		t.Errorf("SweepOnce with missing root: %v", err)
+	}
+}


### PR DESCRIPTION
> Stacked on #42 (schema migrations) — base is `feat/schema-migrations`,
> so the diff shows only this change. Merge #42 first.

Two pieces of state grew without bound on the 2Gi data volume. Expired
`pdf_links` rows were only pruned when someone *fetched* that token, so a
link minted and never clicked stayed forever. Workspace files were never
collected at all (`DEPLOYMENT.md` recorded the TTL purge as unimplemented).

Adds a background sweeper, running every `TYPST_D2_MCP_SWEEP_INTERVAL`
(1h), that:

- deletes `pdf_links` rows past their expiry;
- purges workspace files older than `TYPST_D2_MCP_WORKSPACE_TTL` (7d;
  `0` disables), and removes directories the purge leaves empty;
- records each user's total workspace size, which the admin UI in the
  next branch reads instead of walking the filesystem on page load.

Workspaces are treated as scratch space — everything in them is
reproducible from a re-upload and recompile — so files go on age alone,
with no distinction between `put_file` uploads and generated PDFs. The
one exception is a file with an unexpired download link: those are kept
however old, so a URL already in someone's hands never breaks. Seven days
is comfortably longer than the 1h link TTL, so nothing in flight is ever
at risk.

The walk never follows symlinks, so it cannot reach outside the tenant
root even if a symlink inside one points elsewhere. One user's failure is
logged and skipped rather than aborting the pass.

Also replaces `io.Copy` in the PDF download handler with
`http.ServeContent` plus an mtime+size ETag, giving `Range` requests
(resumable downloads) and `If-None-Match` / `If-Modified-Since` handling.

Considered and declined: moving PDFs to MinIO presigned URLs. It would
not relieve the actual scaling constraint (SQLite on an RWO PVC pins the
deployment to `replicas: 1`), the compile pipeline needs a POSIX
filesystem for `typst`/`d2` so object storage would be a second store
rather than a replacement, and presigned URLs are unrevocable and bypass
the `PDFDownloadTotal` metrics feeding the Grafana dashboard.

Refers #38
