### PR TITLE
feat(templates): house document templates as an owner-namespaced package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+
+# Documentation for the template packages; typst never reads it, and it
+# would otherwise land inside the package namespace directory.
+templates/README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,20 @@ RUN curl -fsSL "https://github.com/typst/typst/releases/download/${TYPST_VERSION
       | tar -xJ -C /usr/local/bin --strip-components=1 \
  && typst --version
 
+# House document templates, resolved by typst as `@house/templates:0.1.0`.
+#
+# typst looks for local packages under $XDG_DATA_HOME/typst/packages/
+# <namespace>/<name>/<version>, so the directory layout *is* the import
+# path. The namespace is an owner slug: one baked-in owner today, per
+# organisation later, without the import path in anyone's document
+# changing.
+#
+# XDG_DATA_HOME is set to an image path so templates ship read-only with
+# the binary. typst's writable cache for @preview packages keeps using
+# $HOME, which the deployment points at its volume.
+COPY templates/ /usr/local/share/typst/packages/
+ENV XDG_DATA_HOME=/usr/local/share
+
 # Drop privileges. UID/GID match the convention used by distroless's
 # "nonroot" so swapping bases later is painless.
 RUN groupadd --system --gid 65532 nonroot \

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -234,6 +234,88 @@ VERIFYING THE RESULT:
   diagrams, or remove non-essential nodes. If you cannot view the PDF
   yourself, advise the user to inspect it.`
 
+// House templates live in a typst local package, so the model imports
+// them by name rather than by path — which matters because the compile
+// root is the staged file's temp directory, not the workspace.
+//
+// The namespace is an owner slug. There is one owner today, baked into
+// the image; when owners become organisations the storage moves, the
+// import path does not.
+const (
+	templateNamespace = "house"
+	templateName      = "templates"
+	templateVersion   = "0.1.0"
+)
+
+// typstDataDir mirrors how typst locates local packages.
+func typstDataDir() string {
+	if d := os.Getenv("XDG_DATA_HOME"); d != "" {
+		return d
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".local", "share")
+}
+
+// templateInstructions describes the house templates to the model, or
+// returns empty when the package is not installed.
+//
+// Advertising them unconditionally would be worse than not having them:
+// a stdio user has no package directory, so the model would confidently
+// write an import that cannot resolve and burn a compile finding out.
+func templateInstructions() string {
+	data := typstDataDir()
+	if data == "" {
+		return ""
+	}
+	pkg := filepath.Join(data, "typst", "packages",
+		templateNamespace, templateName, templateVersion)
+	if _, err := os.Stat(pkg); err != nil {
+		return ""
+	}
+	return fmt.Sprintf(`
+
+HOUSE TEMPLATES:
+  This server ships document templates. Prefer them over styling a
+  document yourself — they exist so that documents from different
+  people, written at different times, come out looking the same.
+
+    #import "@%[1]s/%[2]s:%[3]s": report, adr
+
+  report — owns the look; you write whatever content suits.
+
+    #show: report.with(
+      title: "Deployment architecture",
+      subtitle: "optional",
+      author: "optional",
+    )
+    = Overview
+    Body content, including #d2[...] blocks.
+
+  adr — an architecture decision record. Its sections are arguments
+  rather than headings, so every ADR carries the same ones:
+
+    #show: adr.with(
+      title: "Use a GitHub App for machine access",
+      number: 7,
+      status: "Accepted",
+      background: [Why this came up.],
+      decision: [What was decided.],
+      consequences: [What follows.],
+      alternatives: [Optional.],
+    )
+
+  Note "background", not "context": context is a reserved word in Typst.
+  The rendered heading still reads "Context".
+
+  Do not override the template's fonts, colours or page setup. A
+  document that restyles itself has opted out of the house style, which
+  is the one thing these templates exist to prevent.`,
+		templateNamespace, templateName, templateVersion)
+}
+
 func main() {
 	initLogger()
 
@@ -257,7 +339,7 @@ func main() {
 		serverVersion,
 		server.WithToolCapabilities(false),
 		server.WithResourceCapabilities(false, false),
-		server.WithInstructions(serverInstructions),
+		server.WithInstructions(serverInstructions+templateInstructions()),
 	)
 
 	registerTools(s, factory, store)

--- a/cmd/typst-d2-mcp/templates_test.go
+++ b/cmd/typst-d2-mcp/templates_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// repoTemplates is the package tree as it sits in the repo, which the
+// Dockerfile copies into the image's typst package directory.
+func repoTemplates(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(filepath.Join("..", "..", "templates"))
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("templates dir missing: %v", err)
+	}
+	return dir
+}
+
+// The instructions are only honest when the package is actually
+// installed. A stdio user has no package directory, and telling the
+// model to import something unresolvable costs them a compile — and,
+// against a metered server, possibly their whole day's quota.
+func TestTemplateInstructions_OnlyWhenInstalled(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		t.Setenv("XDG_DATA_HOME", t.TempDir())
+		if got := templateInstructions(); got != "" {
+			t.Errorf("instructions advertised templates that are not installed:\n%s", got)
+		}
+	})
+
+	t.Run("present", func(t *testing.T) {
+		data := t.TempDir()
+		pkg := filepath.Join(data, "typst", "packages",
+			templateNamespace, templateName, templateVersion)
+		if err := os.MkdirAll(pkg, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		t.Setenv("XDG_DATA_HOME", data)
+
+		got := templateInstructions()
+		for _, want := range []string{
+			`@house/templates:0.1.0`,
+			"report",
+			"adr",
+			"background", // not "context" — reserved word in Typst
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("instructions missing %q", want)
+			}
+		}
+	})
+}
+
+// Compiles both document types through the real typst binary, against
+// the package exactly as the repo ships it. This is what catches a
+// template that is valid Typst but broken as an API — a parameter typst
+// reserves, or a body that a show rule cannot pass.
+func TestHouseTemplates_Compile(t *testing.T) {
+	if _, err := exec.LookPath("typst"); err != nil {
+		t.Skip("typst not installed")
+	}
+
+	cases := map[string]string{
+		"report": `#import "@house/templates:0.1.0": report
+#show: report.with(title: "A report", subtitle: "sub", author: "someone")
+= Heading
+Body text with #emph[emphasis] and a #link("https://example.test")[link].
+`,
+		"adr": `#import "@house/templates:0.1.0": adr
+#show: adr.with(
+  title: "A decision",
+  number: 1,
+  status: "Accepted",
+  background: [Why.],
+  decision: [What.],
+  consequences: [So what.],
+)
+== Appendix
+Trailing content.
+`,
+		// Defaults must work: the model will omit optional arguments.
+		"report with defaults": `#import "@house/templates:0.1.0": report
+#show: report.with(title: "Minimal")
+= Only a title
+`,
+	}
+
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			in := filepath.Join(dir, "doc.typ")
+			out := filepath.Join(dir, "doc.pdf")
+			if err := os.WriteFile(in, []byte(src), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			// The repo keeps the tree at <repo>/templates/<ns>/..., while
+			// typst wants <data>/typst/packages/<ns>/..., so stage a
+			// directory in that shape rather than fighting the layout.
+			staged := t.TempDir()
+			pkgRoot := filepath.Join(staged, "typst", "packages")
+			if err := os.MkdirAll(pkgRoot, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.Symlink(filepath.Join(repoTemplates(t), templateNamespace),
+				filepath.Join(pkgRoot, templateNamespace)); err != nil {
+				t.Fatalf("symlink: %v", err)
+			}
+
+			cmd := exec.Command("typst", "compile", in, out)
+			cmd.Env = append(os.Environ(), "XDG_DATA_HOME="+staged)
+
+			if outBytes, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("typst compile failed: %v\n%s", err, outBytes)
+			}
+			if info, err := os.Stat(out); err != nil || info.Size() == 0 {
+				t.Errorf("no PDF produced: %v", err)
+			}
+		})
+	}
+}

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,63 @@
+# House document templates
+
+Typst packages, baked into the image, that documents import by name:
+
+```typst
+#import "@house/templates:0.1.0": report, adr
+```
+
+## Why the layout looks like this
+
+typst resolves local packages from
+`$XDG_DATA_HOME/typst/packages/<namespace>/<name>/<version>`, so this
+directory tree *is* the import path. `XDG_DATA_HOME` is set to
+`/usr/local/share` in the image, which is why templates ship read-only
+alongside the binary while typst's writable `@preview` cache stays under
+`$HOME` on the data volume.
+
+Importing by package name rather than by file path is not a stylistic
+choice: the compile root is the staged `.typ` file's temporary
+directory, not the caller's workspace, so a relative import of a
+workspace file would not resolve at all.
+
+## Why `house` is a namespace and not a folder name
+
+`house` is an **owner slug**. Today there is one owner and its packages
+are baked into the image. The intended path is:
+
+1. one owner, in the image — where this is now
+2. owners' packages on the data volume, so house style changes without
+   an image rebuild
+3. owners become organisations in the schema, with users able to belong
+   to more than one
+4. each compile resolves only the namespaces its caller can see — the
+   same sandboxing discipline as `workspace.ScopedFS`
+5. organisation-scoped template management through the admin UI
+
+Storage moves at every step. The import path in people's documents does
+not, which is the point of putting the owner in the namespace: a user in
+three organisations has no "current organisation" to select, because the
+document already says which one it means.
+
+## Adding a document type
+
+Export a function from `lib.typ`. Two shapes exist deliberately:
+
+- `report` owns the **look**. The author writes what they like.
+- `adr` owns the **structure** too — its sections are arguments, not
+  headings the author has to remember, so every ADR carries the same
+  ones in the same order.
+
+Reach for the second shape when a document type has a required shape;
+consistent styling over inconsistent structure is only half the job.
+
+Two Typst constraints worth knowing before adding one:
+
+- `context` is a reserved word and cannot be a parameter name. `adr`
+  takes `background:` and renders the heading as "Context".
+- A trailing body must be **positional**. `#show: adr.with(...)` passes
+  the rest of the document positionally, and a named `body:` parameter
+  rejects it.
+
+Both are covered by tests in `cmd/typst-d2-mcp/templates_test.go`, which
+compile every type through the real typst binary.

