### PR TITLE
fix(admin): read last_used_at without MAX(), which returns text

### DIFF
--- a/internal/authdb/admin.go
+++ b/internal/authdb/admin.go
@@ -95,7 +95,16 @@ SELECT
   COALESCE(u.email, ''),
   u.quota_per_day,
   (SELECT COUNT(*)   FROM api_keys k WHERE k.user_id = u.id)        AS key_count,
-  (SELECT MAX(k.last_used_at) FROM api_keys k WHERE k.user_id = u.id) AS last_used_at,
+  -- ORDER BY ... LIMIT 1 rather than MAX(): last_used_at is written by
+  -- CURRENT_TIMESTAMP, so it holds SQLite text. A plain column
+  -- reference keeps the column's declared TIMESTAMP type, which is what
+  -- lets the driver hand back a time.Time; wrapping it in an aggregate
+  -- discards that and yields a bare string, which fails to scan into
+  -- sql.NullTime. Rows where the key was never used are excluded so a
+  -- NULL cannot sort above a real timestamp.
+  (SELECT k.last_used_at FROM api_keys k
+    WHERE k.user_id = u.id AND k.last_used_at IS NOT NULL
+    ORDER BY k.last_used_at DESC LIMIT 1)                           AS last_used_at,
   (SELECT c.count FROM compiles c
      WHERE c.user_id = 'gh:' || u.github_id AND c.utc_date = ?)     AS used_today,
   (SELECT w.bytes       FROM workspace_usage w WHERE w.user_id = 'gh:' || u.github_id),

--- a/internal/authdb/admin_test.go
+++ b/internal/authdb/admin_test.go
@@ -476,3 +476,52 @@ func TestAudit_NoRowWhenActionFails(t *testing.T) {
 
 // nowUTC is a tiny helper so tests don't import time solely for this.
 func nowUTC() time.Time { return time.Now().UTC() }
+
+// Regression: AdminUsers failed in production with
+//
+//	scan admin user: ... unsupported Scan, storing driver.Value type
+//	string into type *time.Time
+//
+// because last_used_at is written by CURRENT_TIMESTAMP (SQLite text) and
+// the query wrapped it in MAX(), which discards the column's declared
+// TIMESTAMP type and returns a bare string.
+//
+// Every other test issued keys but never *used* one, leaving
+// last_used_at NULL — a NULL scans into sql.NullTime happily, so the
+// whole suite passed against a query that could not read a used key.
+// IdentityForKey is the step that makes the difference.
+func TestAdminUsers_AfterKeyHasBeenUsed(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+
+	uid, err := s.UpsertGitHubUser(ctx, 42, "octocat", "o@example.com")
+	if err != nil {
+		t.Fatalf("UpsertGitHubUser: %v", err)
+	}
+	key, err := s.IssueAPIKey(ctx, uid)
+	if err != nil {
+		t.Fatalf("IssueAPIKey: %v", err)
+	}
+	if _, err := s.IdentityForKey(ctx, key); err != nil {
+		t.Fatalf("IdentityForKey: %v", err)
+	}
+	// A second key that has never been used: its NULL last_used_at must
+	// not mask the used one.
+	if _, err := s.IssueAPIKey(ctx, uid); err != nil {
+		t.Fatalf("second IssueAPIKey: %v", err)
+	}
+
+	rows, err := s.AdminUsers(ctx, today)
+	if err != nil {
+		t.Fatalf("AdminUsers with a used key: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].KeyCount != 2 {
+		t.Errorf("KeyCount = %d, want 2", rows[0].KeyCount)
+	}
+	if rows[0].LastUsedAt == nil {
+		t.Error("LastUsedAt is nil despite the key having been used")
+	}
+}

--- a/playwright/helpers/db.ts
+++ b/playwright/helpers/db.ts
@@ -26,11 +26,20 @@ export function seedSignedInUser(githubId: number, login: string): string {
   return `gh:${githubId}`;
 }
 
-/** Give a user an API key so the revoke-keys action has something to do. */
+/**
+ * Give a user an API key so the revoke-keys action has something to do.
+ *
+ * last_used_at is set, not left NULL, because a *used* key is what the
+ * production database actually contains — and rendering one used to
+ * fail: the user-list query wrapped that column in MAX(), which returns
+ * SQLite text rather than a timestamp. Seeding an unused key renders a
+ * NULL, which scans fine and hides the bug.
+ */
 export function seedAPIKey(login: string): void {
   sql(
-    `INSERT INTO api_keys(user_id, key_hash)
-     SELECT id, randomblob(32) FROM users WHERE github_login = '${login}'`,
+    `INSERT INTO api_keys(user_id, key_hash, last_used_at)
+     SELECT id, randomblob(32), CURRENT_TIMESTAMP
+       FROM users WHERE github_login = '${login}'`,
   );
 }
 


### PR DESCRIPTION
## Symptom

`/admin` on test rendered **"could not load users"**. The user list query
failed with:

```
scan admin user: sql: Scan error on column index 5, name "last_used_at":
unsupported Scan, storing driver.Value type string into type *time.Time
```

## Cause

`last_used_at` is written by `CURRENT_TIMESTAMP`, so the column holds
SQLite text. A plain column reference keeps the column's declared
`TIMESTAMP` type, and that is what lets the driver hand back a
`time.Time`. Wrapping it in `MAX()` produces an expression with no
declared type, so the driver returns a bare string, which cannot scan
into `sql.NullTime`.

Swapped for `ORDER BY k.last_used_at DESC LIMIT 1`, which is a plain
column reference again. `NULL`s are excluded in the `WHERE` so an unused
key cannot sort above a real timestamp.

## Why nothing caught it

Every test issued API keys but none ever *used* one, so `last_used_at`
was always `NULL` — and `NULL` scans into `sql.NullTime` perfectly well.
The entire suite, unit and browser alike, passed against a query that
could not read a used key. `IdentityForKey` is the call that sets the
column, and no test called it before rendering the list.

Both layers now cover it:

- a store test that calls `IdentityForKey` first, then asserts
  `AdminUsers` succeeds and reports `LastUsedAt`
- the Playwright seed helper, which now sets `last_used_at` because a
  used key is what a production database actually contains

Both were confirmed to fail against the old query before the fix went
in — with `MAX()` restored, the browser suite fails from the
revoke-keys test onward.

## Related audit

The only other `MAX()` in the codebase is over revision integers in
`migrate.go`, which is unaffected. Every other timestamp scan
(`admin_audit.created_at`, `workspace_usage.computed_at`,
`pdf_links.expires_at`) is a plain column read.

Refers #40
