### PR TITLE
ci: give every job a timeout, and stop apt-installing on a cache hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -105,6 +106,7 @@ jobs:
   # Separate job so a browser flake doesn't gate Go-test feedback.
   playwright:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -138,10 +140,11 @@ jobs:
         working-directory: playwright
         run: bunx playwright install --with-deps chromium
 
-      - name: Install Chromium system deps only (cache hit)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        working-directory: playwright
-        run: bunx playwright install-deps chromium
+      # No apt step on a cache hit. `playwright install-deps` took 2m28s on
+      # a job whose tests take 14s, and twice hung past 15 minutes — and
+      # the ubuntu-latest image already ships the libraries Chromium
+      # needs. If one ever is missing the browser fails to launch, which
+      # is loud and immediate rather than subtle.
 
       # playwright.config.ts starts the server itself via
       # scripts/e2e-server.sh, which builds the binary with the Go

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   image:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0

--- a/.github/workflows/verify-tap-write.yml
+++ b/.github/workflows/verify-tap-write.yml
@@ -21,6 +21,7 @@ permissions: {}
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Require the app to be configured
         env:


### PR DESCRIPTION
Prompted by the Playwright job on #59 sitting at 16 minutes with no end
in sight.

## No job had a timeout

`timeout-minutes` appeared nowhere, so every job inherited GitHub's
default of **360 minutes**. Today's hang would have burned six hours of
runner time before anyone intervened.

| job | budget | observed |
| --- | --- | --- |
| `build` | 20m | ~1m20s |
| `playwright` | 15m | ~3m |
| `image` | 30m | ~4m |
| `goreleaser` | 30m | minutes |
| `verify` | 10m | ~30s |

## The hang itself

It was the cache-hit branch, which exists only to apt-install Chromium's
system libraries:

- **2m28s** on the run that completed — against **14s** of actual tests,
  so the job was ~90% apt
- hung past **15 minutes** twice, on two concurrent runs

`ubuntu-latest` already ships the libraries Chromium needs;
`install-deps` is aimed at bare containers. So it's dropped on cache
hit. The cache-miss path still uses `--with-deps`, so a fresh runner is
covered.

If a library really is missing, Chromium fails to launch — loud and
immediate, not a subtle flake. Easy to restore if that happens.

Expected effect: the Playwright job goes from ~3 minutes to ~30 seconds
on a warm cache.

## Also

Corrects a comment claiming `install-deps` takes "20-30s". I copied that
from investor-buddy when I wrote the job and never measured it here.
It's 2m28s.