### PR TITLE
ci: check every PR, and cover the admin UI in a browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+  # No `branches` filter: a PR opened against another branch (a stacked
+  # PR, say) must still be checked. With the filter, PRs #43 and #44 got
+  # no CI at all, and merged unverified. Retargeting a PR to main does
+  # not help either — that fires `edited`, which is not in the default
+  # trigger set.
   pull_request:
-    branches: [main]
     paths-ignore:
       - '**.md'
       - 'LICENSE'
@@ -78,3 +82,62 @@ jobs:
         with:
           version: latest
           install-mode: goinstall
+
+  # Browser-level checks for the admin UI: the things a Go test cannot
+  # reach. Chief among them is SameSite cookie behaviour — the only CSRF
+  # defence the admin actions have, and enforced by the browser alone.
+  # Separate job so a browser flake doesn't gate Go-test feedback.
+  playwright:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install Playwright deps
+        working-directory: playwright
+        run: bun install --frozen-lockfile
+
+      # Cache the Chromium download between runs, keyed on the lockfile
+      # so it invalidates when @playwright/test is bumped.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('playwright/bun.lock') }}
+
+      - name: Install Chromium + system deps (cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: playwright
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install Chromium system deps only (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: playwright
+        run: bunx playwright install-deps chromium
+
+      # playwright.config.ts starts the server itself via
+      # scripts/e2e-server.sh, which builds the binary with the Go
+      # toolchain set up above.
+      - name: Run Playwright tests
+        working-directory: playwright
+        run: bunx playwright test
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: playwright/playwright-report
+          retention-days: 7

--- a/playwright/.gitignore
+++ b/playwright/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/playwright/bun.lock
+++ b/playwright/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "typst-d2-mcp-playwright",
+      "devDependencies": {
+        "@playwright/test": "1.49.1",
+      },
+    },
+  },
+  "packages": {
+    "@playwright/test": ["@playwright/test@1.49.1", "", { "dependencies": { "playwright": "1.49.1" }, "bin": { "playwright": "cli.js" } }, "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "playwright": ["playwright@1.49.1", "", { "dependencies": { "playwright-core": "1.49.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA=="],
+
+    "playwright-core": ["playwright-core@1.49.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg=="],
+  }
+}

--- a/playwright/helpers/db.ts
+++ b/playwright/helpers/db.ts
@@ -1,0 +1,60 @@
+import { execFileSync } from "node:child_process";
+
+// The admin UI's quota, reset and key actions only render for accounts
+// that have completed the OAuth flow, i.e. that have a `users` row. The
+// suite forges session cookies rather than driving GitHub, so no such
+// row exists unless we make one.
+//
+// Seeding goes through the sqlite3 CLI against the server's live
+// database. The server has already run its migrations by the time
+// Playwright's webServer health check passes, so the schema is in place
+// and this only inserts rows.
+
+const STATE_DIR = process.env.E2E_STATE_DIR ?? "/tmp/typst-d2-mcp-e2e";
+const DB = `${STATE_DIR}/auth.sqlite`;
+
+function sql(statement: string): string {
+  return execFileSync("sqlite3", [DB, statement], { encoding: "utf8" });
+}
+
+/** Insert a user who has "signed in", returning their identity key. */
+export function seedSignedInUser(githubId: number, login: string): string {
+  sql(
+    `INSERT OR REPLACE INTO users(github_id, github_login, email)
+     VALUES(${githubId}, '${login}', '${login}@example.test')`,
+  );
+  return `gh:${githubId}`;
+}
+
+/** Give a user an API key so the revoke-keys action has something to do. */
+export function seedAPIKey(login: string): void {
+  sql(
+    `INSERT INTO api_keys(user_id, key_hash)
+     SELECT id, randomblob(32) FROM users WHERE github_login = '${login}'`,
+  );
+}
+
+export function countInvites(login: string): number {
+  return Number(
+    sql(`SELECT COUNT(*) FROM invites WHERE github_login = '${login}'`).trim(),
+  );
+}
+
+export function countUsers(login: string): number {
+  return Number(
+    sql(`SELECT COUNT(*) FROM users WHERE github_login = '${login}'`).trim(),
+  );
+}
+
+export function quotaFor(login: string): string {
+  return sql(
+    `SELECT IFNULL(CAST(quota_per_day AS TEXT), 'NULL')
+       FROM users WHERE github_login = '${login}'`,
+  ).trim();
+}
+
+export function auditActions(): string[] {
+  return sql(`SELECT action FROM admin_audit ORDER BY id`)
+    .split("\n")
+    .filter(Boolean);
+}

