### PR TITLE
chore: enable the admin UI on test, and assert the download metrics

### DIFF
--- a/cmd/typst-d2-mcp/pdfdownload_test.go
+++ b/cmd/typst-d2-mcp/pdfdownload_test.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+	"github.com/dlouwers/typst-d2-mcp/internal/metrics"
 	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 // pdfBody is long enough that a Range request returns a recognisable
@@ -163,4 +165,108 @@ func TestPDFDownload_LinkCannotEscapeTenantRoot(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404 for a traversing path", rec.Code)
 	}
+}
+
+// The Grafana dashboard is built on PDFDownloadTotal, so a dropped
+// .Inc() would break observability silently — the handler would still
+// serve the right bytes and every other test would still pass. These
+// assert the counter moves on each labelled path.
+//
+// Counters are package-level and shared across the whole test binary, so
+// everything here measures a delta rather than an absolute value.
+func downloadCount(t *testing.T, result string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(metrics.PDFDownloadTotal.WithLabelValues(result))
+}
+
+func TestPDFDownload_MetricsOnSuccess(t *testing.T) {
+	h, _, token := newDownloadFixture(t)
+	before := downloadCount(t, metrics.ResultOK)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/d/"+token, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	if got := downloadCount(t, metrics.ResultOK) - before; got != 1 {
+		t.Errorf("ok counter moved by %v, want 1", got)
+	}
+}
+
+// A Range request is one download, not two: the counter increments
+// before ServeContent decides how much of the file to write.
+func TestPDFDownload_MetricsCountRangeRequestOnce(t *testing.T) {
+	h, _, token := newDownloadFixture(t)
+	before := downloadCount(t, metrics.ResultOK)
+
+	req := httptest.NewRequest(http.MethodGet, "/d/"+token, nil)
+	req.Header.Set("Range", "bytes=0-7")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", rec.Code)
+	}
+
+	if got := downloadCount(t, metrics.ResultOK) - before; got != 1 {
+		t.Errorf("ok counter moved by %v, want 1", got)
+	}
+}
+
+func TestPDFDownload_MetricsOnNotFound(t *testing.T) {
+	h, store, _ := newDownloadFixture(t)
+
+	t.Run("unknown token", func(t *testing.T) {
+		before := downloadCount(t, metrics.ResultNotFound)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/d/nosuchtoken", nil))
+		if got := downloadCount(t, metrics.ResultNotFound) - before; got != 1 {
+			t.Errorf("not_found counter moved by %v, want 1", got)
+		}
+	})
+
+	t.Run("swept file", func(t *testing.T) {
+		token, err := store.MintPDFLink(t.Context(), "gh:1", "gone.pdf", time.Hour)
+		if err != nil {
+			t.Fatalf("MintPDFLink: %v", err)
+		}
+		before := downloadCount(t, metrics.ResultNotFound)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/d/"+token, nil))
+		if got := downloadCount(t, metrics.ResultNotFound) - before; got != 1 {
+			t.Errorf("not_found counter moved by %v, want 1", got)
+		}
+	})
+}
+
+func TestPDFDownload_MetricsOnFailure(t *testing.T) {
+	h, _, _ := newDownloadFixture(t)
+
+	t.Run("malformed token", func(t *testing.T) {
+		before := downloadCount(t, metrics.ResultFail)
+		rec := httptest.NewRecorder()
+		// A path with a further slash is not a token shape we mint.
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/d/some/token", nil))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want 404", rec.Code)
+		}
+		if got := downloadCount(t, metrics.ResultFail) - before; got != 1 {
+			t.Errorf("fail counter moved by %v, want 1", got)
+		}
+	})
+
+	t.Run("no store configured", func(t *testing.T) {
+		// AUTH=none deployments have no store; the endpoint must refuse
+		// rather than panic, and say so in the metrics.
+		noStore := handlePDFDownload(workspace.TenantFactory{Root: t.TempDir()}, nil)
+		before := downloadCount(t, metrics.ResultFail)
+		rec := httptest.NewRecorder()
+		noStore.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/d/anything", nil))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want 404", rec.Code)
+		}
+		if got := downloadCount(t, metrics.ResultFail) - before; got != 1 {
+			t.Errorf("fail counter moved by %v, want 1", got)
+		}
+	})
 }

