### PR TITLE
feat: chunked append mode for put_file — over-limit assets (#71, part C)

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -829,18 +829,29 @@ When running against a local stdio server, prefer your host's filesystem
 tools (Write/Edit) so you don't ship the file content through this
 channel.
 
-Size limit: content must be at most %d bytes (%s) measured AFTER decoding.
-For base64, that bound is the decoded size — roughly 3/4 of the string you
-pass — NOT the length of the base64 string, so judge against the decoded
-size, not the encoded one. Raise %s on the server to lift the ceiling.
-Pushing a binary asset that fits under this limit — e.g. an image a Typst
-document references, which must exist in the workspace before you compile —
-is expected and supported: do it rather than giving up or falling back to a
-local toolchain, which a hosted deployment may not have.
+Size limit: each call's content must be at most %d bytes (%s) measured
+AFTER decoding. For base64, that bound is the decoded size — roughly 3/4
+of the string you pass — NOT the length of the base64 string, so judge
+against the decoded size, not the encoded one. Raise %s on the server to
+lift the ceiling. Pushing a binary asset that fits under this limit —
+e.g. an image a Typst document references, which must exist in the
+workspace before you compile — is expected and supported: do it rather
+than giving up or falling back to a local toolchain, which a hosted
+deployment may not have.
+
+Chunked upload for a file LARGER than the per-call limit: split it into
+slices each at most the limit above and send them in order — the first
+with mode "overwrite" (the default; it truncates any previous file), then
+each remaining slice with mode "append". The slices are concatenated
+verbatim on disk, so a base64 asset must be decoded to bytes first and
+split on byte boundaries (do not split the base64 text itself). This is
+how you get an over-limit asset in; the per-call limit still bounds each
+slice, and the cumulative budget below still bounds the whole file.
 
 A hosted workspace may also have a cumulative byte budget across all its
-files. A write that would push the total over that budget is rejected;
-call workspace_info to see the budget and remaining space before pushing.
+files. A write (or append) that would push the total over that budget is
+rejected; call workspace_info to see the budget and remaining space before
+pushing.
 
 The path is resolved through the server's active workspace. In local
 mode any path is accepted; in scoped/hosted mode the path must be
@@ -856,6 +867,9 @@ relative and stay within the workspace (traversal is rejected).`,
 		),
 		mcp.WithString("encoding",
 			mcp.Description(`"utf8" (default) for text or "base64" for binary data.`),
+		),
+		mcp.WithString("mode",
+			mcp.Description(`"overwrite" (default) truncates and writes; "append" adds to the end of an existing file, for streaming a file larger than the per-call limit in chunks.`),
 		),
 	)
 	s.AddTool(putFileTool, handlePutFile(factory, store))
@@ -1172,6 +1186,10 @@ func handlePutFile(factory workspace.Factory, store *authdb.Store) server.ToolHa
 			return mcp.NewToolResultErrorFromErr("workspace setup", err), nil
 		}
 		encoding := strings.ToLower(request.GetString("encoding", "utf8"))
+		mode := strings.ToLower(request.GetString("mode", "overwrite"))
+		if mode != "overwrite" && mode != "append" {
+			return mcp.NewToolResultError(fmt.Sprintf("unknown mode %q (expected overwrite or append)", mode)), nil
+		}
 
 		var data []byte
 		switch encoding {
@@ -1202,7 +1220,7 @@ func handlePutFile(factory workspace.Factory, store *authdb.Store) server.ToolHa
 		// workspace has no bounded size (tracked=false).
 		id, _ := identity.FromContext(ctx)
 		if budget := effectiveWorkspaceBudget(ctx, store, id); budget > 0 {
-			projected, tracked, err := projectedUsage(resolver, path, int64(len(data)))
+			projected, tracked, err := projectedUsage(resolver, path, int64(len(data)), mode)
 			if err != nil {
 				metrics.PutFileTotal.WithLabelValues(metrics.ResultFail).Inc()
 				return mcp.NewToolResultErrorFromErr("measure workspace", err), nil
@@ -1217,12 +1235,20 @@ func handlePutFile(factory workspace.Factory, store *authdb.Store) server.ToolHa
 			}
 		}
 
-		if _, err := workspace.WriteFile(resolver, path, data); err != nil {
+		write := workspace.WriteFile
+		if mode == "append" {
+			write = workspace.AppendFile
+		}
+		if _, err := write(resolver, path, data); err != nil {
 			metrics.PutFileTotal.WithLabelValues(metrics.ResultFail).Inc()
 			return mcp.NewToolResultErrorFromErr("write file", err), nil
 		}
 		metrics.PutFileTotal.WithLabelValues(metrics.ResultOK).Inc()
-		return mcp.NewToolResultText(fmt.Sprintf("wrote %d bytes to %s", len(data), path)), nil
+		verb := "wrote"
+		if mode == "append" {
+			verb = "appended"
+		}
+		return mcp.NewToolResultText(fmt.Sprintf("%s %d bytes to %s", verb, len(data), path)), nil
 	}
 }
 
@@ -1245,14 +1271,19 @@ func effectiveWorkspaceBudget(ctx context.Context, store *authdb.Store, id ident
 }
 
 // projectedUsage returns what the workspace would total after writing
-// newSize bytes to path, and whether the workspace's size is even tracked
-// (false in local mode, where a cumulative budget is meaningless). An
-// in-place overwrite is accounted for by discounting the target's current
-// size, so rewriting a file never counts its bytes twice.
-func projectedUsage(r workspace.Resolver, path string, newSize int64) (total int64, tracked bool, err error) {
+// newSize bytes to path in the given mode, and whether the workspace's
+// size is even tracked (false in local mode, where a cumulative budget is
+// meaningless). In "overwrite" mode the target's current size is
+// discounted, so rewriting a file never counts its bytes twice; in
+// "append" mode the new bytes add to the existing file, so nothing is
+// discounted.
+func projectedUsage(r workspace.Resolver, path string, newSize int64, mode string) (total int64, tracked bool, err error) {
 	used, tracked, err := workspace.Usage(r)
 	if err != nil || !tracked {
 		return 0, tracked, err
+	}
+	if mode == "append" {
+		return used + newSize, true, nil
 	}
 	var existing int64
 	if resolved, rerr := r.Resolve(path); rerr == nil {

--- a/cmd/typst-d2-mcp/putfile_test.go
+++ b/cmd/typst-d2-mcp/putfile_test.go
@@ -34,6 +34,19 @@ func putFileStore(t *testing.T, ctx context.Context, factory workspace.Factory, 
 	return res
 }
 
+// putFileMode invokes put_file with an explicit mode ("overwrite"/"append").
+func putFileMode(t *testing.T, ctx context.Context, factory workspace.Factory, path, content, mode string) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "put_file"
+	req.Params.Arguments = map[string]any{"path": path, "content": content, "mode": mode}
+	res, err := handlePutFile(factory, nil)(ctx, req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	return res
+}
+
 func TestPutFile_BudgetEnforced(t *testing.T) {
 	root := t.TempDir()
 	factory := workspace.TenantFactory{Root: root}
@@ -103,6 +116,73 @@ func TestPutFile_PerWorkspaceOverrideBeatsEnvDefault(t *testing.T) {
 	// 60 + 60 = 120 > 100 override.
 	if res := putFileStore(t, ctx, factory, store, "b.bin", string(make([]byte, 60))); !res.IsError {
 		t.Fatal("write over the per-workspace override was accepted, want rejection")
+	}
+}
+
+func TestPutFile_ChunkedUploadExceedsPerCallLimit(t *testing.T) {
+	// A per-call limit of 4 bytes; assemble an 10-byte file from three
+	// chunks (4 + 4 + 2), each within the limit, via overwrite then append.
+	t.Setenv(envMaxInputBytes, "4")
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	id := identity.Identity{UserID: "u"}
+	ctx := identity.WithIdentity(context.Background(), id)
+
+	if res := putFileMode(t, ctx, factory, "big.bin", "AAAA", "overwrite"); res.IsError {
+		t.Fatalf("chunk 1 (overwrite) rejected: %+v", res.Content)
+	}
+	if res := putFileMode(t, ctx, factory, "big.bin", "BBBB", "append"); res.IsError {
+		t.Fatalf("chunk 2 (append) rejected: %+v", res.Content)
+	}
+	if res := putFileMode(t, ctx, factory, "big.bin", "CC", "append"); res.IsError {
+		t.Fatalf("chunk 3 (append) rejected: %+v", res.Content)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, id.UserID, "big.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "AAAABBBBCC" {
+		t.Errorf("assembled file = %q, want %q", got, "AAAABBBBCC")
+	}
+
+	// A single chunk over the per-call limit is still rejected.
+	if res := putFileMode(t, ctx, factory, "big.bin", "AAAAA", "append"); !res.IsError {
+		t.Error("a 5-byte chunk over the 4-byte per-call limit was accepted")
+	}
+}
+
+func TestPutFile_AppendCountsAgainstBudgetWithoutDiscount(t *testing.T) {
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	id := identity.Identity{UserID: "u"}
+	ctx := identity.WithIdentity(context.Background(), id)
+	t.Setenv(envWorkspaceBudget, "100")
+
+	// 80 bytes, then append 30 -> 110 > 100: appends add to usage (no
+	// overwrite discount), so this must be rejected.
+	if res := putFileMode(t, ctx, factory, "a.bin", string(make([]byte, 80)), "overwrite"); res.IsError {
+		t.Fatalf("initial 80-byte write rejected: %+v", res.Content)
+	}
+	res := putFileMode(t, ctx, factory, "a.bin", string(make([]byte, 30)), "append")
+	if !res.IsError {
+		t.Fatal("append that would total 110 > 100 budget was accepted")
+	}
+	if text, ok := mcp.AsTextContent(res.Content[0]); !ok || !strings.Contains(text.Text, "budget") {
+		t.Errorf("error does not mention budget: %+v", res.Content[0])
+	}
+}
+
+func TestPutFile_UnknownModeRejected(t *testing.T) {
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "u"})
+	res := putFileMode(t, ctx, factory, "a.bin", "x", "sideways")
+	if !res.IsError {
+		t.Fatal("unknown mode was accepted")
+	}
+	if text, ok := mcp.AsTextContent(res.Content[0]); !ok || !strings.Contains(text.Text, "unknown mode") {
+		t.Errorf("error does not explain the bad mode: %+v", res.Content[0])
 	}
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -217,8 +217,9 @@ func (f TenantFactory) Resolver(id identity.Identity) (Resolver, error) {
 }
 
 // WriteFile resolves path through r and writes content, creating parent
-// directories as needed. It is the back-end for the put_file MCP tool.
-// The returned string is the resolved on-disk path (useful for logging /
+// directories as needed and truncating any existing file. It is the
+// back-end for the put_file MCP tool's default (overwrite) mode. The
+// returned string is the resolved on-disk path (useful for logging /
 // tests); callers should not echo it back to clients in HTTP mode.
 func WriteFile(r Resolver, path string, content []byte) (string, error) {
 	resolved, err := r.Resolve(path)
@@ -230,6 +231,30 @@ func WriteFile(r Resolver, path string, content []byte) (string, error) {
 	}
 	if err := os.WriteFile(resolved, content, 0o600); err != nil {
 		return "", fmt.Errorf("write file: %w", err)
+	}
+	return resolved, nil
+}
+
+// AppendFile resolves path through r and appends content to the file,
+// creating it (and parent directories) if absent. It is the back-end for
+// put_file's append mode, which lets a client stream a file larger than
+// the per-call size cap in bounded chunks. Callers should not echo the
+// resolved path back to clients in HTTP mode.
+func AppendFile(r Resolver, path string, content []byte) (string, error) {
+	resolved, err := r.Resolve(path)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(resolved), 0o700); err != nil {
+		return "", fmt.Errorf("create parent dirs: %w", err)
+	}
+	f, err := os.OpenFile(resolved, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("open for append: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(content); err != nil {
+		return "", fmt.Errorf("append to file: %w", err)
 	}
 	return resolved, nil
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -257,3 +257,42 @@ func TestUsage(t *testing.T) {
 		t.Errorf("Usage(ScopedFS) bytes = %d, want 42", bytes)
 	}
 }
+
+func TestAppendFile(t *testing.T) {
+	root := t.TempDir()
+	s, err := NewScopedFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Append to a non-existent file creates it.
+	if _, err := AppendFile(s, "a.bin", []byte("hello ")); err != nil {
+		t.Fatalf("first AppendFile: %v", err)
+	}
+	// A second append concatenates rather than truncating.
+	if _, err := AppendFile(s, "a.bin", []byte("world")); err != nil {
+		t.Fatalf("second AppendFile: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, "a.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello world" {
+		t.Errorf("file content = %q, want %q", got, "hello world")
+	}
+}
+
+func TestAppendFile_CreatesParentDirs(t *testing.T) {
+	root := t.TempDir()
+	s, err := NewScopedFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AppendFile(s, "nested/deep/a.bin", []byte("x")); err != nil {
+		t.Fatalf("AppendFile into a new subtree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "nested", "deep", "a.bin")); err != nil {
+		t.Errorf("appended file not created: %v", err)
+	}
+}


### PR DESCRIPTION
Implements **part C** of #71, the last piece: a single asset larger than the per-call `put_file` limit had no client-side path into a hosted workspace. Add an **append mode** so a large file streams in bounded chunks.

## Change

- **`put_file` gains a `mode` parameter:** `"overwrite"` (default — truncates and writes, the prior behaviour) or `"append"` (adds to the end). To upload a file over the per-call limit, send it as slices each within the limit: first slice `overwrite`, the rest `append`. Slices concatenate verbatim on disk, so a base64 asset is decoded and split on **byte** boundaries (not the base64 text).
- **`workspace.AppendFile`** backs the new mode (`O_APPEND|O_CREATE`).
- **Limits still hold:** the per-call cap bounds each slice; the cumulative workspace budget bounds the whole file. `projectedUsage` is mode-aware — append adds to usage (no overwrite discount).

## Why append, not by-reference

By-reference (server fetches a URL) adds SSRF surface *and* doesn't help the reported case — a local image the agent read from disk has no URL. Chunked append needs no new transport or security surface.

**Honest residual:** append does not remove the base64-through-context cost — the bytes still traverse the model, now in slices. A side-channel upload would, but a pure MCP agent can only call tools, so that's noted as possible future work rather than built.

## Verification (devcontainer)

`go test ./...`, `gofmt`, `golangci-lint` clean. Unit tests: `AppendFile` (concatenation, parent-dir creation), chunked upload assembling a file larger than the per-call limit, append-counts-against-budget-without-discount, single-chunk-over-limit-still-rejected, unknown-mode-rejected.

**End-to-end stdio smoke test:** streamed a **3000-byte** binary through a per-call limit of **2000** in two 1500-byte chunks (`overwrite` + `append`) and got back a **byte-identical** file (SHA-256 match):
```
resp 2 wrote 1500 bytes to /tmp/assembled.bin
resp 3 appended 1500 bytes to /tmp/assembled.bin
original  sha256: 089ded93…  assembled sha256: 089ded93…  MATCH
```

## Closes #71

Parts A (budget), B (`workspace_info`), A2 (per-workspace override), and C (this) are all merged/open — this completes the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)