--- a/playwright/helpers/session.ts
+++ b/playwright/helpers/session.ts
@@ -1,0 +1,41 @@
+import { createHmac } from "node:crypto";
+import type { BrowserContext } from "@playwright/test";
+
+// Mirrors SessionCodec in internal/web/session.go:
+//   value = base64url(login|unixExpiry) + "." + base64url(hmacSHA256(key, payload))
+// Forging the cookie directly is what lets these tests exercise the
+// admin UI without standing up a fake GitHub for the OAuth round trip.
+// The signing key is fixed by scripts/e2e-server.sh.
+
+const KEY = process.env.E2E_SESSION_KEY ?? "e2e-fixed-session-key";
+export const ADMIN_LOGIN = process.env.E2E_ADMIN ?? "e2eadmin";
+
+const b64url = (b: Buffer) => b.toString("base64url");
+
+export function sessionValue(login: string, ttlSeconds = 3600): string {
+  const payload = b64url(
+    Buffer.from(`${login}|${Math.floor(Date.now() / 1000) + ttlSeconds}`),
+  );
+  const mac = b64url(createHmac("sha256", KEY).update(payload).digest());
+  return `${payload}.${mac}`;
+}
+
+/** Give the context a valid admin session for `login`. */
+export async function signIn(
+  context: BrowserContext,
+  origin: string,
+  login: string = ADMIN_LOGIN,
+): Promise<void> {
+  const { hostname } = new URL(origin);
+  await context.addCookies([
+    {
+      name: "ttd2_admin_session",
+      value: sessionValue(login),
+      domain: hostname,
+      path: "/",
+      httpOnly: true,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+}

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "typst-d2-mcp-playwright",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.49.1"
+  }
+}

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,60 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Browser-level checks for the admin UI: the things a Go test cannot
+// reach. Chief among them is SameSite cookie behaviour, which is
+// enforced by the browser and by nothing else — it is the only CSRF
+// defence the admin actions have.
+//
+// Two hostnames are used so "cross-site" is genuinely cross-site.
+// SameSite compares registrable domains and ignores the port, so
+// 127.0.0.1:18081 -> 127.0.0.1:18080 would be *same* site and would
+// prove nothing. `admin.test` and `evil.test` are distinct sites;
+// --host-resolver-rules maps both to the loopback interface, so no DNS
+// and no /etc/hosts entry is involved.
+
+const PORT = Number(process.env.E2E_PORT ?? 18080);
+const EVIL_PORT = Number(process.env.E2E_EVIL_PORT ?? 18081);
+
+export const APP_ORIGIN = `http://admin.test:${PORT}`;
+export const EVIL_ORIGIN = `http://evil.test:${EVIL_PORT}`;
+
+export default defineConfig({
+  testDir: "./tests",
+  // The server keeps a single SQLite file; parallel workers would race
+  // on the invite/user rows the tests create and delete.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }], ["list"]]
+    : [["html", { open: "never" }], ["list"]],
+  use: {
+    baseURL: APP_ORIGIN,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "off",
+    launchOptions: {
+      args: [
+        `--host-resolver-rules=MAP admin.test 127.0.0.1, MAP evil.test 127.0.0.1`,
+      ],
+      // Escape hatch for machines that already have a Chromium and
+      // would rather not pull Playwright's pinned build (a ~150MB
+      // download). CI leaves this unset and uses the pinned one.
+      ...(process.env.E2E_CHROMIUM_PATH
+        ? { executablePath: process.env.E2E_CHROMIUM_PATH }
+        : {}),
+    },
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "../scripts/e2e-server.sh",
+    // Health check on the loopback address: the resolver rules above
+    // apply inside the browser, not to Playwright's own probe.
+    url: `http://127.0.0.1:${PORT}/healthz`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/playwright/tests/access.spec.ts
+++ b/playwright/tests/access.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+import { APP_ORIGIN } from "../playwright.config";
+import { signIn, sessionValue } from "../helpers/session";
+
+// Access control as a browser sees it, including the cookie attributes
+// the CSRF defence rests on.
+
+test.describe("access control", () => {
+  test("an unauthenticated visit lands on the sign-in page", async ({ page }) => {
+    await page.goto(`${APP_ORIGIN}/admin/`);
+    await expect(page).toHaveURL(/\/admin\/signin$/);
+    await expect(page.getByRole("link", { name: /Sign in with GitHub/ })).toBeVisible();
+  });
+
+  test("the sign-in link goes to GitHub with an admin-scoped state", async ({ page }) => {
+    // Stop at the redirect rather than actually leaving for github.com.
+    await page.route("https://github.com/**", (route) =>
+      route.fulfill({ contentType: "text/html", body: "<html>github</html>" }),
+    );
+    const [request] = await Promise.all([
+      page.waitForRequest("https://github.com/login/oauth/authorize**"),
+      page.goto(`${APP_ORIGIN}/admin/login`),
+    ]);
+    const state = new URL(request.url()).searchParams.get("state") ?? "";
+    // The prefix is what lets the shared callback tell an admin login
+    // apart from an MCP client's authorization.
+    expect(state.startsWith("ttd2adm_")).toBe(true);
+  });
+
+  test("a non-admin session is refused", async ({ context, page }) => {
+    await signIn(context, APP_ORIGIN, "somebodyelse");
+    const response = await page.goto(`${APP_ORIGIN}/admin/`);
+    expect(response?.status()).toBe(403);
+  });
+
+  test("a tampered session is treated as absent", async ({ context, page }) => {
+    await context.addCookies([
+      {
+        name: "ttd2_admin_session",
+        value: sessionValue("e2eadmin").slice(0, -3) + "xxx",
+        domain: "admin.test",
+        path: "/",
+      },
+    ]);
+    await page.goto(`${APP_ORIGIN}/admin/`);
+    await expect(page).toHaveURL(/\/admin\/signin$/);
+  });
+
+  test("the session cookie is HttpOnly and SameSite=Lax", async ({ context }) => {
+    await signIn(context, APP_ORIGIN);
+    const [cookie] = (await context.cookies(APP_ORIGIN)).filter(
+      (c) => c.name === "ttd2_admin_session",
+    );
+    expect(cookie.httpOnly).toBe(true);
+    // Lax is the CSRF defence; Strict would break the return leg of the
+    // GitHub round trip that sets this cookie in the first place.
+    expect(cookie.sameSite).toBe("Lax");
+  });
+
+  test("pages load only vendored assets, no external hosts", async ({ context, page }) => {
+    await signIn(context, APP_ORIGIN);
+    const external: string[] = [];
+    page.on("request", (r) => {
+      const host = new URL(r.url()).hostname;
+      if (host !== "admin.test") external.push(r.url());
+    });
+    await page.goto(`${APP_ORIGIN}/admin/`);
+    await page.waitForLoadState("networkidle");
+    expect(external).toEqual([]);
+  });
+});

--- a/playwright/tests/csrf.spec.ts
+++ b/playwright/tests/csrf.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+import { APP_ORIGIN, EVIL_ORIGIN } from "../playwright.config";
+import { signIn } from "../helpers/session";
+import { countInvites } from "../helpers/db";
+
+// The admin actions have exactly one CSRF defence: the session cookie is
+// SameSite=Lax, so browsers do not attach it to a cross-site POST. That
+// is enforced by the browser and by nothing in the Go code, which is why
+// it cannot be tested anywhere but here.
+//
+// admin.test and evil.test are distinct registrable domains, so this is
+// genuinely cross-*site*. Two ports on 127.0.0.1 would not be: SameSite
+// ignores the port.
+
+const attackPage = (target: string, login: string) => `<!doctype html>
+<html><body>
+  <form id="attack" method="post" action="${target}/admin/invite">
+    <input type="hidden" name="login" value="${login}">
+  </form>
+  <script>document.getElementById('attack').submit();</script>
+</body></html>`;
+
+test.describe("cross-site request forgery", () => {
+  test("a cross-site POST cannot invite, even with a valid session", async ({
+    context,
+    page,
+  }) => {
+    await signIn(context, APP_ORIGIN);
+
+    // Positive control first: the session really does work same-site.
+    // Without this, a broken app would make the test below pass for the
+    // wrong reason.
+    await page.goto(`${APP_ORIGIN}/admin/`);
+    await expect(page.locator("#users")).toBeVisible();
+
+    await page.route(`${EVIL_ORIGIN}/attack`, (route) =>
+      route.fulfill({
+        contentType: "text/html",
+        body: attackPage(APP_ORIGIN, "csrfvictim"),
+      }),
+    );
+
+    const response = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url() === `${APP_ORIGIN}/admin/invite` && r.request().method() === "POST",
+      ),
+      page.goto(`${EVIL_ORIGIN}/attack`),
+    ]).then(([r]) => r);
+
+    // No cookie travels with the cross-site POST, so the server sees an
+    // unauthenticated request and refuses it outright.
+    expect(response.status()).toBe(401);
+    expect(countInvites("csrfvictim")).toBe(0);
+  });
+
+  test("the same request from the app's own origin succeeds", async ({
+    context,
+    page,
+  }) => {
+    await signIn(context, APP_ORIGIN);
+    await page.goto(`${APP_ORIGIN}/admin/`);
+
+    await page.fill('#invite-login', "samesiteinvitee");
+    await page.click('form.invite button[type="submit"]');
+
+    await expect(page.locator("#users")).toContainText("samesiteinvitee");
+    expect(countInvites("samesiteinvitee")).toBe(1);
+  });
+});

--- a/playwright/tests/htmx.spec.ts
+++ b/playwright/tests/htmx.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect, type Page } from "@playwright/test";
+import { APP_ORIGIN } from "../playwright.config";
+import { signIn } from "../helpers/session";
+import {
+  auditActions,
+  countInvites,
+  countUsers,
+  quotaFor,
+  seedAPIKey,
+  seedSignedInUser,
+} from "../helpers/db";
+
+// Every admin action replies in dual mode: htmx gets an out-of-band
+// flash plus a refreshed table, a plain form post gets a redirect. The
+// Go tests cover only the invite action under htmx; these cover the rest,
+// and prove the swap really happens in the browser without a reload.
+
+/** Marks the current document; a full page load clears it. */
+async function markDocument(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as unknown as { __alive?: boolean }).__alive = true;
+  });
+}
+
+async function documentSurvived(page: Page): Promise<boolean> {
+  return page.evaluate(
+    () => (window as unknown as { __alive?: boolean }).__alive === true,
+  );
+}
+
+/** Opens the per-row Manage panel for a login. */
+async function openRow(page: Page, login: string) {
+  const row = page.locator("tr", { hasText: login });
+  await row.locator("summary").click();
+  return row;
+}
+
+test.describe("htmx actions", () => {
+  test.beforeEach(async ({ context, page }) => {
+    await signIn(context, APP_ORIGIN);
+    await page.goto(`${APP_ORIGIN}/admin/`);
+    // htmx must actually be running, or these tests would silently
+    // degrade into the plain-form-post path and prove nothing.
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => typeof (window as unknown as { htmx?: unknown }).htmx,
+        ),
+      )
+      .toBe("object");
+  });
+
+  test("invite swaps the table in place, without reloading", async ({ page }) => {
+    await markDocument(page);
+
+    await page.fill('#invite-login', "htmxinvitee");
+    await page.click('form.invite button[type="submit"]');
+
+    await expect(page.locator("#users")).toContainText("htmxinvitee");
+    await expect(page.locator("#flash")).toContainText("Invited htmxinvitee");
+    expect(await documentSurvived(page)).toBe(true);
+    expect(countInvites("htmxinvitee")).toBe(1);
+  });
+
+  test("setting a fixed quota updates the row", async ({ page }) => {
+    seedSignedInUser(4242, "quotauser");
+    await page.reload();
+
+    const row = await openRow(page, "quotauser");
+    await row.locator('input[name="mode"][value="fixed"]').check();
+    await row.locator('input[name="value"]').fill("12");
+    await markDocument(page);
+    await row.getByRole("button", { name: "Save quota" }).click();
+
+    await expect(page.locator("#flash")).toContainText("Quota updated");
+    await expect(page.locator("tr", { hasText: "quotauser" })).toContainText("12/day");
+    expect(await documentSurvived(page)).toBe(true);
+    expect(quotaFor("quotauser")).toBe("12");
+  });
+
+  test("unlimited quota renders as unlimited", async ({ page }) => {
+    seedSignedInUser(4243, "unlimiteduser");
+    await page.reload();
+
+    const row = await openRow(page, "unlimiteduser");
+    await row.locator('input[name="mode"][value="unlimited"]').check();
+    await row.getByRole("button", { name: "Save quota" }).click();
+
+    await expect(page.locator("tr", { hasText: "unlimiteduser" })).toContainText(
+      "unlimited",
+    );
+    expect(quotaFor("unlimiteduser")).toBe("0");
+  });
+
+  test("reset today's counter reports back", async ({ page }) => {
+    seedSignedInUser(4244, "resetuser");
+    await page.reload();
+
+    const row = await openRow(page, "resetuser");
+    await markDocument(page);
+    await row.getByRole("button", { name: "Reset today's counter" }).click();
+
+    await expect(page.locator("#flash")).toContainText("counter reset");
+    expect(await documentSurvived(page)).toBe(true);
+  });
+
+  test("revoking API keys reports the count and clears the badge", async ({ page }) => {
+    seedSignedInUser(4245, "keyuser");
+    seedAPIKey("keyuser");
+    await page.reload();
+    await expect(page.locator("tr", { hasText: "keyuser" })).not.toContainText("none");
+
+    const row = await openRow(page, "keyuser");
+    await row.getByRole("button", { name: "Revoke API keys" }).click();
+
+    await expect(page.locator("#flash")).toContainText("Revoked 1 key(s)");
+    await expect(page.locator("tr", { hasText: "keyuser" })).toContainText("none");
+  });
+
+  test("revoking access removes the invite", async ({ page }) => {
+    await page.fill('#invite-login', "revokeme");
+    await page.click('form.invite button[type="submit"]');
+    await expect(page.locator("#users")).toContainText("revokeme");
+
+    const row = await openRow(page, "revokeme");
+    await row.getByRole("button", { name: "Revoke access" }).click();
+
+    await expect(page.locator("#flash")).toContainText("effective immediately");
+    expect(countInvites("revokeme")).toBe(0);
+  });
+
+  test("delete requires the typed login and then removes the user", async ({ page }) => {
+    seedSignedInUser(4246, "deleteme");
+    await page.reload();
+
+    // Wrong confirmation is refused.
+    let row = await openRow(page, "deleteme");
+    await row.locator('input[name="confirm"]').fill("deletem");
+    await row.getByRole("button", { name: "Delete user and all data" }).click();
+    await expect(page.locator("#flash")).toContainText("type the login exactly");
+    expect(countUsers("deleteme")).toBe(1);
+
+    // Correct confirmation goes through.
+    row = await openRow(page, "deleteme");
+    await row.locator('input[name="confirm"]').fill("deleteme");
+    await row.getByRole("button", { name: "Delete user and all data" }).click();
+    await expect(page.locator("#flash")).toContainText("Deleted deleteme");
+    await expect(page.locator("#users")).not.toContainText("deleteme");
+    expect(countUsers("deleteme")).toBe(0);
+  });
+
+  test("every action reached above is recorded in the audit log", async ({ page }) => {
+    const actions = new Set(auditActions());
+    for (const action of [
+      "invite",
+      "set_quota",
+      "reset_today",
+      "revoke_keys",
+      "revoke_access",
+      "delete_user",
+    ]) {
+      expect(actions.has(action), `audit log is missing ${action}`).toBe(true);
+    }
+
+    await page.goto(`${APP_ORIGIN}/admin/audit`);
+    await expect(page.locator("table")).toContainText("delete_user");
+  });
+});

