### PR TITLE
feat(admin): show which build is running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,14 @@ COPY . .
 # Static-ish build: CGO disabled (modernc.org/sqlite is pure Go, so this
 # is safe), trimpath to keep the binary reproducible.
 ARG VERSION=dev
+# Passed by .github/workflows/image.yml. Declared here or the build-args
+# are silently dropped — which is what used to happen, leaving the binary
+# with no way to name the commit it was built from.
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     go build -trimpath \
-      -ldflags="-s -w -X main.serverVersion=${VERSION}" \
+      -ldflags="-s -w -X main.serverVersion=${VERSION} -X main.gitSHA=${GIT_SHA} -X main.buildTime=${BUILD_TIME}" \
       -o /out/typst-d2-mcp \
       ./cmd/typst-d2-mcp
 

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -34,6 +34,14 @@ import (
 // the linker to rewrite it.
 var serverVersion = "dev"
 
+// gitSHA and buildTime are stamped the same way, from build-args the
+// image workflow already computes. They are what let an operator tie a
+// running container back to a commit — the admin UI shows them.
+var (
+	gitSHA    = "unknown"
+	buildTime = "unknown"
+)
+
 const (
 	serverName = "typst-d2-mcp"
 
@@ -51,6 +59,7 @@ const (
 	envGitHubSecret    = "TYPST_D2_MCP_GITHUB_CLIENT_SECRET"
 	envGitHubAllowlist = "TYPST_D2_MCP_GITHUB_ALLOWLIST"
 	envAdmins          = "TYPST_D2_MCP_ADMINS"
+	envEnvironment     = "TYPST_D2_MCP_ENV"
 	envSessionKey      = "TYPST_D2_MCP_SESSION_KEY"
 	envQuotaPerDay     = "TYPST_D2_MCP_QUOTA_PER_DAY"
 	envLogLevel        = "TYPST_D2_MCP_LOG_LEVEL"
@@ -256,6 +265,9 @@ func main() {
 
 	slog.Info("starting",
 		"version", serverVersion,
+		"git_sha", gitSHA,
+		"build_time", buildTime,
+		"env", os.Getenv(envEnvironment),
 		"auth", backend.Name(),
 		"admins", len(parseAllowlist(os.Getenv(envAdmins))),
 		"quota_per_day", quotaPerDay(),
@@ -560,12 +572,26 @@ func newAdminUI(gh *auth.GitHub, store *authdb.Store, factory workspace.Factory)
 			"invite_only", gh.InviteOnly())
 	}
 
+	// Schema revision is read once: migrations only run at startup, so
+	// it cannot change under a running process.
+	revision, err := store.SchemaRevision()
+	if err != nil {
+		return nil, fmt.Errorf("read schema revision: %w", err)
+	}
+
 	return web.New(web.Config{
 		Store:         store,
 		GitHub:        gh,
 		Sessions:      web.NewSessionCodec(key, 12*time.Hour, secure),
 		WorkspaceRoot: root,
 		QuotaDefault:  quotaPerDay,
+		Build: web.BuildInfo{
+			Environment:    os.Getenv(envEnvironment),
+			Version:        serverVersion,
+			GitSHA:         gitSHA,
+			BuildTime:      buildTime,
+			SchemaRevision: revision,
+		},
 	})
 }
 

--- a/deploy/k8s/overlays/test/config.env
+++ b/deploy/k8s/overlays/test/config.env
@@ -28,3 +28,7 @@ TYPST_D2_MCP_LOG_LEVEL=debug
 # An admin login is implicitly allowed, so an empty invites table can
 # never lock the operator out.
 TYPST_D2_MCP_ADMINS=dlouwers
+
+# Renders the deployment banner in the admin UI. Unset on prod, so the
+# banner itself means "not production".
+TYPST_D2_MCP_ENV=test

--- a/internal/web/admin_test.go
+++ b/internal/web/admin_test.go
@@ -24,6 +24,11 @@ type fixture struct {
 
 func newFixture(t *testing.T) *fixture {
 	t.Helper()
+	return newFixtureWithBuild(t, BuildInfo{})
+}
+
+func newFixtureWithBuild(t *testing.T, build BuildInfo) *fixture {
+	t.Helper()
 
 	store, err := authdb.Open(filepath.Join(t.TempDir(), "auth.sqlite"))
 	if err != nil {
@@ -47,6 +52,7 @@ func newFixture(t *testing.T) *fixture {
 		Sessions:      codec,
 		WorkspaceRoot: ws,
 		QuotaDefault:  func() int { return 1 },
+		Build:         build,
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -569,5 +575,76 @@ func TestUsersPage_RendersQuotaOverrides(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("page missing quota label %q", want)
 		}
+	}
+}
+
+// The banner exists so an operator can tell which build is answering
+// without shelling into the pod — the question that made a stale image
+// hard to diagnose. It is server-rendered rather than a custom element
+// so it survives with JavaScript off, which is when you most need it.
+func TestBanner_ShownWithBuildInfo(t *testing.T) {
+	f := newFixtureWithBuild(t, BuildInfo{
+		Environment:    "test",
+		Version:        "sha-3a6a156",
+		GitSHA:         "3a6a156",
+		BuildTime:      "2026-08-18T06:19:22Z",
+		SchemaRevision: 5,
+	})
+
+	rec := f.do(t, f.as(t, "dlouwers", http.MethodGet, "/admin/", nil))
+	body := rec.Body.String()
+	for _, want := range []string{
+		"env-banner", "test", "sha-3a6a156", "3a6a156",
+		"2026-08-18T06:19:22Z", "schema r5",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("banner missing %q", want)
+		}
+	}
+}
+
+// Production sets no environment, so the strip must not render at all —
+// its presence is the signal.
+func TestBanner_HiddenWithoutEnvironment(t *testing.T) {
+	f := newFixtureWithBuild(t, BuildInfo{
+		Version:        "v1.2.3",
+		SchemaRevision: 5,
+	})
+
+	rec := f.do(t, f.as(t, "dlouwers", http.MethodGet, "/admin/", nil))
+	if strings.Contains(rec.Body.String(), "env-banner") {
+		t.Error("banner rendered with no environment set")
+	}
+}
+
+// A local build has no ldflags, so sha and time are the "unknown"
+// placeholders; showing those is worse than showing nothing.
+func TestBanner_OmitsUnknownBuildFields(t *testing.T) {
+	f := newFixtureWithBuild(t, BuildInfo{
+		Environment:    "dev",
+		Version:        "dev",
+		GitSHA:         "unknown",
+		BuildTime:      "unknown",
+		SchemaRevision: 5,
+	})
+
+	rec := f.do(t, f.as(t, "dlouwers", http.MethodGet, "/admin/", nil))
+	body := rec.Body.String()
+	if !strings.Contains(body, "env-banner") {
+		t.Fatal("banner not rendered")
+	}
+	if strings.Contains(body, "unknown") {
+		t.Error("banner shows \"unknown\" placeholders instead of omitting them")
+	}
+}
+
+// The sign-in page is where an operator lands when something is wrong,
+// so it needs the banner as much as the authenticated pages.
+func TestBanner_ShownOnSignInPage(t *testing.T) {
+	f := newFixtureWithBuild(t, BuildInfo{Environment: "test", Version: "sha-abc"})
+
+	rec := f.do(t, f.as(t, "", http.MethodGet, "/admin/signin", nil))
+	if !strings.Contains(rec.Body.String(), "env-banner") {
+		t.Error("sign-in page has no banner")
 	}
 }

--- a/internal/web/handlers_admin.go
+++ b/internal/web/handlers_admin.go
@@ -22,6 +22,7 @@ type pageVM struct {
 	Admin      string
 	Flash      string
 	FlashLevel string
+	Build      BuildInfo
 }
 
 // usersVM is the view model for the user list.
@@ -50,6 +51,7 @@ func (s *Server) usersViewModel(r *http.Request) (usersVM, error) {
 		pageVM: pageVM{
 			Title: "Users — typst-d2-mcp admin",
 			Admin: adminLogin(r.Context()),
+			Build: s.cfg.Build,
 		},
 		Rows:         rows,
 		DefaultQuota: s.cfg.QuotaDefault(),
@@ -84,6 +86,7 @@ func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
 		pageVM: pageVM{
 			Title: "Audit — typst-d2-mcp admin",
 			Admin: adminLogin(r.Context()),
+			Build: s.cfg.Build,
 		},
 		Entries: entries,
 	})

--- a/internal/web/handlers_login.go
+++ b/internal/web/handlers_login.go
@@ -24,7 +24,10 @@ type loginVM struct {
 // expired session does not silently bounce a browser to github.com.
 func (s *Server) handleSignInPage(w http.ResponseWriter, r *http.Request) {
 	s.renderPage(w, "login", loginVM{
-		pageVM: pageVM{Title: "Sign in — typst-d2-mcp admin"},
+		pageVM: pageVM{
+			Title: "Sign in — typst-d2-mcp admin",
+			Build: s.cfg.Build,
+		},
 		Reason: r.URL.Query().Get("reason"),
 	})
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -44,6 +44,21 @@ type Config struct {
 	// QuotaDefault reports the deployment-wide default a user inherits
 	// when they have no override.
 	QuotaDefault func() int
+
+	// Build identifies the running binary in the admin UI's banner.
+	Build BuildInfo
+}
+
+// BuildInfo is what the banner shows so an operator can tell which
+// build is answering, without shelling into the pod. Environment is the
+// switch: empty renders no banner at all, so production stays plain and
+// the loud strip means "not production".
+type BuildInfo struct {
+	Environment    string
+	Version        string
+	GitSHA         string
+	BuildTime      string
+	SchemaRevision int
 }
 
 // Server renders and handles the admin UI.

--- a/internal/web/static/app.css
+++ b/internal/web/static/app.css
@@ -118,3 +118,24 @@ td.actions form.danger {
 td.actions form.danger label { font-size: var(--sl-font-size-sm); color: var(--sl-color-muted); }
 
 .signin { max-width: 32rem; }
+
+/* Deployment banner. Loud on purpose: it only renders outside
+   production, and its job is to stop you reading a test environment as
+   the real one. Amber rather than a brand colour for the same reason —
+   it should not look like part of the product. */
+.env-banner {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sl-space-3);
+  align-items: baseline;
+  padding: var(--sl-space-2) var(--sl-space-5);
+  background: var(--sl-color-amber-500, #f59e0b);
+  color: #1a1a1a;
+  font-family: var(--sl-font-family-mono, ui-monospace, monospace);
+  font-size: var(--sl-font-size-xs);
+  letter-spacing: 0.02em;
+}
+.env-banner strong {
+  text-transform: uppercase;
+  font-weight: var(--sl-font-weight-heavy, 800);
+}

--- a/internal/web/templates/base.tmpl
+++ b/internal/web/templates/base.tmpl
@@ -10,6 +10,24 @@
 <script type="module" src="/admin/static/components.js"></script>
 </head>
 <body>
+{{/*
+  Deployment banner. Rendered server-side rather than as a custom
+  element so it survives with JavaScript off — the whole point is to
+  identify the running build when something is wrong, which is exactly
+  when you cannot assume the page is healthy.
+
+  Only shown when TYPST_D2_MCP_ENV is set, so production is plain and
+  the strip itself means "not production".
+*/}}
+{{with .Build}}{{if .Environment}}
+<div class="env-banner" role="status">
+  <strong>{{.Environment}}</strong>
+  <span>{{.Version}}</span>
+  {{if ne .GitSHA "unknown"}}<span>{{.GitSHA}}</span>{{end}}
+  {{if ne .BuildTime "unknown"}}<span>built {{.BuildTime}}</span>{{end}}
+  <span>schema r{{.SchemaRevision}}</span>
+</div>
+{{end}}{{end}}
 <header class="topbar">
   <a class="brand" href="/admin/">
     <img src="/admin/static/vendor/lantern-mark.svg" alt="" width="28" height="28">


### PR DESCRIPTION
> *"Still could not load users, no way for me to see what test version is
> running."*

The second half of that is the important part. A stale ConfigMap (#47)
and a stale image (#48) both present as "the app is broken", and nothing
on screen distinguishes either from a code bug. This adds the missing
signal.

## The banner

Every admin page — including the sign-in page, since that is where a
locked-out operator lands — carries a strip with:

- the environment label
- the version, commit and build time of the running binary
- the applied schema revision

It renders **only when `TYPST_D2_MCP_ENV` is set**, so production stays
plain and the presence of the strip is itself the "not production"
signal. Set to `test` on the test overlay; prod is untouched.

Server-rendered rather than a custom element, which is where it departs
from investor-buddy's `ib-env-banner`: this thing earns its keep when
something is already wrong, and that is a bad moment to assume the
page's JavaScript is healthy. `unknown` placeholders from a local build
are omitted rather than displayed.

## A build-info gap it uncovered

`.github/workflows/image.yml` has been passing `GIT_SHA` and
`BUILD_TIME` build-args that the **Dockerfile never declared**, so
Docker discarded them and the binary carried no commit information —
even though the workflow comment says they "get baked into the binary
via ldflags so operators can correlate a running container to a specific
commit". They are declared now and stamped alongside `VERSION`.

Checked by building with those ldflags and reading the values back off a
running server, rather than trusting the syntax:

```
"version":"sha-testing" "git_sha":"abc1234" "build_time":"2026-08-18T06:19:22Z" "env":"test"
```

Refers #40
