### PR TITLE
fix(admin): send an expired htmx action to the sign-in page

### DIFF
--- a/internal/web/admin_test.go
+++ b/internal/web/admin_test.go
@@ -648,3 +648,36 @@ func TestBanner_ShownOnSignInPage(t *testing.T) {
 		t.Error("sign-in page has no banner")
 	}
 }
+
+// An expired session used to make every htmx action look inert: htmx
+// does not swap error responses, so a 401 produced no visible change.
+// HX-Redirect turns it into a trip to the sign-in page.
+func TestAccess_ExpiredSessionRedirectsHTMXAction(t *testing.T) {
+	f := newFixture(t)
+
+	r := f.as(t, "", http.MethodPost, "/admin/invite", url.Values{"login": {"someone"}})
+	r.AddCookie(&http.Cookie{Name: SessionCookie, Value: "stale.value"})
+	r.Header.Set("HX-Request", "true")
+	rec := f.do(t, r)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+	if got := rec.Header().Get("HX-Redirect"); got != "/admin/signin" {
+		t.Errorf("HX-Redirect = %q, want /admin/signin", got)
+	}
+}
+
+// A non-htmx POST keeps the plain 401: there is no browser to redirect,
+// and a redirect would mask the failure from a script or curl.
+func TestAccess_ExpiredSessionPlainPostStays401(t *testing.T) {
+	f := newFixture(t)
+
+	rec := f.do(t, f.as(t, "", http.MethodPost, "/admin/invite", url.Values{"login": {"someone"}}))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+	if rec.Header().Get("HX-Redirect") != "" {
+		t.Error("HX-Redirect set on a non-htmx request")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -139,7 +139,17 @@ func (s *Server) requireAdmin(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		login, ok := s.cfg.Sessions.Login(r)
 		if !ok {
-			if r.Method == http.MethodGet && !isHTMX(r) {
+			// htmx does not swap error responses, so a bare 401 leaves the
+			// button looking inert — which is exactly how an expired
+			// session presented: "Save quota fails", with nothing on
+			// screen to say why. HX-Redirect is honoured whatever the
+			// status, so the browser goes to sign in instead.
+			if isHTMX(r) {
+				w.Header().Set("HX-Redirect", "/admin/signin")
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			if r.Method == http.MethodGet {
 				http.Redirect(w, r, "/admin/signin", http.StatusSeeOther)
 				return
 			}

--- a/playwright/tests/access.spec.ts
+++ b/playwright/tests/access.spec.ts
@@ -69,3 +69,33 @@ test.describe("access control", () => {
     expect(external).toEqual([]);
   });
 });
+
+// The Go test only asserts the HX-Redirect header; whether htmx acts on
+// it for a 401 is a browser behaviour. This is the scenario that was
+// reported as "Save quota fails": a session invalidated by a rollout,
+// leaving every action apparently inert.
+test("an htmx action with a dead session lands on the sign-in page", async ({
+  context,
+  page,
+}) => {
+  await signIn(context, APP_ORIGIN);
+  await page.goto(`${APP_ORIGIN}/admin/`);
+  await expect(page.locator("#users")).toBeVisible();
+
+  // Invalidate the session behind the page's back, as a pod restart
+  // with a generated signing key does.
+  await context.clearCookies();
+  await context.addCookies([
+    {
+      name: "ttd2_admin_session",
+      value: "stale.value",
+      domain: "admin.test",
+      path: "/",
+    },
+  ]);
+
+  await page.fill("#invite-login", "afterexpiry");
+  await page.click('form.invite button[type="submit"]');
+
+  await expect(page).toHaveURL(/\/admin\/signin$/);
+});


### PR DESCRIPTION
> *"Save quota button fails now"* — with nothing on screen explaining it.

## What was happening

htmx does not swap error responses, so `requireAdmin`'s bare `401` for an
expired session produced **no visible change whatsoever**. The button
looked broken; the session looked fine.

A rollout is enough to trigger it. `TYPST_D2_MCP_SESSION_KEY` is not
sealed yet, so the server generates a random key per process — every new
pod invalidates every open session. An admin tab loaded before the
rollout keeps rendering fine and then fails silently on its next action,
which is exactly the sequence here: sign in, set a quota successfully,
#49 rolls out, next click does nothing.

## The fix

Set `HX-Redirect: /admin/signin` on the 401 when the request came from
htmx, so the browser goes to sign in rather than sitting there. It is
honoured regardless of status — checked against the vendored htmx source,
then confirmed in a browser, because a header proves nothing about what
the client does with it.

A non-htmx POST keeps the plain `401`: there is no browser to redirect,
and a redirect would mask the failure from a script or curl.

The new Playwright test signs in, loads the page, invalidates the cookie
behind the page's back (as a pod restart does), then clicks an action and
asserts the browser lands on the sign-in page. Removing the header makes
it fail, so it is testing the fix rather than the happy path.

## Still worth doing separately

This makes the symptom legible; it does not stop sessions dying on every
rollout. Sealing a real `TYPST_D2_MCP_SESSION_KEY` does that — the value
is already in both overlays' sealed-secret examples.

Refers #40