--- a/playwright/tests/no-js.spec.ts
+++ b/playwright/tests/no-js.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "@playwright/test";
+import { APP_ORIGIN } from "../playwright.config";
+import { signIn } from "../helpers/session";
+import { countInvites, countUsers, quotaFor, seedSignedInUser } from "../helpers/db";
+
+// The admin UI is supposed to work with JavaScript unavailable: the
+// forms are ordinary POSTs, the handlers redirect with a banner instead
+// of swapping a fragment, and the row panels are <details> rather than a
+// scripted dialog.
+//
+// This is also the check on a design decision — the Stormlantern
+// sl-input / sl-button components submit through ElementInternals, so
+// they would take every action here down with them. These tests fail if
+// anyone swaps the native controls back for them.
+
+test.use({ javaScriptEnabled: false });
+
+test.describe("without javascript", () => {
+  test.beforeEach(async ({ context }) => {
+    await signIn(context, APP_ORIGIN);
+  });
+
+  test("the page still renders its content", async ({ page }) => {
+    await page.goto(`${APP_ORIGIN}/admin/`);
+    // sl-* elements never upgrade, but they are display-only wrappers,
+    // so their contents must still be readable.
+    await expect(page.locator("#users")).toContainText("Login");
+    await expect(page.getByRole("button", { name: "Invite" })).toBeVisible();
+  });
+
+  test("invite works as a plain form post and redirects with a banner", async ({ page }) => {
+    await page.goto(`${APP_ORIGIN}/admin/`);
+    await page.fill('#invite-login', "nojsinvitee");
+    await page.click('form.invite button[type="submit"]');
+
+    // The redirect lands back on the list with the message in the query.
+    await expect(page).toHaveURL(/\/admin\/\?flash=/);
+    await expect(page.locator("#flash")).toContainText("Invited nojsinvitee");
+    await expect(page.locator("#users")).toContainText("nojsinvitee");
+    expect(countInvites("nojsinvitee")).toBe(1);
+  });
+
+  test("the row panel opens without script and quota can be set", async ({ page }) => {
+    seedSignedInUser(5252, "nojsquota");
+    await page.goto(`${APP_ORIGIN}/admin/`);
+
+    const row = page.locator("tr", { hasText: "nojsquota" });
+    // <details> is native HTML; clicking the summary works with no JS.
+    await row.locator("summary").click();
+    await row.locator('input[name="mode"][value="unlimited"]').check();
+    await row.getByRole("button", { name: "Save quota" }).click();
+
+    await expect(page.locator("#flash")).toContainText("Quota updated");
+    expect(quotaFor("nojsquota")).toBe("0");
+  });
+
+  test("delete still enforces the typed confirmation", async ({ page }) => {
+    seedSignedInUser(5253, "nojsdelete");
+    await page.goto(`${APP_ORIGIN}/admin/`);
+
+    let row = page.locator("tr", { hasText: "nojsdelete" });
+    await row.locator("summary").click();
+    await row.locator('input[name="confirm"]').fill("wrong");
+    await row.getByRole("button", { name: "Delete user and all data" }).click();
+    await expect(page.locator("#flash")).toContainText("type the login exactly");
+    expect(countUsers("nojsdelete")).toBe(1);
+
+    row = page.locator("tr", { hasText: "nojsdelete" });
+    await row.locator("summary").click();
+    await row.locator('input[name="confirm"]').fill("nojsdelete");
+    await row.getByRole("button", { name: "Delete user and all data" }).click();
+    await expect(page.locator("#flash")).toContainText("Deleted nojsdelete");
+    expect(countUsers("nojsdelete")).toBe(0);
+  });
+});

