### PR TITLE
ci: reach the design system with a GitHub App, not a PAT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,22 +39,38 @@ jobs:
 
       # The Stormlantern assets under internal/web/static/vendor/ are
       # committed so the image build stays toolchain-free. This catches a
-      # forgotten re-sync after the design system changes. Inert until a
-      # DESIGN_SYSTEM_TOKEN secret exists with read access to that repo.
+      # forgotten re-sync after the design system changes.
+      #
+      # Access is via a GitHub App rather than a PAT: the token is minted
+      # per run and expires in an hour, it is owned by the account rather
+      # than by a person whose access it would otherwise inherit, and
+      # there is no annual expiry to renew by hand. The app id is a repo
+      # variable (it is not secret); only the private key is a secret.
+      #
+      # All three steps stay inert until DS_APP_ID is set, so a fork or a
+      # fresh clone builds without them rather than failing.
+      - name: Mint a token for the design system
+        id: ds_token
+        if: vars.DS_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.DS_APP_ID }}
+          private-key: ${{ secrets.DS_APP_PRIVATE_KEY }}
+          owner: dlouwers
+          repositories: stormlantern-design-system
+
       - name: Check out design system
-        if: env.DS_TOKEN != ''
-        uses: actions/checkout@v4
+        if: vars.DS_APP_ID != ''
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: dlouwers/stormlantern-design-system
-          token: ${{ env.DS_TOKEN }}
+          token: ${{ steps.ds_token.outputs.token }}
           path: .design-system
-        env:
-          DS_TOKEN: ${{ secrets.DESIGN_SYSTEM_TOKEN }}
+          persist-credentials: false
 
       - name: Check vendored assets are in sync
-        if: env.DS_TOKEN != ''
+        if: vars.DS_APP_ID != ''
         env:
-          DS_TOKEN: ${{ secrets.DESIGN_SYSTEM_TOKEN }}
           STORMLANTERN_DS: .design-system
         run: |
           ./scripts/sync-vendor.sh

--- a/scripts/sync-vendor.sh
+++ b/scripts/sync-vendor.sh
@@ -7,6 +7,22 @@
 # image-build time. CI runs this script followed by `git diff
 # --exit-code` to catch a forgotten re-sync.
 #
+# That CI check needs read access to the (private) design-system repo,
+# via a GitHub App rather than a personal token — the token is minted per
+# run and expires in an hour, and it belongs to the account rather than
+# to a person whose access it would otherwise inherit. To enable it:
+#
+#   1. Create a GitHub App under the dlouwers account. No webhook. Give
+#      it exactly one permission: Repository -> Contents -> Read-only.
+#   2. Install it, selecting only stormlantern-design-system.
+#   3. Generate a private key (downloads a .pem).
+#   4. In dlouwers/typst-d2-mcp:
+#        gh variable set DS_APP_ID --body "<the app id>"
+#        gh secret set DS_APP_PRIVATE_KEY < /path/to/key.pem
+#
+# Until DS_APP_ID exists the three steps in ci.yml skip, so a fork or a
+# fresh clone builds without them.
+#
 # Source is a local checkout of the design-system repo rather than the
 # GitHub Packages registry, because the packages are restricted and the
 # build would otherwise need a token. Point STORMLANTERN_DS at the


### PR DESCRIPTION
The vendored-asset drift check needs read access to the private
design-system repo. It was written against a `DESIGN_SYSTEM_TOKEN`
secret that was never created, so those steps have always skipped.

Switches it to a **GitHub App**, which is the better shape for machine
access:

- the token is **minted per run and expires in ~an hour**, rather than a
  credential sitting in secrets indefinitely
- it belongs to the **account, not a person** — a fine-grained PAT
  inherits your access and dies when you rotate it or leave
- **no annual expiry** to renew by hand, which is how PAT-based CI
  usually breaks
- actions attribute to the app rather than to you

The app id is a repo **variable** (it is not secret); only the private
key is a secret. `persist-credentials: false` on the checkout keeps the
minted token out of the workspace git config.

All three steps remain gated on `vars.DS_APP_ID`, so a fork or a fresh
clone builds without them rather than failing.

## To enable

```sh
# 1. Create a GitHub App under dlouwers. No webhook.
#    One permission: Repository -> Contents -> Read-only.
# 2. Install it, selecting only stormlantern-design-system.
# 3. Generate a private key (.pem).
gh variable set DS_APP_ID --body "<app id>" --repo dlouwers/typst-d2-mcp
gh secret set DS_APP_PRIVATE_KEY --repo dlouwers/typst-d2-mcp < key.pem
```

The same steps are recorded in the header of `scripts/sync-vendor.sh`,
next to the claim they support.

## Worth knowing

These steps have **never run** — not before this change either — so the
first build with `DS_APP_ID` present may still need a fix, most likely
around the checkout path or `STORMLANTERN_DS`. Send me the log if it
goes red.

If you later want one identity for all machine access, the same app can
take over `HOMEBREW_TAP_TOKEN` in `release.yml`. Deliberately not done
here: a release-path change deserves its own PR.

Refers #40
