### PR TITLE
feat: workspace_info tool — query storage limit and current usage (#71, part B)

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -840,6 +841,26 @@ relative and stay within the workspace (traversal is rejected).`,
 		),
 	)
 	s.AddTool(putFileTool, handlePutFile(factory))
+
+	workspaceInfoTool := mcp.NewTool("workspace_info",
+		mcp.WithDescription(fmt.Sprintf(`Report the active workspace's storage limits and current usage.
+
+Call this before pushing a large asset with put_file to check what will
+fit. Takes no arguments; returns JSON:
+  - per_call_limit_bytes / per_call_limit_human: the maximum size of a
+    single put_file payload, measured on DECODED bytes (see put_file).
+    Raise %s on the server to change it.
+  - usage_tracked: true in scoped/hosted mode, where the workspace is a
+    bounded per-tenant directory; false in local stdio mode, where the
+    workspace is the shared filesystem and has no size worth reporting.
+  - used_bytes / used_human: total bytes currently stored in the
+    workspace, measured live at call time. Present only when
+    usage_tracked is true.
+
+A cumulative workspace budget is not yet enforced; today only the
+per-call limit bounds writes.`, envMaxInputBytes)),
+	)
+	s.AddTool(workspaceInfoTool, handleWorkspaceInfo(factory))
 }
 
 func registerResources(s *server.MCPServer, factory workspace.Factory) {
@@ -1159,6 +1180,46 @@ func handlePutFile(factory workspace.Factory) server.ToolHandlerFunc {
 		}
 		metrics.PutFileTotal.WithLabelValues(metrics.ResultOK).Inc()
 		return mcp.NewToolResultText(fmt.Sprintf("wrote %d bytes to %s", len(data), path)), nil
+	}
+}
+
+// workspaceInfo is the JSON payload returned by the workspace_info tool.
+// UsedBytes/UsedHuman are pointers/omitempty so they are absent (not a
+// misleading zero) in local mode, where usage is not tracked.
+type workspaceInfo struct {
+	PerCallLimitBytes int64  `json:"per_call_limit_bytes"`
+	PerCallLimitHuman string `json:"per_call_limit_human"`
+	UsageTracked      bool   `json:"usage_tracked"`
+	UsedBytes         *int64 `json:"used_bytes,omitempty"`
+	UsedHuman         string `json:"used_human,omitempty"`
+}
+
+func handleWorkspaceInfo(factory workspace.Factory) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		resolver, err := resolverFor(ctx, factory)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("workspace setup", err), nil
+		}
+		limit := maxInputBytes()
+		used, tracked, err := workspace.Usage(resolver)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("measure workspace", err), nil
+		}
+		info := workspaceInfo{
+			PerCallLimitBytes: limit,
+			PerCallLimitHuman: humanBytes(limit),
+			UsageTracked:      tracked,
+		}
+		if tracked {
+			u := used
+			info.UsedBytes = &u
+			info.UsedHuman = humanBytes(used)
+		}
+		payload, err := json.MarshalIndent(info, "", "  ")
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("encode workspace info", err), nil
+		}
+		return mcp.NewToolResultText(string(payload)), nil
 	}
 }
 

--- a/cmd/typst-d2-mcp/workspaceinfo_test.go
+++ b/cmd/typst-d2-mcp/workspaceinfo_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// callWorkspaceInfo invokes the handler and returns the decoded payload.
+func callWorkspaceInfo(t *testing.T, ctx context.Context, factory workspace.Factory) workspaceInfo {
+	t.Helper()
+	res, err := handleWorkspaceInfo(factory)(ctx, mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool result is an error: %+v", res.Content)
+	}
+	text, ok := mcp.AsTextContent(res.Content[0])
+	if !ok {
+		t.Fatalf("first content block is not text: %T", res.Content[0])
+	}
+	var info workspaceInfo
+	if err := json.Unmarshal([]byte(text.Text), &info); err != nil {
+		t.Fatalf("decode payload %q: %v", text.Text, err)
+	}
+	return info
+}
+
+func TestHandleWorkspaceInfo_LocalUntracked(t *testing.T) {
+	info := callWorkspaceInfo(t, context.Background(), workspace.LocalFactory{})
+
+	if info.UsageTracked {
+		t.Error("usage_tracked = true in local mode, want false")
+	}
+	if info.UsedBytes != nil {
+		t.Errorf("used_bytes present in local mode: %d", *info.UsedBytes)
+	}
+	if info.PerCallLimitBytes != maxInputBytes() {
+		t.Errorf("per_call_limit_bytes = %d, want %d", info.PerCallLimitBytes, maxInputBytes())
+	}
+	if info.PerCallLimitHuman == "" {
+		t.Error("per_call_limit_human is empty")
+	}
+}
+
+func TestHandleWorkspaceInfo_ScopedTracked(t *testing.T) {
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	id := identity.Identity{UserID: "user123"}
+	ctx := identity.WithIdentity(context.Background(), id)
+
+	// Empty workspace: tracked, zero bytes.
+	info := callWorkspaceInfo(t, ctx, factory)
+	if !info.UsageTracked {
+		t.Fatal("usage_tracked = false in scoped mode, want true")
+	}
+	if info.UsedBytes == nil || *info.UsedBytes != 0 {
+		t.Fatalf("used_bytes = %v, want 0", info.UsedBytes)
+	}
+
+	// Write 128 bytes into the user's scoped root, then re-measure.
+	if err := os.WriteFile(filepath.Join(root, id.UserID, "asset.bin"), make([]byte, 128), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info = callWorkspaceInfo(t, ctx, factory)
+	if info.UsedBytes == nil || *info.UsedBytes != 128 {
+		t.Fatalf("used_bytes = %v, want 128", info.UsedBytes)
+	}
+	if info.UsedHuman == "" {
+		t.Error("used_human is empty when usage is tracked")
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -9,7 +9,9 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,6 +115,70 @@ func (s *ScopedFS) Resolve(path string) (string, error) {
 		return "", fmt.Errorf("path escapes workspace: %s", path)
 	}
 	return cleaned, nil
+}
+
+// WorkspaceRoot returns the absolute directory that bounds this resolver,
+// satisfying Bounded. It is the measurable extent of a scoped workspace.
+func (s *ScopedFS) WorkspaceRoot() string { return s.Root }
+
+// Bounded is implemented by resolvers whose workspace is confined to a
+// single on-disk root, making its total size a meaningful quantity.
+// LocalFS deliberately does not implement it: in stdio mode the
+// "workspace" is the shared filesystem and has no size worth reporting.
+type Bounded interface {
+	WorkspaceRoot() string
+}
+
+// Usage reports the total bytes stored in r's workspace and whether that
+// number is meaningful. Bounded resolvers (ScopedFS) return their measured
+// size; unbounded ones (LocalFS) return tracked=false with zero bytes.
+func Usage(r Resolver) (bytes int64, tracked bool, err error) {
+	b, ok := r.(Bounded)
+	if !ok {
+		return 0, false, nil
+	}
+	total, err := DirBytes(b.WorkspaceRoot())
+	if err != nil {
+		return 0, true, err
+	}
+	return total, true, nil
+}
+
+// DirBytes returns the summed size of the regular files under dir,
+// walking recursively. Symlinks and other irregular entries are skipped
+// (their size is meaningless and WalkDir does not follow them), matching
+// how the sweeper measures a workspace. A dir that does not exist counts
+// as zero: a user who has written nothing yet has an empty workspace, not
+// an error.
+func DirBytes(dir string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil // vanished mid-walk (or absent root); skip
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return total, err
+	}
+	return total, nil
 }
 
 // Factory picks the workspace.Resolver for a given identity. It lets

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -186,3 +186,74 @@ func TestMustExist(t *testing.T) {
 		t.Errorf("expected directory-rejection error, got %v", err)
 	}
 }
+
+func TestDirBytes(t *testing.T) {
+	root := t.TempDir()
+	// 100 + 200 bytes across a nested layout.
+	if err := os.WriteFile(filepath.Join(root, "a.bin"), make([]byte, 100), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "b.bin"), make([]byte, 200), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := DirBytes(root)
+	if err != nil {
+		t.Fatalf("DirBytes: %v", err)
+	}
+	if got != 300 {
+		t.Errorf("DirBytes = %d, want 300", got)
+	}
+
+	// A symlink must not be followed or counted.
+	if err := os.Symlink(filepath.Join(root, "a.bin"), filepath.Join(root, "link")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	got, err = DirBytes(root)
+	if err != nil {
+		t.Fatalf("DirBytes after symlink: %v", err)
+	}
+	if got != 300 {
+		t.Errorf("DirBytes with symlink = %d, want 300 (symlink not counted)", got)
+	}
+}
+
+func TestDirBytes_MissingDirIsZero(t *testing.T) {
+	got, err := DirBytes(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("DirBytes on missing dir: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("DirBytes on missing dir = %d, want 0", got)
+	}
+}
+
+func TestUsage(t *testing.T) {
+	// LocalFS is unbounded: usage is not tracked.
+	if bytes, tracked, err := Usage(LocalFS{}); err != nil || tracked || bytes != 0 {
+		t.Errorf("Usage(LocalFS) = (%d, %v, %v), want (0, false, nil)", bytes, tracked, err)
+	}
+
+	// ScopedFS is bounded: usage is the measured size of its root.
+	root := t.TempDir()
+	s, err := NewScopedFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "f.bin"), make([]byte, 42), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bytes, tracked, err := Usage(s)
+	if err != nil {
+		t.Fatalf("Usage(ScopedFS): %v", err)
+	}
+	if !tracked {
+		t.Error("Usage(ScopedFS) tracked = false, want true")
+	}
+	if bytes != 42 {
+		t.Errorf("Usage(ScopedFS) bytes = %d, want 42", bytes)
+	}
+}


### PR DESCRIPTION
Implements **part B** of #71: a read-only MCP tool so an agent can check what will fit **before** pushing an asset with `put_file`, rather than guessing and falling back to a local toolchain (the failure behind #69).

## `workspace_info`

No arguments; returns JSON:

| field | meaning |
|---|---|
| `per_call_limit_bytes` / `per_call_limit_human` | the `put_file` **decoded-byte** cap (`TYPST_D2_MCP_MAX_INPUT_BYTES`) |
| `usage_tracked` | `true` in scoped/hosted mode (bounded per-tenant dir); `false` in local stdio mode (shared filesystem — no size worth reporting) |
| `used_bytes` / `used_human` | total bytes stored, measured **live** at call time; omitted (not a misleading `0`) when usage isn't tracked |

Live example (stdio/local mode):
```json
{ "per_call_limit_bytes": 1048576, "per_call_limit_human": "1.0 MiB", "usage_tracked": false }
```

## Design

- Measurement lives in the **workspace package**: a `Bounded` interface (satisfied by `ScopedFS`, not `LocalFS`) + `DirBytes`, which sums regular-file sizes and skips symlinks — **matching how the sweeper measures a workspace**, so the two definitions agree.
- Live measurement (not the sweeper's cached `WorkspaceUsage`): accurate the moment `put_file` writes, and no dependency on a sweep having run. Cheap for one user's tree. (The cached value + `computed_at` remains an option if this ever proves costly — noted on #71.)

## Scope

Deliberately **just the query**. Out of scope, tracked in #71:
- **Part A** — a cumulative workspace *budget* (mirror the existing per-day compile-quota model). The tool description states the budget is not yet enforced.
- **Part C** — chunked / by-reference ingest for assets over the per-call cap.

## Verification

Devcontainer (host lacks `@house/templates`): `go test ./...`, `gofmt`, `golangci-lint` all clean. Added unit tests for `DirBytes`/`Usage` (incl. symlink-not-counted, missing-dir-is-zero) and handler tests for both tracked and untracked branches. Plus an **stdio JSON-RPC smoke test** of the live tool (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)