### PR TITLE
fix(admin): stop the quota form refusing to save Default or Unlimited

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -191,9 +191,14 @@ func quotaNumber(n int) string {
 	return fmt.Sprintf("%d/day", n)
 }
 
-// quotaValue is the number to prefill the edit field with.
+// quotaValue is the number to prefill the "fixed" edit field with.
+//
+// An override of 0 means unlimited, not a fixed quota of zero, so it
+// prefills nothing. Returning "0" here put an invalid value in a
+// number input and made the browser refuse to submit the form at all —
+// including when Default or Unlimited was the selected mode.
 func quotaValue(override *int) string {
-	if override == nil {
+	if override == nil || *override == 0 {
 		return ""
 	}
 	return fmt.Sprintf("%d", *override)

--- a/internal/web/templates/partials.tmpl
+++ b/internal/web/templates/partials.tmpl
@@ -63,8 +63,17 @@
                   <legend>Quota</legend>
                   <label><input type="radio" name="mode" value="default" {{if not .QuotaOverride}}checked{{end}}> Default</label>
                   <label><input type="radio" name="mode" value="unlimited" {{if and .QuotaOverride (eq (deref .QuotaOverride) 0)}}checked{{end}}> Unlimited</label>
+                  {{/*
+                    No min/required on this field. It is validated by the
+                    browser whatever mode is selected, and there is no way to
+                    disable it conditionally without JavaScript — which this
+                    form deliberately does not depend on. A constraint here
+                    blocks saving Default or Unlimited whenever the box holds
+                    a value the constraint rejects. The server validates the
+                    number instead, and says so in the flash.
+                  */}}
                   <label><input type="radio" name="mode" value="fixed"> Fixed
-                    <input type="number" name="value" min="1" placeholder="10" value="{{quotaValue .QuotaOverride}}" class="narrow">
+                    <input type="number" name="value" inputmode="numeric" placeholder="10" value="{{quotaValue .QuotaOverride}}" class="narrow">
                   </label>
                   <button type="submit" class="btn btn-primary btn-sm">Save quota</button>
                 </fieldset>

--- a/playwright/helpers/db.ts
+++ b/playwright/helpers/db.ts
@@ -67,3 +67,11 @@ export function auditActions(): string[] {
     .split("\n")
     .filter(Boolean);
 }
+
+/** Set a user's quota override directly: NULL inherits, 0 unlimited, N caps. */
+export function seedQuota(login: string, quota: number | null): void {
+  sql(
+    `UPDATE users SET quota_per_day = ${quota === null ? "NULL" : quota}
+      WHERE github_login = '${login}'`,
+  );
+}

--- a/playwright/tests/htmx.spec.ts
+++ b/playwright/tests/htmx.spec.ts
@@ -7,6 +7,7 @@ import {
   countUsers,
   quotaFor,
   seedAPIKey,
+  seedQuota,
   seedSignedInUser,
 } from "../helpers/db";
 
@@ -164,5 +165,64 @@ test.describe("htmx actions", () => {
 
     await page.goto(`${APP_ORIGIN}/admin/audit`);
     await expect(page.locator("table")).toContainText("delete_user");
+  });
+});
+
+// Regression: a user already set to Unlimited stores quota_per_day = 0,
+// which the template prefilled into the "fixed" number input. With
+// min="1" on that input the browser refused to submit the form at all,
+// so an unlimited user could not be moved back to Default or re-saved
+// as Unlimited — the button simply did nothing.
+//
+// Browser-level by necessity: HTML constraint validation is enforced by
+// the browser, so no Go test could see it. It also survives JavaScript
+// being off, which is why the constraint could not just be toggled.
+test.describe("quota form validation", () => {
+  test.beforeEach(async ({ context, page }) => {
+    await signIn(context, APP_ORIGIN);
+    await page.goto(`${APP_ORIGIN}/admin/`);
+  });
+
+  test("an unlimited user can be set back to Default", async ({ page }) => {
+    seedSignedInUser(7001, "wasunlimited");
+    seedQuota("wasunlimited", 0);
+    await page.reload();
+    await expect(page.locator("tr", { hasText: "wasunlimited" })).toContainText("unlimited");
+
+    const row = await openRow(page, "wasunlimited");
+    await row.locator('input[name="mode"][value="default"]').check();
+    await row.getByRole("button", { name: "Save quota" }).click();
+
+    await expect(page.locator("#flash")).toContainText("Quota updated");
+    expect(quotaFor("wasunlimited")).toBe("NULL");
+  });
+
+  test("an unlimited user can be re-saved as Unlimited", async ({ page }) => {
+    seedSignedInUser(7002, "stayunlimited");
+    seedQuota("stayunlimited", 0);
+    await page.reload();
+
+    const row = await openRow(page, "stayunlimited");
+    await row.locator('input[name="mode"][value="unlimited"]').check();
+    await row.getByRole("button", { name: "Save quota" }).click();
+
+    await expect(page.locator("#flash")).toContainText("Quota updated");
+    expect(quotaFor("stayunlimited")).toBe("0");
+  });
+
+  // A junk value in the box must not block an unrelated mode either; the
+  // server decides, and only when Fixed is actually selected.
+  test("a junk value in the fixed box does not block saving Default", async ({ page }) => {
+    seedSignedInUser(7003, "junkvalue");
+    seedQuota("junkvalue", 5);
+    await page.reload();
+
+    const row = await openRow(page, "junkvalue");
+    await row.locator('input[name="value"]').fill("0");
+    await row.locator('input[name="mode"][value="default"]').check();
+    await row.getByRole("button", { name: "Save quota" }).click();
+
+    await expect(page.locator("#flash")).toContainText("Quota updated");
+    expect(quotaFor("junkvalue")).toBe("NULL");
   });
 });


### PR DESCRIPTION
> *"It validates the fixed input field when I try to save Unlimited or Default."*

## What was happening

A user set to Unlimited stores `quota_per_day = 0`, and the template
prefilled that `0` into the **fixed** number input — which carried
`min="1"`.

A number input is validated by the browser whatever else the form
contains, so that one invalid value blocked submission of the **whole
form**, including the Default and Unlimited radios that have nothing to
do with it. The button looked inert and said nothing, because the
request was never sent.

It only appeared once a user was actually set to Unlimited, which is why
it surfaced during the live quota verification rather than earlier.

## The fix

- **`0` prefills nothing.** Zero means unlimited, not a fixed quota of
  zero, so it never belonged in that box.
- **The `min` constraint is gone.** A field cannot be conditionally
  disabled without JavaScript, and this form deliberately works without
  it, so *any* client-side constraint there can block an unrelated mode.
  The server already validates the number and reports it in the flash —
  that path is unit-tested and unchanged.

## Why the tests missed it

The browser suite is the only place this could have been caught: HTML
constraint validation is enforced by the browser, so no Go test can see
it. It missed it because every quota test started from a user with **no
override**, where the box is empty and valid.

Three cases added, all of which fail against the old template and pass
against the new one:

- an unlimited user moved back to Default
- an unlimited user re-saved as Unlimited
- a junk value in the fixed box not blocking a save of Default

24 browser tests pass; Go tests unchanged and green.

Refers #40
