### PR TITLE
feat: enforce a cumulative workspace byte budget (#71, part A)

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -46,12 +46,13 @@ var (
 const (
 	serverName = "typst-d2-mcp"
 
-	envTransport      = "TYPST_D2_MCP_TRANSPORT"
-	envAddr           = "TYPST_D2_MCP_ADDR"
-	envPath           = "TYPST_D2_MCP_PATH"
-	envWorkspace      = "TYPST_D2_MCP_WORKSPACE"
-	envCompileTimeout = "TYPST_D2_MCP_COMPILE_TIMEOUT"
-	envMaxInputBytes  = "TYPST_D2_MCP_MAX_INPUT_BYTES"
+	envTransport       = "TYPST_D2_MCP_TRANSPORT"
+	envAddr            = "TYPST_D2_MCP_ADDR"
+	envPath            = "TYPST_D2_MCP_PATH"
+	envWorkspace       = "TYPST_D2_MCP_WORKSPACE"
+	envCompileTimeout  = "TYPST_D2_MCP_COMPILE_TIMEOUT"
+	envMaxInputBytes   = "TYPST_D2_MCP_MAX_INPUT_BYTES"
+	envWorkspaceBudget = "TYPST_D2_MCP_WORKSPACE_BUDGET_BYTES"
 
 	envAuth            = "TYPST_D2_MCP_AUTH"
 	envDB              = "TYPST_D2_MCP_DB"
@@ -86,7 +87,11 @@ const (
 	defaultPath           = "/mcp"
 	defaultCompileTimeout = 30 * time.Second
 	defaultMaxInputBytes  = int64(1 << 20) // 1 MiB
-	defaultQuotaPerDay    = 1
+	// 0 = no cumulative workspace budget (the historical behaviour); only
+	// the per-call cap applies. A positive value bounds a tenant's total
+	// stored bytes, enforced at put_file.
+	defaultWorkspaceBudget = int64(0)
+	defaultQuotaPerDay     = 1
 
 	// pdfURIPrefix is the scheme + host used by the compile tool when it
 	// returns a ResourceLink for the produced PDF. Clients can fetch the
@@ -106,6 +111,14 @@ func compileTimeout() time.Duration {
 // by put_file). It bounds memory + parser work before any d2/typst exec.
 func maxInputBytes() int64 {
 	return int64Env(envMaxInputBytes, defaultMaxInputBytes)
+}
+
+// workspaceBudgetBytes is the cumulative cap on a tenant's total stored
+// bytes, enforced at put_file. 0 disables the check (only the per-call
+// limit applies), and it is inert in local stdio mode where the
+// workspace is the shared filesystem rather than a bounded directory.
+func workspaceBudgetBytes() int64 {
+	return int64Env(envWorkspaceBudget, defaultWorkspaceBudget)
 }
 
 // humanBytes renders a byte count in binary units for human-facing text
@@ -824,6 +837,10 @@ document references, which must exist in the workspace before you compile —
 is expected and supported: do it rather than giving up or falling back to a
 local toolchain, which a hosted deployment may not have.
 
+A hosted workspace may also have a cumulative byte budget across all its
+files. A write that would push the total over that budget is rejected;
+call workspace_info to see the budget and remaining space before pushing.
+
 The path is resolved through the server's active workspace. In local
 mode any path is accepted; in scoped/hosted mode the path must be
 relative and stay within the workspace (traversal is rejected).`,
@@ -856,9 +873,14 @@ fit. Takes no arguments; returns JSON:
   - used_bytes / used_human: total bytes currently stored in the
     workspace, measured live at call time. Present only when
     usage_tracked is true.
+  - budget_bytes / budget_human: the cumulative cap on the workspace's
+    total size. Present only when a budget is configured; absent means
+    no cumulative cap (only the per-call limit applies).
+  - available_bytes / available_human: budget minus current usage,
+    floored at zero. Present only alongside budget_bytes.
 
-A cumulative workspace budget is not yet enforced; today only the
-per-call limit bounds writes.`, envMaxInputBytes)),
+When budget_bytes is present, a put_file that would push used_bytes over
+it is rejected — check available_bytes before pushing a large asset.`, envMaxInputBytes)),
 	)
 	s.AddTool(workspaceInfoTool, handleWorkspaceInfo(factory))
 }
@@ -1174,6 +1196,24 @@ func handlePutFile(factory workspace.Factory) server.ToolHandlerFunc {
 			)), nil
 		}
 
+		// Cumulative workspace budget. Inert when unset (0) or in local
+		// mode, where the workspace has no bounded size (tracked=false).
+		if budget := workspaceBudgetBytes(); budget > 0 {
+			projected, tracked, err := projectedUsage(resolver, path, int64(len(data)))
+			if err != nil {
+				metrics.PutFileTotal.WithLabelValues(metrics.ResultFail).Inc()
+				return mcp.NewToolResultErrorFromErr("measure workspace", err), nil
+			}
+			if tracked && projected > budget {
+				metrics.PutFileTotal.WithLabelValues(metrics.ResultOverBudget).Inc()
+				return mcp.NewToolResultError(fmt.Sprintf(
+					"workspace budget exceeded: this write would bring the workspace to %d bytes (%s), over the %d byte (%s) budget; "+
+						"delete files you no longer need, or ask an administrator to raise %s",
+					projected, humanBytes(projected), budget, humanBytes(budget), envWorkspaceBudget,
+				)), nil
+			}
+		}
+
 		if _, err := workspace.WriteFile(resolver, path, data); err != nil {
 			metrics.PutFileTotal.WithLabelValues(metrics.ResultFail).Inc()
 			return mcp.NewToolResultErrorFromErr("write file", err), nil
@@ -1183,15 +1223,39 @@ func handlePutFile(factory workspace.Factory) server.ToolHandlerFunc {
 	}
 }
 
+// projectedUsage returns what the workspace would total after writing
+// newSize bytes to path, and whether the workspace's size is even tracked
+// (false in local mode, where a cumulative budget is meaningless). An
+// in-place overwrite is accounted for by discounting the target's current
+// size, so rewriting a file never counts its bytes twice.
+func projectedUsage(r workspace.Resolver, path string, newSize int64) (total int64, tracked bool, err error) {
+	used, tracked, err := workspace.Usage(r)
+	if err != nil || !tracked {
+		return 0, tracked, err
+	}
+	var existing int64
+	if resolved, rerr := r.Resolve(path); rerr == nil {
+		if info, serr := os.Stat(resolved); serr == nil && info.Mode().IsRegular() {
+			existing = info.Size()
+		}
+	}
+	return used - existing + newSize, true, nil
+}
+
 // workspaceInfo is the JSON payload returned by the workspace_info tool.
-// UsedBytes/UsedHuman are pointers/omitempty so they are absent (not a
-// misleading zero) in local mode, where usage is not tracked.
+// Used/Budget/Available fields are pointers/omitempty so they are absent
+// (not a misleading zero) when they do not apply: usage in local mode, and
+// budget/available when no budget is configured.
 type workspaceInfo struct {
 	PerCallLimitBytes int64  `json:"per_call_limit_bytes"`
 	PerCallLimitHuman string `json:"per_call_limit_human"`
 	UsageTracked      bool   `json:"usage_tracked"`
 	UsedBytes         *int64 `json:"used_bytes,omitempty"`
 	UsedHuman         string `json:"used_human,omitempty"`
+	BudgetBytes       *int64 `json:"budget_bytes,omitempty"`
+	BudgetHuman       string `json:"budget_human,omitempty"`
+	AvailableBytes    *int64 `json:"available_bytes,omitempty"`
+	AvailableHuman    string `json:"available_human,omitempty"`
 }
 
 func handleWorkspaceInfo(factory workspace.Factory) server.ToolHandlerFunc {
@@ -1214,6 +1278,19 @@ func handleWorkspaceInfo(factory workspace.Factory) server.ToolHandlerFunc {
 			u := used
 			info.UsedBytes = &u
 			info.UsedHuman = humanBytes(used)
+			// Budget/available only when a budget is configured; an
+			// unconfigured budget means unlimited, so the fields stay absent.
+			if budget := workspaceBudgetBytes(); budget > 0 {
+				b := budget
+				info.BudgetBytes = &b
+				info.BudgetHuman = humanBytes(budget)
+				avail := budget - used
+				if avail < 0 {
+					avail = 0
+				}
+				info.AvailableBytes = &avail
+				info.AvailableHuman = humanBytes(avail)
+			}
 		}
 		payload, err := json.MarshalIndent(info, "", "  ")
 		if err != nil {

--- a/cmd/typst-d2-mcp/putfile_test.go
+++ b/cmd/typst-d2-mcp/putfile_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// putFile invokes the put_file handler with utf8 content and returns the
+// raw result for inspection.
+func putFile(t *testing.T, ctx context.Context, factory workspace.Factory, path, content string) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "put_file"
+	req.Params.Arguments = map[string]any{"path": path, "content": content}
+	res, err := handlePutFile(factory)(ctx, req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	return res
+}
+
+func TestPutFile_BudgetEnforced(t *testing.T) {
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	id := identity.Identity{UserID: "user123"}
+	ctx := identity.WithIdentity(context.Background(), id)
+	t.Setenv(envWorkspaceBudget, "100")
+
+	// A 60-byte write fits under the 100-byte budget.
+	if res := putFile(t, ctx, factory, "a.bin", string(make([]byte, 60))); res.IsError {
+		t.Fatalf("first write rejected unexpectedly: %+v", res.Content)
+	}
+
+	// A further 60 bytes would total 120 > 100: rejected, and not written.
+	res := putFile(t, ctx, factory, "b.bin", string(make([]byte, 60)))
+	if !res.IsError {
+		t.Fatal("over-budget write was accepted, want rejection")
+	}
+	if text, ok := mcp.AsTextContent(res.Content[0]); !ok || !strings.Contains(text.Text, "budget") {
+		t.Errorf("error message does not mention budget: %+v", res.Content[0])
+	}
+	if _, err := os.Stat(filepath.Join(root, id.UserID, "b.bin")); !os.IsNotExist(err) {
+		t.Errorf("rejected file b.bin should not exist, stat err = %v", err)
+	}
+}
+
+func TestPutFile_BudgetOverwriteNotDoubleCounted(t *testing.T) {
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "u"})
+	t.Setenv(envWorkspaceBudget, "100")
+
+	// Fill to 80 bytes.
+	if res := putFile(t, ctx, factory, "a.bin", string(make([]byte, 80))); res.IsError {
+		t.Fatalf("initial 80-byte write rejected: %+v", res.Content)
+	}
+	// Overwriting a.bin with another 80 bytes must be judged as 80 total
+	// (the old 80 is discounted), not 160 — so it stays within budget.
+	if res := putFile(t, ctx, factory, "a.bin", string(make([]byte, 80))); res.IsError {
+		t.Fatalf("in-place overwrite wrongly counted as new bytes: %+v", res.Content)
+	}
+}
+
+func TestPutFile_BudgetInertInLocalMode(t *testing.T) {
+	// LocalFS is unbounded: the budget must not apply even when configured.
+	dir := t.TempDir()
+	t.Setenv(envWorkspaceBudget, "10")
+	res := putFile(t, context.Background(), workspace.LocalFactory{},
+		filepath.Join(dir, "big.bin"), string(make([]byte, 500)))
+	if res.IsError {
+		t.Fatalf("budget wrongly enforced in local mode: %+v", res.Content)
+	}
+}
+
+func TestPutFile_BudgetDisabledByDefault(t *testing.T) {
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "u"})
+	// No budget env set (0 = unlimited): a large write is accepted.
+	if res := putFile(t, ctx, factory, "a.bin", string(make([]byte, 10_000))); res.IsError {
+		t.Fatalf("write rejected with no budget configured: %+v", res.Content)
+	}
+	if got := workspaceBudgetBytes(); got != 0 {
+		t.Errorf("workspaceBudgetBytes default = %d, want 0", got)
+	}
+}

--- a/cmd/typst-d2-mcp/workspaceinfo_test.go
+++ b/cmd/typst-d2-mcp/workspaceinfo_test.go
@@ -76,4 +76,56 @@ func TestHandleWorkspaceInfo_ScopedTracked(t *testing.T) {
 	if info.UsedHuman == "" {
 		t.Error("used_human is empty when usage is tracked")
 	}
+	// No budget configured: budget/available absent.
+	if info.BudgetBytes != nil || info.AvailableBytes != nil {
+		t.Errorf("budget fields present without a budget: budget=%v available=%v",
+			info.BudgetBytes, info.AvailableBytes)
+	}
+}
+
+func TestHandleWorkspaceInfo_BudgetFields(t *testing.T) {
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	id := identity.Identity{UserID: "u"}
+	ctx := identity.WithIdentity(context.Background(), id)
+	t.Setenv(envWorkspaceBudget, "1000")
+
+	if err := os.MkdirAll(filepath.Join(root, id.UserID), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, id.UserID, "f.bin"), make([]byte, 200), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info := callWorkspaceInfo(t, ctx, factory)
+
+	if info.BudgetBytes == nil || *info.BudgetBytes != 1000 {
+		t.Fatalf("budget_bytes = %v, want 1000", info.BudgetBytes)
+	}
+	if info.AvailableBytes == nil || *info.AvailableBytes != 800 {
+		t.Fatalf("available_bytes = %v, want 800 (1000-200)", info.AvailableBytes)
+	}
+	if info.BudgetHuman == "" || info.AvailableHuman == "" {
+		t.Error("human budget/available labels are empty")
+	}
+}
+
+func TestHandleWorkspaceInfo_AvailableFlooredAtZero(t *testing.T) {
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	id := identity.Identity{UserID: "u"}
+	ctx := identity.WithIdentity(context.Background(), id)
+	t.Setenv(envWorkspaceBudget, "100")
+
+	// Usage already over budget (e.g. budget lowered after the fact):
+	// available must floor at 0, never go negative.
+	if err := os.MkdirAll(filepath.Join(root, id.UserID), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, id.UserID, "f.bin"), make([]byte, 250), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info := callWorkspaceInfo(t, ctx, factory)
+	if info.AvailableBytes == nil || *info.AvailableBytes != 0 {
+		t.Fatalf("available_bytes = %v, want 0 (floored)", info.AvailableBytes)
+	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -24,6 +24,7 @@ const (
 	ResultQuotaExceeded = "quota_exceeded"
 	ResultTimeout       = "timeout"
 	ResultTooLarge      = "too_large"
+	ResultOverBudget    = "over_budget"
 	ResultDecodeError   = "decode_error"
 	ResultNotFound      = "not_found"
 )
@@ -50,8 +51,10 @@ var (
 
 	// PutFileTotal counts every put_file invocation, labelled by
 	// result. ok = file written; too_large = exceeded
-	// TYPST_D2_MCP_MAX_INPUT_BYTES; decode_error = base64 input
-	// malformed; fail = any other write/resolve failure.
+	// TYPST_D2_MCP_MAX_INPUT_BYTES; over_budget = would exceed the
+	// workspace budget (TYPST_D2_MCP_WORKSPACE_BUDGET_BYTES);
+	// decode_error = base64 input malformed; fail = any other
+	// write/resolve failure.
 	PutFileTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "typst_d2_mcp_put_file_total",
 		Help: "Total put_file invocations by terminal result.",


### PR DESCRIPTION
Implements **part A** of #71, on top of the merged `workspace_info` (#73): a configurable cap on a tenant's **total** stored bytes, complementing the existing per-call `put_file` limit.

Two distinct concerns, kept separate: the **per-call cap** bounds a single payload; the **budget** bounds the whole workspace.

## Change

- **`TYPST_D2_MCP_WORKSPACE_BUDGET_BYTES`** (default `0` = unlimited, so existing deployments are unaffected). A positive value is enforced at `put_file`: a write whose *projected* total would exceed the budget is rejected with a distinct `over_budget` metric result and a message naming the projected total, the budget, and the env to raise it.
- **Overwrite-aware:** the projected total discounts the target file's current size, so rewriting a file never double-counts.
- **Inert in local stdio mode** (shared filesystem, usage untracked) — verified by smoke test: with the budget env set, `workspace_info` still reports `usage_tracked: false` and no budget fields.
- **`workspace_info` extended:** `budget_bytes` / `available_bytes` (floored at zero) present when a budget is configured, so an agent can check headroom before pushing. Absent ⇒ unlimited.

## Scope

Deliberately the **deployment-wide** budget + enforcement. Out of scope, tracked in #71 as **part A2**: a per-user admin override of the default, mirroring the compile-quota model (migration + `EffectiveWorkspaceBudget`/`SetWorkspaceBudget` + admin UI + audit).

## Verification

Devcontainer: `go test ./...`, `gofmt`, `golangci-lint` clean. New tests drive the real handlers via a scoped `TenantFactory`: enforcement (over-budget rejected + not written), overwrite-not-double-counted, budget-inert-in-local-mode, default-disabled, plus `workspace_info` budget/available fields incl. floor-at-zero. Plus an stdio JSON-RPC smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)