### PR TITLE
fix(ci): unblock Dependabot PRs and add step-level timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      # The design-system steps need the GitHub App private key, which lives
+      # only in the regular Actions secret store. Dependabot runs (and fork
+      # PRs) get an *empty* `secrets` context — yet `vars` still resolve there,
+      # so guarding on `vars.DS_APP_CLIENT_ID != ''` alone lets the token-mint
+      # step run and then fail hard with "private-key must be non-empty",
+      # taking the whole job red. Gate on the key itself: absent key ⇒ the DS
+      # steps stay inert. Referencing an absent secret yields "" (no error), so
+      # this is safe to evaluate in every context. `secrets` is not usable in an
+      # `if:`, but reading it into a job-level env var and testing that is the
+      # documented workaround.
+      HAS_DS_KEY: ${{ secrets.DS_APP_PRIVATE_KEY != '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -28,14 +40,17 @@ jobs:
           cache: true
 
       - name: Install D2
+        timeout-minutes: 3
         run: curl -fsSL https://d2lang.com/install.sh | sh -s --
 
       - name: Install Typst
+        timeout-minutes: 3
         run: |
           curl -fsSL https://github.com/typst/typst/releases/download/v0.14.2/typst-x86_64-unknown-linux-musl.tar.xz \
             | tar -xJ -C /usr/local/bin --strip-components=1
 
       - name: Download dependencies
+        timeout-minutes: 5
         run: go mod download
 
       # The Stormlantern assets under internal/web/static/vendor/ are
@@ -48,11 +63,13 @@ jobs:
       # there is no annual expiry to renew by hand. The app id is a repo
       # variable (it is not secret); only the private key is a secret.
       #
-      # All three steps stay inert until DS_APP_CLIENT_ID is set, so a fork
-      # or a fresh clone builds without them rather than failing.
+      # All three steps stay inert unless DS_APP_PRIVATE_KEY is available (see
+      # HAS_DS_KEY above), so a Dependabot run, a fork PR, or a fresh clone
+      # builds without them rather than failing on the missing key.
       - name: Mint a token for the design system
         id: ds_token
-        if: vars.DS_APP_CLIENT_ID != ''
+        if: env.HAS_DS_KEY == 'true'
+        timeout-minutes: 2
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.DS_APP_CLIENT_ID }}
@@ -61,7 +78,8 @@ jobs:
           repositories: stormlantern-design-system
 
       - name: Check out design system
-        if: vars.DS_APP_CLIENT_ID != ''
+        if: env.HAS_DS_KEY == 'true'
+        timeout-minutes: 3
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: dlouwers/stormlantern-design-system
@@ -70,7 +88,8 @@ jobs:
           persist-credentials: false
 
       - name: Check vendored assets are in sync
-        if: vars.DS_APP_CLIENT_ID != ''
+        if: env.HAS_DS_KEY == 'true'
+        timeout-minutes: 2
         env:
           STORMLANTERN_DS: .design-system
         run: |
@@ -79,18 +98,23 @@ jobs:
             || { echo "::error::vendored design-system assets are stale; run scripts/sync-vendor.sh"; exit 1; }
 
       - name: Run go vet
+        timeout-minutes: 5
         run: go vet ./...
 
       - name: Run tests
+        timeout-minutes: 10
         run: go test -v ./...
 
       - name: Build typst-d2-prep
+        timeout-minutes: 5
         run: go build -v ./cmd/typst-d2-prep
 
       - name: Build typst-d2-mcp
+        timeout-minutes: 5
         run: go build -v ./cmd/typst-d2-mcp
 
       - name: Lint
+        timeout-minutes: 10
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
@@ -118,6 +142,7 @@ jobs:
           bun-version: latest
 
       - name: Install Playwright deps
+        timeout-minutes: 3
         working-directory: playwright
         run: bun install --frozen-lockfile
 
@@ -132,6 +157,7 @@ jobs:
 
       - name: Install Chromium + system deps (cache miss)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 8
         working-directory: playwright
         run: bunx playwright install --with-deps chromium
 
@@ -145,6 +171,7 @@ jobs:
       # scripts/e2e-server.sh, which builds the binary with the Go
       # toolchain set up above.
       - name: Run Playwright tests
+        timeout-minutes: 5
         working-directory: playwright
         run: bunx playwright test
 


### PR DESCRIPTION
## Problem

CI failed on every Dependabot PR (#65 sqlite, #66 upload-artifact, #67 setup-buildx, #68 build-push-action). The **build** job died at *"Mint a token for the design system"*:

```
Error: The 'private-key' input must be set to a non-empty string.
```

The step was guarded on `vars.DS_APP_CLIENT_ID != ''`. On Dependabot runs the repository *variable* still resolves, but the run uses the **separate Dependabot secret store** (`Secret source: Dependabot` in the log) where `secrets.DS_APP_PRIVATE_KEY` is empty — an intentional GitHub security boundary for untrusted diffs. So the guard passed, the step ran, and the missing key failed it, cascading to skip vet/tests/build/lint and turn the job red. The same hole hits fork PRs.

## Fix

- **Gate on the actual precondition — the private key's presence** — via a job-level `HAS_DS_KEY` env var (`secrets` can't be referenced directly in an `if:`; reading it into env is the documented workaround). Dependabot and fork PRs now skip the three design-system steps and run the real validation, which is exactly what should gate a dependency bump. The vendored-asset sync check still gates push-to-`main`, where it is both possible (secrets available) and meaningful (assets could actually drift).
- **Add step-level `timeout-minutes`** to the network- and browser-bound steps (D2/Typst install, `go mod download`, token mint, DS checkout, tests, lint, Playwright deps/Chromium/test run) so a genuine hang fails fast instead of consuming the full 20/15-minute job budget. The Playwright job's own comment already noted `install-deps` hung twice past the limit.

Validated with `actionlint` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)