### PR TITLE
ci(release): push Homebrew formulae with a GitHub App, not a PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,31 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.23'
+          # go.mod requires 1.25.5. With 1.23 here the build still worked,
+          # but only because the go command silently downloaded the newer
+          # toolchain on every run — slower, and it hid the mismatch.
+          go-version: '1.25'
           cache: true
+
+      # Writing the Homebrew formulae is machine access to another repo, so
+      # it goes through a GitHub App rather than a personal token: minted
+      # per run, expiring in about an hour, owned by the account rather
+      # than by a person whose access it would otherwise inherit, and with
+      # no annual expiry to renew by hand. The app is installed on
+      # dlouwers/homebrew-tap alone, with Contents: write and nothing else.
+      #
+      # Separate from the read app on purpose — App permissions apply to
+      # every repo in an installation, so a shared app would silently give
+      # the design-system repo write access.
+      - name: Mint a token for the Homebrew tap
+        id: tap_token
+        if: vars.TAP_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          owner: dlouwers
+          repositories: homebrew-tap
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
@@ -31,4 +54,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # Falls back to the old PAT while the app is being adopted, so a
+          # release cannot break on a half-finished switch. Delete
+          # HOMEBREW_TAP_TOKEN once a release has gone out on the app.
+          HOMEBREW_TAP_TOKEN: ${{ steps.tap_token.outputs.token || secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
Moves the last PAT off a personal credential. Writing formulae to
`dlouwers/homebrew-tap` is machine access to another repo, so it goes
through a GitHub App on the same reasoning as the design-system read:
minted per run, ~1h lifetime, owned by the account rather than by a
person whose access it inherits, no annual renewal.

The app is installed on **`homebrew-tap` alone**, `Contents: write`,
nothing else — and is deliberately **separate from the read app**, since
App permissions apply to every repo in an installation and a shared one
would silently grant the design-system repo write access.

`.goreleaser.yml` is **untouched**: `HOMEBREW_TAP_TOKEN` remains the env
var it reads, now carrying a minted token.

## Safe to merge before the variable exists

```yaml
HOMEBREW_TAP_TOKEN: ${{ steps.tap_token.outputs.token || secrets.HOMEBREW_TAP_TOKEN }}
```

The mint step is gated on `vars.TAP_APP_ID`, and the expression falls
back to the existing PAT. So a release works whether or not the app is
configured, and cannot break on a half-finished switch. **Delete
`HOMEBREW_TAP_TOKEN` once a release has gone out on the app.**

To configure:

```sh
gh variable set TAP_APP_ID --body "<app id>" --repo dlouwers/typst-d2-mcp
open --raw ~/Downloads/<key>.pem | gh secret set TAP_APP_PRIVATE_KEY --repo dlouwers/typst-d2-mcp
```

## Also in here

`go-version: '1.23'` in this workflow, against a module requiring
`1.25.5`. Releases worked only because the go command silently
downloaded the newer toolchain each run — so the built binaries were
already 1.25; this just stops hiding it and skips the download.

## Worth knowing

A release path can't be exercised without cutting a tag, so **the next
release is this code's first real run**. That is what the fallback is
for: if anything about the app is misconfigured, the mint step is
skipped or fails and the release proceeds on the old PAT rather than
dying after artifacts are published.

And once branch protection lands on the tap, add the app to the bypass
list — otherwise goreleaser's direct push is rejected.