--- a/templates/house/templates/0.1.0/lib.typ
+++ b/templates/house/templates/0.1.0/lib.typ
@@ -1,0 +1,139 @@
+// House document templates.
+//
+// Imported as `@house/templates:0.1.0`, where `house` is the namespace
+// typst resolves from $XDG_DATA_HOME/typst/packages/<namespace>/. That
+// namespace is the *owner* slug: today there is one, baked into the
+// image; later it is per-organisation, materialised per request. The
+// import path is what ends up inside people's documents, so it is
+// deliberately already organisation-shaped.
+//
+// Two shapes on purpose:
+//
+//   report — owns the look. The author writes whatever content they
+//            like and it comes out consistent.
+//
+//   adr    — owns the *structure* too. Sections are arguments, not
+//            headings the author remembers to write, so every ADR has
+//            the same ones in the same order.
+//
+// Styling only ever comes from here. A document that overrides fonts or
+// colours has opted out of the house style, which defeats the point.
+
+#let _accent = rgb("#1f5673")
+#let _muted = rgb("#5b6b73")
+
+// Page geometry suits A4 portrait with diagrams: generous margins so a
+// wide `#d2` block has somewhere to breathe rather than touching the
+// edge of the page.
+#let _page-setup(body) = {
+  set page(
+    paper: "a4",
+    margin: (top: 2.5cm, bottom: 2.5cm, x: 2.2cm),
+    numbering: "1",
+    number-align: center,
+  )
+  set text(size: 10.5pt, lang: "en")
+  set par(justify: true, leading: 0.7em)
+
+  show heading.where(level: 1): it => block(
+    above: 1.6em, below: 0.8em,
+    text(size: 15pt, weight: 700, fill: _accent, it.body),
+  )
+  show heading.where(level: 2): it => block(
+    above: 1.2em, below: 0.6em,
+    text(size: 12pt, weight: 600, it.body),
+  )
+  show link: it => text(fill: _accent, it)
+  show raw.where(block: false): it => box(
+    fill: luma(240), inset: (x: 3pt), outset: (y: 3pt), radius: 2pt, it,
+  )
+
+  // Diagrams are figures: centred, with the caption styled down so it
+  // reads as a label rather than competing with body text.
+  show figure.caption: it => text(size: 9pt, fill: _muted, it)
+
+  body
+}
+
+#let _title-block(title, subtitle, author, date) = {
+  // Titles are never justified or hyphenated: body justification is
+  // fine, but a hyphenated title ("machine ac-cess") looks like a fault.
+  set par(justify: false)
+  set text(hyphenate: false)
+  block(width: 100%, inset: (bottom: 1.2em))[
+    #text(size: 24pt, weight: 800, fill: _accent, title)
+    #if subtitle != none [
+      #linebreak()
+      #text(size: 13pt, fill: _muted, subtitle)
+    ]
+    #v(0.4em)
+    #line(length: 100%, stroke: 0.8pt + _accent)
+    #v(0.2em)
+    #text(size: 9.5pt, fill: _muted)[
+      #if author != none [#author #h(1em)]
+      #date
+    ]
+  ]
+}
+
+/// A general technical document: title block, then whatever the author
+/// writes. Use this when the content's shape is the author's choice.
+#let report(
+  title: "Untitled",
+  subtitle: none,
+  author: none,
+  date: datetime.today().display("[year]-[month]-[day]"),
+  body,
+) = {
+  show: _page-setup
+  _title-block(title, subtitle, author, date)
+  body
+}
+
+/// An architecture decision record. The sections are arguments rather
+/// than headings, so every ADR carries the same ones, in the same order,
+/// whoever wrote it.
+///
+/// The first section is `background:` rather than `context:` because
+/// `context` is a reserved word in Typst and cannot be a parameter name.
+/// The heading still reads "Context", which is the convention people
+/// expect to see.
+///
+/// Use it as `#show: adr.with(...)`, which hands the rest of the
+/// document over as the trailing `body`; anything written there lands
+/// after the fixed sections, as an appendix. `body` is positional
+/// because that is how a show rule passes it — a named parameter would
+/// reject the document.
+#let adr(
+  title: "Untitled decision",
+  number: none,
+  status: "Proposed",
+  date: datetime.today().display("[year]-[month]-[day]"),
+  background: [],
+  decision: [],
+  consequences: [],
+  alternatives: none,
+  body,
+) = {
+  show: _page-setup
+
+  let heading-text = if number != none [ADR #number: #title] else [#title]
+  _title-block(heading-text, none, none, date)
+
+  block(
+    fill: luma(245), inset: 8pt, radius: 3pt, width: 100%,
+    text(size: 9.5pt)[*Status:* #status],
+  )
+
+  heading(level: 1)[Context]
+  background
+  heading(level: 1)[Decision]
+  decision
+  heading(level: 1)[Consequences]
+  consequences
+  if alternatives != none {
+    heading(level: 1)[Alternatives considered]
+    alternatives
+  }
+  body
+}

--- a/templates/house/templates/0.1.0/typst.toml
+++ b/templates/house/templates/0.1.0/typst.toml
@@ -1,0 +1,7 @@
+[package]
+name = "templates"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["typst-d2-mcp"]
+license = "MIT"
+description = "House document templates for typst-d2-mcp."


### PR DESCRIPTION
Rung 1 of #63: **one owner's templates, baked into the image**, addressed
the way they will still be addressed once owners are organisations.

```typst
#import "@house/templates:0.1.0": report, adr
```

## Two shapes, deliberately

- **`report`** owns the *look*. The author writes whatever content suits.
- **`adr`** owns the *structure* too — its sections are arguments, not
  headings someone has to remember, so every ADR carries the same ones
  in the same order.

Consistent styling over inconsistent structure is only half the job, and
the second shape is the half that usually gets skipped.

## Why `house` is a namespace, not a folder

typst resolves local packages from
`$XDG_DATA_HOME/typst/packages/<namespace>/<name>/<version>` — the
directory layout **is** the import path. Putting the owner there is the
load-bearing decision, because storage can move underneath it repeatedly
while the import path lives inside other people's documents.

It also disposes of the multi-tenancy question: a user in three
organisations needs no "current organisation" selector, because the
document already names the one it means.

Importing by package name rather than file path is forced rather than
stylistic — the compile root is the staged `.typ` file's temp directory,
not the caller's workspace, so a relative import of a workspace file
cannot resolve at all.

## Honest about availability

Templates appear in `serverInstructions` **only when the package is
installed**. A stdio user has no package directory; telling the model to
write an unresolvable import would cost a compile, and against a 1/day
quota possibly the user's whole day.

## Two typst constraints, found by building it

- **`context` is a reserved word** and cannot be a parameter name. `adr`
  takes `background:`; the rendered heading still reads "Context".
- **A trailing body must be positional** — `#show: adr.with(...)` passes
  the document positionally, and a named `body:` rejects it.

Both are covered by tests rather than by comments, and recorded in
`templates/README.md` for whoever adds the third document type.

Refers #63