--- a/deploy/k8s/overlays/prod/sealed-secret.yaml.example
+++ b/deploy/k8s/overlays/prod/sealed-secret.yaml.example
@@ -25,3 +25,7 @@ stringData:
   # a fresh random string per environment:
   #   openssl rand -hex 32
   TYPST_D2_MCP_METRICS_BEARER: "REPLACE_WITH_OPENSSL_RAND_HEX_32"
+  # Signs admin browser sessions. Leave it out and the server generates
+  # a random key per process, which works but signs every admin out on
+  # each restart or rollout.
+  TYPST_D2_MCP_SESSION_KEY: "REPLACE_WITH_OPENSSL_RAND_HEX_32"

--- a/deploy/k8s/overlays/test/configmap-patch.yaml
+++ b/deploy/k8s/overlays/test/configmap-patch.yaml
@@ -17,3 +17,12 @@ data:
   # one operator, "0 = unlimited" is effectively "unlimited for me".
   TYPST_D2_MCP_QUOTA_PER_DAY: "0"
   TYPST_D2_MCP_LOG_LEVEL: "debug"
+  # Admin UI at /admin. Naming an administrator is also what closes a
+  # deployment to uninvited accounts — harmless here, because the
+  # allowlist above already restricts this environment to one login.
+  # On prod the same setting would deny every existing user until they
+  # are invited, so invite first there.
+  #
+  # An admin login is implicitly allowed, so an empty invites table can
+  # never lock the operator out.
+  TYPST_D2_MCP_ADMINS: "dlouwers"

--- a/deploy/k8s/overlays/test/sealed-secret.yaml.example
+++ b/deploy/k8s/overlays/test/sealed-secret.yaml.example
@@ -12,3 +12,7 @@ stringData:
   TYPST_D2_MCP_GITHUB_CLIENT_ID: "Iv1.XXXXXXXXXXXXXXXX"
   TYPST_D2_MCP_GITHUB_CLIENT_SECRET: "github_pat_XXXXXXXXXXXXXXXXXXXXXX"
   TYPST_D2_MCP_METRICS_BEARER: "REPLACE_WITH_OPENSSL_RAND_HEX_32"
+  # Signs admin browser sessions. Leave it out and the server generates
+  # a random key per process, which works but signs every admin out on
+  # each restart or rollout.
+  TYPST_D2_MCP_SESSION_KEY: "REPLACE_WITH_OPENSSL_RAND_HEX_32"

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect


### PR DESCRIPTION
Two loose ends from the admin UI work, so the remaining verification on
#38 and #40 can actually be attempted.

## The admin UI was documented but never configured

`TYPST_D2_MCP_ADMINS` and `TYPST_D2_MCP_SESSION_KEY` were set in **no
overlay**, so `/admin` is unreachable on the deployed environments —
the server logs `no administrators configured` — and the three hands-on
items on #40 could not be started.

Turns it on for **test only**. That is the safe environment: it already
sets `TYPST_D2_MCP_GITHUB_ALLOWLIST: "dlouwers"`, so it is invite-only
already and naming an admin changes no access posture. Prod is the
opposite — no allowlist today, so the same setting would close it and
deny every existing user until invited. Deliberately not touched here.

`TYPST_D2_MCP_SESSION_KEY` is added to both overlays' sealed-secret
**examples**, to be sealed with a real value
(`openssl rand -hex 32`). Without it the server generates a random key
per process, which works but signs every admin out on each restart or
rollout. No Deployment change is needed: `envFrom`/`secretRef` already
surfaces every key in the secret as an env var.

### After merging, to run the #40 checks on test

The image is auto-bumped by Flux, so once the new config reconciles:

- `TYPST_D2_MCP_QUOTA_PER_DAY` is `"0"` on test, i.e. already unlimited
  for everyone. Setting a user to unlimited there proves nothing —
  temporarily set it to `"1"` while testing the override, then revert.

## PDFDownloadTotal was unasserted

The Grafana dashboard is built on this counter, so a dropped `.Inc()`
would break observability silently: the handler would still serve the
right bytes and every existing test would still pass.

Adds assertions for the `ok`, `not_found` and `fail` paths, plus one
that a `Range` request counts as a single download rather than two.
Counters are package-level and shared across the test binary, so these
measure deltas rather than absolute values.

Verified by mutation rather than assumed: removing the success-path
increment fails them with `ok counter moved by 0, want 1`, and restoring
it passes.

`prometheus/testutil` brings in one small test-only indirect dependency
(`kylelemons/godebug`).

Refers #38
Refers #40
