### PR TITLE
ci: clear the deprecation warnings from the app token workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -48,21 +48,21 @@ jobs:
       # there is no annual expiry to renew by hand. The app id is a repo
       # variable (it is not secret); only the private key is a secret.
       #
-      # All three steps stay inert until DS_APP_ID is set, so a fork or a
-      # fresh clone builds without them rather than failing.
+      # All three steps stay inert until DS_APP_CLIENT_ID is set, so a fork
+      # or a fresh clone builds without them rather than failing.
       - name: Mint a token for the design system
         id: ds_token
-        if: vars.DS_APP_ID != ''
+        if: vars.DS_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.DS_APP_ID }}
+          client-id: ${{ vars.DS_APP_CLIENT_ID }}
           private-key: ${{ secrets.DS_APP_PRIVATE_KEY }}
           owner: dlouwers
           repositories: stormlantern-design-system
 
       - name: Check out design system
-        if: vars.DS_APP_ID != ''
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        if: vars.DS_APP_CLIENT_ID != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: dlouwers/stormlantern-design-system
           token: ${{ steps.ds_token.outputs.token }}
@@ -70,7 +70,7 @@ jobs:
           persist-credentials: false
 
       - name: Check vendored assets are in sync
-        if: vars.DS_APP_ID != ''
+        if: vars.DS_APP_CLIENT_ID != ''
         env:
           STORMLANTERN_DS: .design-system
         run: |
@@ -109,7 +109,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -34,7 +34,7 @@ jobs:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
         id: tap_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAP_APP_ID }}
+          client-id: ${{ vars.TAP_APP_CLIENT_ID }}
           private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
           owner: dlouwers
           repositories: homebrew-tap

--- a/.github/workflows/verify-tap-write.yml
+++ b/.github/workflows/verify-tap-write.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - name: Require the app to be configured
         env:
-          TAP_APP_ID: ${{ vars.TAP_APP_ID }}
+          TAP_APP_CLIENT_ID: ${{ vars.TAP_APP_CLIENT_ID }}
         run: |
-          if [ -z "$TAP_APP_ID" ]; then
-            echo "::error::TAP_APP_ID is not set — configure the app before running this"
+          if [ -z "$TAP_APP_CLIENT_ID" ]; then
+            echo "::error::TAP_APP_CLIENT_ID is not set — configure the app before running this"
             exit 1
           fi
 
@@ -36,13 +36,13 @@ jobs:
         id: tap_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAP_APP_ID }}
+          client-id: ${{ vars.TAP_APP_CLIENT_ID }}
           private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
           owner: dlouwers
           repositories: homebrew-tap
 
       - name: Check out the tap
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: dlouwers/homebrew-tap
           token: ${{ steps.tap_token.outputs.token }}


### PR DESCRIPTION
Both deprecations the tap verification run surfaced:

```
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
Node.js 20 is deprecated ... actions/checkout@11d5960…
```

## `app-id` → `client-id`

Applied to all three workflows that mint a token (CI, release, verify).

**These are different values.** The app id is the number GitHub shows as
"App ID"; the client id is the `Iv23li…` string beside it on the same
page. So the variables are renamed to match what they now hold, rather
than leaving `*_APP_ID` quietly containing a client id:

| old | new |
| --- | --- |
| `DS_APP_ID` | `DS_APP_CLIENT_ID` |
| `TAP_APP_ID` | `TAP_APP_CLIENT_ID` |

The **ruleset bypass on the tap still uses the numeric app id** — that
is GitHub's own configuration rather than ours, and is untouched.

## checkout 4.4.0 → 7.0.1

Everywhere, including the one call already on 5.1.0, so the repo has a
single version. Reviewed the majors: v5 moved to Node 24, v6 changed
where credentials are persisted, v7 blocks fork checkouts on
`pull_request_target` / `workflow_run` — none of which this repo uses.

## Before merging

Set the two new variables, or CI and releases lose their token. Both
client ids are on each app's settings page:

```sh
gh variable set DS_APP_CLIENT_ID  --body "Iv23li…" --repo dlouwers/typst-d2-mcp
gh variable set TAP_APP_CLIENT_ID --body "Iv23li…" --repo dlouwers/typst-d2-mcp
```

Setting them early is harmless — nothing reads them until this merges.
Afterwards, `gh variable delete DS_APP_ID` and `TAP_APP_ID`.

## Note on #59

That PR deletes the `if: vars.TAP_APP_ID != ''` guard this one renames,
so whichever lands second needs a one-line conflict resolution. Merging
#59 first makes this a clean rebase.

## Then re-run the verifier

`verify-tap-write.yml` exercises the client-id switch *and* the checkout
credential-persistence change on the one path that depends on both — for
an empty commit rather than a broken release.