--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["@playwright/test"]
+  },
+  "include": ["**/*.ts", "playwright.config.ts"]
+}

--- a/scripts/e2e-server.sh
+++ b/scripts/e2e-server.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Start typst-d2-mcp for the Playwright suite.
+#
+# Configuration is deliberately fixed and fake: a throwaway SQLite file
+# and workspace under a temp dir, a known session-signing key so tests
+# can forge an admin session without driving GitHub's OAuth flow, and a
+# GitHub client id/secret that are never used (no test reaches the
+# token endpoint).
+#
+# PUBLIC_URL is http, not https, so the session cookie is issued without
+# the Secure flag — a Secure cookie would be dropped by the browser over
+# plain http and every test would fail at the sign-in step.
+#
+# TYPST_D2_MCP_ADMINS is the login the tests forge sessions for.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+# Fixed path, not mktemp: the Playwright suite needs to find auth.sqlite
+# to seed a signed-in user, because the quota and key actions only render
+# for accounts that have completed the OAuth flow. Wiped on every start,
+# so a run never inherits the previous run's rows.
+STATE="${E2E_STATE_DIR:-/tmp/typst-d2-mcp-e2e}"
+rm -rf "$STATE"
+mkdir -p "$STATE"
+
+# Prebuilt binary wins (lets a machine without a Go toolchain run the
+# suite against a binary built elsewhere); otherwise build here.
+BIN="${TYPST_D2_MCP_E2E_BIN:-}"
+if [ -z "$BIN" ]; then
+  command -v go >/dev/null || {
+    echo "no go toolchain and no TYPST_D2_MCP_E2E_BIN set" >&2
+    exit 1
+  }
+  BIN="$STATE/typst-d2-mcp"
+  go build -o "$BIN" "$REPO_ROOT/cmd/typst-d2-mcp"
+fi
+
+export TYPST_D2_MCP_TRANSPORT=http
+export TYPST_D2_MCP_ADDR="127.0.0.1:${E2E_PORT:-18080}"
+export TYPST_D2_MCP_METRICS_ADDR="127.0.0.1:${E2E_METRICS_PORT:-19090}"
+export TYPST_D2_MCP_AUTH=github
+export TYPST_D2_MCP_DB="$STATE/auth.sqlite"
+export TYPST_D2_MCP_WORKSPACE="$STATE/workspaces"
+export TYPST_D2_MCP_PUBLIC_URL="http://admin.test:${E2E_PORT:-18080}"
+export TYPST_D2_MCP_GITHUB_CLIENT_ID=e2e-client
+export TYPST_D2_MCP_GITHUB_CLIENT_SECRET=e2e-secret
+export TYPST_D2_MCP_ADMINS="${E2E_ADMIN:-e2eadmin}"
+export TYPST_D2_MCP_SESSION_KEY="${E2E_SESSION_KEY:-e2e-fixed-session-key}"
+export TYPST_D2_MCP_LOG_FORMAT=text
+
+exec "$BIN"


