### PR TITLE
fix(put_file): advertise the decoded-byte size limit (#69)

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -107,6 +107,23 @@ func maxInputBytes() int64 {
 	return int64Env(envMaxInputBytes, defaultMaxInputBytes)
 }
 
+// humanBytes renders a byte count in binary units for human-facing text
+// (the put_file description and its too-large error). Mirrors the admin
+// UI's bytesLabel; kept here to avoid importing internal/web into the
+// command.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for m := n / unit; m >= unit; m /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGT"[exp])
+}
+
 // quotaPerDay is the per-user UTC-day ceiling on successful compile
 // attempts; 0 disables the check. Only enforced for non-anonymous
 // identities (i.e. authenticated users), so self-hosted single-tenant
@@ -787,8 +804,9 @@ split it, simplify it, or switch to 'direction: down'.`),
 	)
 	s.AddTool(compileTypstTool, handleCompileTypst(factory, store))
 
+	inputLimit := maxInputBytes()
 	putFileTool := mcp.NewTool("put_file",
-		mcp.WithDescription(`Write a file into the server's active workspace.
+		mcp.WithDescription(fmt.Sprintf(`Write a file into the server's active workspace.
 
 Use this only when your runtime cannot directly write to the target
 filesystem — for example when talking to a hosted MCP server over HTTP.
@@ -796,9 +814,19 @@ When running against a local stdio server, prefer your host's filesystem
 tools (Write/Edit) so you don't ship the file content through this
 channel.
 
+Size limit: content must be at most %d bytes (%s) measured AFTER decoding.
+For base64, that bound is the decoded size — roughly 3/4 of the string you
+pass — NOT the length of the base64 string, so judge against the decoded
+size, not the encoded one. Raise %s on the server to lift the ceiling.
+Pushing a binary asset that fits under this limit — e.g. an image a Typst
+document references, which must exist in the workspace before you compile —
+is expected and supported: do it rather than giving up or falling back to a
+local toolchain, which a hosted deployment may not have.
+
 The path is resolved through the server's active workspace. In local
 mode any path is accepted; in scoped/hosted mode the path must be
-relative and stay within the workspace (traversal is rejected).`),
+relative and stay within the workspace (traversal is rejected).`,
+			inputLimit, humanBytes(inputLimit), envMaxInputBytes)),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Destination path. Workspace-relative in scoped/hosted mode; any path in local mode."),
@@ -1120,8 +1148,8 @@ func handlePutFile(factory workspace.Factory) server.ToolHandlerFunc {
 		if limit := maxInputBytes(); int64(len(data)) > limit {
 			metrics.PutFileTotal.WithLabelValues(metrics.ResultTooLarge).Inc()
 			return mcp.NewToolResultError(fmt.Sprintf(
-				"content too large: %d bytes (limit %d, set %s to raise)",
-				len(data), limit, envMaxInputBytes,
+				"content too large: %d bytes decoded (%s) exceeds the limit of %d bytes (%s); set %s on the server to raise it",
+				len(data), humanBytes(int64(len(data))), limit, humanBytes(limit), envMaxInputBytes,
 			)), nil
 		}
 

--- a/cmd/typst-d2-mcp/main_test.go
+++ b/cmd/typst-d2-mcp/main_test.go
@@ -29,6 +29,29 @@ func TestDurationEnv(t *testing.T) {
 	}
 }
 
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{"zero", 0, "0 B"},
+		{"sub-unit", 512, "512 B"},
+		{"one KiB", 1024, "1.0 KiB"},
+		{"one and a half KiB", 1536, "1.5 KiB"},
+		{"default input limit", 1 << 20, "1.0 MiB"},
+		{"the reported image decoded", 982791, "959.8 KiB"},
+		{"gibibyte", 1 << 30, "1.0 GiB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := humanBytes(tt.in); got != tt.want {
+				t.Errorf("humanBytes(%d) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestInt64Env(t *testing.T) {
 	const key = "TYPST_D2_MCP_TEST_INT"
 	tests := []struct {


### PR DESCRIPTION
Fixes #69.

## Problem

An agent compiling a Typst document that references a ~0.94 MiB image judged the payload by its **base64 string length (1.31 MB)**, decided it was "too big to pass as a parameter", **never called `put_file`**, and fell back to a local `typst` toolchain the hosted deployment didn't have. The image was actually **under** the 1 MiB `put_file` limit (decoded ≈ 0.937 MiB) — the call would have succeeded.

The server gave the model nothing to judge with: the limit was invisible until hit, it's measured on **decoded** bytes while the model reasoned about the base64 string, and the description nudged *away* from shipping content through the channel.

## Change

- **`put_file` description** now states the limit dynamically, clarifies it applies to **decoded** bytes (~3/4 of the base64 string, not its length), and says pushing an under-limit asset is expected — not a reason to fall back to a local toolchain a hosted deployment may not have.
- **Too-large error** now reports decoded size and limit in both bytes and human units, and names the env var to raise it.
- Added a `humanBytes` helper (mirrors the admin UI's `bytesLabel`) with a table-driven test.

## Verification

All in the **devcontainer** (host lacks the `@house/templates` package): `go build`, `go vet`, `go test ./...`, `gofmt`, and `golangci-lint run` — all clean. The house-template tests that fail on the host pass in the container.

Scope note: the genuine ceiling for assets *larger* than the limit (no client-side upload path) is tracked separately in #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)