### PR TITLE
chore: move to golangci-lint v2, clearing the last Node 20 warning

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -48,13 +48,10 @@ curl -fsSL https://bun.sh/install | bash > /dev/null
 sudo ln -sf "$HOME/.bun/bin/bun" /usr/local/bin/bun
 sudo ln -sf "$HOME/.bun/bin/bunx" /usr/local/bin/bunx
 
-# golangci-lint is pinned to the version CI runs (what
-# golangci-lint-action resolves `latest` to at its pinned version). v1
-# and v2 disagree about config format and default linters, so an
-# unpinned install would mean a clean local run does not imply a clean
-# CI run. Moving both to 2.x is a separate job.
+# Both local and CI are on golangci-lint v2 now, driven by .golangci.yml,
+# so `latest` matches what CI resolves rather than drifting from it.
 echo "==> Go tools"
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 go install golang.org/x/tools/gopls@latest
 go install golang.org/x/vuln/cmd/govulncheck@latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,14 +91,9 @@ jobs:
         run: go build -v ./cmd/typst-d2-mcp
 
       - name: Lint
-        # The action's default install-mode downloads a pre-built
-        # binary that ships with Go 1.24 and refuses to lint a Go-1.25
-        # module. `goinstall` recompiles the linter with the runner's
-        # toolchain (set above to 1.25), avoiding the version mismatch.
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
-          install-mode: goinstall
 
   # Browser-level checks for the admin UI: the things a Go test cannot
   # reach. Chief among them is SameSite cookie behaviour — the only CSRF

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+# golangci-lint v2.
+#
+# v1 shipped a set of built-in exclusions and applied them silently; v2
+# removed that behaviour and expects them to be named. `std-error-handling`
+# is the preset holding the ones this repo relied on — unchecked deferred
+# Close on a read, os.Remove of a temp file, fmt.Fprint to a
+# ResponseWriter. Without it the v1 -> v2 move would surface eleven
+# findings that v1 had been hiding rather than eleven new problems.
+#
+# Two of those eleven were real and are fixed rather than excluded: a
+# Close after *writing* a temp file can hide a flush error, which would
+# hand typst a truncated document.
+version: "2"
+
+linters:
+  exclusions:
+    presets:
+      - std-error-handling

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -832,7 +832,12 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		if _, err := tmpFile.WriteString(processed); err != nil {
 			return mcp.NewToolResultErrorFromErr("Failed to write temp file", err), nil
 		}
-		tmpFile.Close()
+		// Checked: a failed flush here would hand typst a truncated
+		// document, and the compile error that followed would point at the
+		// wrong thing.
+		if err := tmpFile.Close(); err != nil {
+			return mcp.NewToolResultErrorFromErr("Failed to close temp file", err), nil
+		}
 
 		// Output PDF sits next to the input .typ inside the workspace.
 		resolvedOut := strings.TrimSuffix(resolvedIn, ".typ") + ".pdf"

--- a/internal/typst/typst.go
+++ b/internal/typst/typst.go
@@ -25,7 +25,11 @@ func Compile(content, outputFile string) error {
 		tmpFile.Close()
 		return fmt.Errorf("failed to write temp file: %w", err)
 	}
-	tmpFile.Close()
+	// Checked, unlike the close in the error path above: a failed flush
+	// here means typst would compile a truncated document.
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
 
 	// Compile with Typst
 	cmd := exec.Command("typst", "compile", tmpPath, outputFile)


### PR DESCRIPTION
`golangci-lint-action` v6 is the only action still targeting Node 20, and
**v7+ supports golangci-lint v2 only** — so clearing that last warning
means taking the linter major.

## What v2 changed

v2 removed the built-in exclusions v1 applied silently, so a bare run
reports **11 errcheck findings**. They are not new problems; they are
what v1 was hiding.

**Ten are genuinely ignorable** — deferred `Close` on a read,
`os.Remove` of a temp file, `fmt.Fprint` to a `ResponseWriter`.
`.golangci.yml` names the `std-error-handling` preset that covers
exactly those, so the migration is behaviour-neutral rather than quietly
changing what is enforced.

**Two were real, and are fixed rather than excluded.** `Close` after
*writing* a temp file, in `typst.Compile` and in the compile handler:

```go
tmpFile.WriteString(content)
tmpFile.Close()          // unchecked
```

A failed flush there hands `typst` a truncated document, and the compile
error that follows points at the wrong thing. Adding the preset would
have buried both again, so they are handled first.

## Also

- action → v9.3.0
- `install-mode: goinstall` dropped — it existed because v1's prebuilt
  binaries refused a `go 1.25` module, which v2 builds do not
- devcontainer stops pinning `v1.64.8`, so local and CI share a major
  again

Verified locally against v2.12.2: `0 issues`, and the Go suite passes.