### PR DESCRIPTION
Two fixes for gaps the last three PRs exposed.

## CI ran on nothing

The `pull_request` trigger filtered on `branches: [main]`, so #43 and
#44 — opened against their parent branch in the stack — got **no checks
at all** and merged unverified. Retargeting to `main` when the parent
merged does not rescue it either: that fires an `edited` event, which is
not in the default trigger set.

Dropping the `branches` filter means any PR against any base is checked.
`paths-ignore` is unchanged.

## Some claims could only be checked in a browser

Three items on #40's test plan could not be ticked from Go. This adds a
Playwright suite — structured like investor-buddy's, with its own
`package.json`, bun lockfile, and a CI job that caches the Chromium
download — covering exactly those.

**CSRF / SameSite.** The admin actions have one CSRF defence: the
session cookie is `SameSite=Lax`, so browsers do not attach it to a
cross-site POST. That is enforced by the browser and by nothing in the
Go code. `admin.test` and `evil.test` are mapped to loopback with
Chromium's `--host-resolver-rules`, so the attack is genuinely
cross-*site* — SameSite compares registrable domains and ignores the
port, so two ports on `127.0.0.1` would be same site and would prove
nothing. The forged POST must return 401 with no invite row created, and
a same-site positive control sits beside it so the test cannot pass
merely because the endpoint is broken.

