### PR TITLE
ci(release): drop the Homebrew PAT fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
       # the design-system repo write access.
       - name: Mint a token for the Homebrew tap
         id: tap_token
-        if: vars.TAP_APP_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.TAP_APP_ID }}
@@ -55,7 +54,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Falls back to the old PAT while the app is being adopted, so a
-          # release cannot break on a half-finished switch. Delete
-          # HOMEBREW_TAP_TOKEN once a release has gone out on the app.
-          HOMEBREW_TAP_TOKEN: ${{ steps.tap_token.outputs.token || secrets.HOMEBREW_TAP_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.tap_token.outputs.token }}


### PR DESCRIPTION
The app write path is verified end to end — #58's workflow minted a
token, checked out the tap, and pushed to a protected `main`, exercising
the app id, the private key, the installation scope and the ruleset
bypass in a single run.

So both scaffolds go:

- the `|| secrets.HOMEBREW_TAP_TOKEN` fallback
- the `if: vars.TAP_APP_ID != ''` guard on the mint step

They existed to keep a release working while the app was unproven.
Keeping them now would only hide a broken app behind an expression that
cannot help anyway: once the branch is protected, a personal token is
rejected from `main` exactly as a misconfigured app would be.

`HOMEBREW_TAP_TOKEN` is deleted from the repository secrets.

The verification workflow stays — it is the thing to re-run after
rotating the private key, changing the installation, or editing the
ruleset, rather than finding out at the next release.