**htmx.** All six actions, where the Go tests covered only invite. Each
asserts the table swapped *and* the document was never reloaded, via a
marker on `window` that a navigation would clear.

**No JavaScript.** Every action again with scripting disabled. This is
the regression test for a design decision in #44: the admin UI uses
native `<input>`/`<button>` rather than `sl-input`/`sl-button`, because
those are form-associated custom elements that submit through
`ElementInternals` and would take every action down with them. Row
panels are `<details>` for the same reason. If anyone swaps them back,
these fail.

**Access control as a browser sees it.** Sign-in redirect, the
`ttd2adm_` state prefix that distinguishes an admin login from an MCP
client authorization, non-admin 403, tampered cookie, the cookie
attributes themselves, and that no request leaves `admin.test`.

## How the suite gets a session

Rather than standing up a fake GitHub, tests forge the session cookie —
`helpers/session.ts` mirrors `SessionCodec`, which is why
`scripts/e2e-server.sh` fixes the signing key. The script also uses a
wiped, predictable state dir so the suite can seed a signed-in user
through `sqlite3`: the quota, reset and revoke-keys actions only render
for accounts that have completed the OAuth flow, and forging a cookie
skips the upsert that would create one.

`E2E_CHROMIUM_PATH` lets a machine that already has a Chromium skip
Playwright's pinned ~150MB download. CI leaves it unset.

20 tests, all passing locally.

Refers #40
