### PR TITLE
feat: seed house templates onto the data volume (#63 step 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,14 @@ RUN curl -fsSL "https://github.com/typst/typst/releases/download/${TYPST_VERSION
 # organisation later, without the import path in anyone's document
 # changing.
 #
-# XDG_DATA_HOME is set to an image path so templates ship read-only with
-# the binary. typst's writable cache for @preview packages keeps using
-# $HOME, which the deployment points at its volume.
-COPY templates/ /usr/local/share/typst/packages/
-ENV XDG_DATA_HOME=/usr/local/share
+# The templates are embedded in the binary (package ./templates) and
+# seeded onto the data volume on startup, so XDG_DATA_HOME points at the
+# volume rather than a read-only image path. That is what lets house style
+# change on the volume without an image rebuild (#63 step 2). The seed
+# target sits beside — not inside — the workspace tree, so the sweeper
+# never purges it. typst's writable @preview cache uses $HOME (XDG_CACHE_HOME),
+# unaffected by this.
+ENV XDG_DATA_HOME=/var/lib/typst-d2-mcp/data
 
 # Drop privileges. UID/GID match the convention used by distroless's
 # "nonroot" so swapping bases later is painless.

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -25,6 +26,7 @@ import (
 	"github.com/dlouwers/typst-d2-mcp/internal/sweeper"
 	"github.com/dlouwers/typst-d2-mcp/internal/web"
 	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/dlouwers/typst-d2-mcp/templates"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/yosida95/uritemplate/v3"
@@ -313,6 +315,57 @@ func typstDataDir() string {
 	return filepath.Join(home, ".local", "share")
 }
 
+// seedBundledTemplates copies the binary's embedded template packages onto
+// the typst package path (typstDataDir()/typst/packages) so a hosted
+// deployment resolves them from the data volume rather than a baked-in
+// image path — #63 step 2, "house style changes without an image rebuild".
+//
+// It writes only files that are absent, so it is safe to run on every
+// startup and never clobbers a template an operator has customised on the
+// volume (bump the package version to ship a change). The target sits under
+// XDG_DATA_HOME, a sibling of the workspace root, so the sweeper — which
+// only walks TYPST_D2_MCP_WORKSPACE — never purges it.
+func seedBundledTemplates() {
+	data := typstDataDir()
+	if data == "" {
+		slog.Warn("no data dir resolved; skipping template seed")
+		return
+	}
+	pkgRoot := filepath.Join(data, "typst", "packages")
+	var seeded int
+	err := fs.WalkDir(templates.FS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		dst := filepath.Join(pkgRoot, path) // path e.g. house/templates/0.1.0/lib.typ
+		if _, statErr := os.Stat(dst); statErr == nil {
+			return nil // already present — never overwrite
+		}
+		content, readErr := templates.FS.ReadFile(path)
+		if readErr != nil {
+			return fmt.Errorf("read embedded %s: %w", path, readErr)
+		}
+		if mkErr := os.MkdirAll(filepath.Dir(dst), 0o755); mkErr != nil {
+			return fmt.Errorf("create %s: %w", filepath.Dir(dst), mkErr)
+		}
+		if wErr := os.WriteFile(dst, content, 0o644); wErr != nil {
+			return fmt.Errorf("write %s: %w", dst, wErr)
+		}
+		seeded++
+		return nil
+	})
+	if err != nil {
+		slog.Error("template seed failed", "err", err, "dir", pkgRoot)
+		return
+	}
+	if seeded > 0 {
+		slog.Info("seeded bundled templates onto the data volume", "files", seeded, "dir", pkgRoot)
+	}
+}
+
 // templateInstructions describes the house templates to the model, or
 // returns empty when the package is not installed.
 //
@@ -386,6 +439,15 @@ func main() {
 	}
 	if closer != nil {
 		defer closer()
+	}
+
+	// Hosted mode seeds the house templates onto the data volume before the
+	// server advertises them, so a fresh volume resolves them and an
+	// operator can edit them there without an image rebuild (#63 step 2).
+	// Local stdio users are left untouched: they only see templates they
+	// installed themselves.
+	if isHTTPTransport() {
+		seedBundledTemplates()
 	}
 
 	s := server.NewMCPServer(

--- a/cmd/typst-d2-mcp/templates_test.go
+++ b/cmd/typst-d2-mcp/templates_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 )
 
-// repoTemplates is the package tree as it sits in the repo, which the
-// Dockerfile copies into the image's typst package directory.
+// repoTemplates is the package tree as it sits in the repo — the source
+// of truth that the templates package embeds and the server seeds onto
+// the data volume on startup.
 func repoTemplates(t *testing.T) string {
 	t.Helper()
 	dir, err := filepath.Abs(filepath.Join("..", "..", "templates"))
@@ -123,5 +124,73 @@ Trailing content.
 				t.Errorf("no PDF produced: %v", err)
 			}
 		})
+	}
+}
+
+// Seeding writes the embedded package tree onto the typst package path,
+// leaves an operator's edits alone, and produces a tree typst can resolve.
+func TestSeedBundledTemplates(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+	pkg := filepath.Join(data, "typst", "packages", templateNamespace, templateName, templateVersion)
+
+	seedBundledTemplates()
+
+	for _, f := range []string{"typst.toml", "lib.typ"} {
+		if _, err := os.Stat(filepath.Join(pkg, f)); err != nil {
+			t.Fatalf("seed did not write %s: %v", f, err)
+		}
+	}
+
+	// The seeded content must match the repo source of truth byte-for-byte.
+	for _, f := range []string{"typst.toml", "lib.typ"} {
+		got, _ := os.ReadFile(filepath.Join(pkg, f))
+		want, err := os.ReadFile(filepath.Join(repoTemplates(t), templateNamespace, templateName, templateVersion, f))
+		if err != nil {
+			t.Fatalf("read repo %s: %v", f, err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("seeded %s differs from the repo source", f)
+		}
+	}
+
+	// Non-destructive: an operator edit on the volume survives a re-seed.
+	custom := []byte("// operator customised\n")
+	if err := os.WriteFile(filepath.Join(pkg, "lib.typ"), custom, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedBundledTemplates() // must not overwrite
+	if got, _ := os.ReadFile(filepath.Join(pkg, "lib.typ")); string(got) != string(custom) {
+		t.Error("re-seed clobbered an operator's customised template")
+	}
+}
+
+// A document compiles against the *seeded* package, proving the embedded
+// tree is a resolvable typst package and not just files on disk.
+func TestSeedBundledTemplates_Compiles(t *testing.T) {
+	if _, err := exec.LookPath("typst"); err != nil {
+		t.Skip("typst not installed")
+	}
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+	seedBundledTemplates()
+
+	dir := t.TempDir()
+	in := filepath.Join(dir, "doc.typ")
+	out := filepath.Join(dir, "doc.pdf")
+	src := `#import "@house/templates:0.1.0": report
+#show: report.with(title: "Seeded")
+= Body
+`
+	if err := os.WriteFile(in, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("typst", "compile", in, out)
+	cmd.Env = append(os.Environ(), "XDG_DATA_HOME="+data)
+	if outBytes, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("compile against seeded package failed: %v\n%s", err, outBytes)
+	}
+	if info, err := os.Stat(out); err != nil || info.Size() == 0 {
+		t.Errorf("no PDF produced from seeded package: %v", err)
 	}
 }

--- a/deploy/k8s/base/config.env
+++ b/deploy/k8s/base/config.env
@@ -12,6 +12,11 @@ TYPST_D2_MCP_PATH=/mcp
 TYPST_D2_MCP_METRICS_ADDR=:9090
 TYPST_D2_MCP_WORKSPACE=/var/lib/typst-d2-mcp/workspaces
 TYPST_D2_MCP_DB=/var/lib/typst-d2-mcp/auth.sqlite
+# House templates are seeded here (beside workspaces/, so the sweeper does
+# not purge them) from the binary on startup and resolved by typst as
+# $XDG_DATA_HOME/typst/packages/<owner>/<name>/<version>. Edit them on the
+# volume to change house style without an image rebuild (#63 step 2).
+XDG_DATA_HOME=/var/lib/typst-d2-mcp/data
 TYPST_D2_MCP_AUTH=github
 TYPST_D2_MCP_PUBLIC_URL=https://typst-d2-mcp.stormlantern.nl
 TYPST_D2_MCP_QUOTA_PER_DAY=1

--- a/templates/embed.go
+++ b/templates/embed.go
@@ -1,0 +1,19 @@
+// Package templates carries the house document templates, embedded into
+// the binary so they travel with it rather than being COPY'd into the
+// image at a fixed path. In hosted mode the server seeds this tree onto
+// the data volume on startup (see seedBundledTemplates), which is what
+// lets house style change on the volume without an image rebuild — step 2
+// of #63.
+//
+// The embed path mirrors typst's local-package layout under
+// <namespace>/<name>/<version>/, so seeding is a straight copy into
+// $XDG_DATA_HOME/typst/packages/.
+package templates
+
+import "embed"
+
+// FS holds the bundled package tree rooted at the owner namespace, e.g.
+// house/templates/0.1.0/{typst.toml,lib.typ}.
+//
+//go:embed house
+var FS embed.FS


### PR DESCRIPTION
Implements **step 2 of #63** ("the ladder"): move the house templates off the read-only image path onto the data volume, so **house style changes without an image rebuild** — still one hardcoded owner (`house`), and living **outside `workspaces/`** so the sweeper never purges them.

## Change

- **Embed** the template tree into the binary (new package `./templates`, `//go:embed house`), so it travels with the binary instead of a Dockerfile `COPY`.
- **Seed on startup** (hosted/HTTP mode): copy the embedded packages onto the typst package path under `XDG_DATA_HOME`, writing **only files that are absent**. A fresh volume gets the shipped house style automatically (no regression from step 1); an operator's edits on the volume **survive** a restart. To ship a template change, bump the package version — matching #63's "Version pinning" note. Local stdio users are left untouched.
- **`XDG_DATA_HOME` → `/var/lib/typst-d2-mcp/data`** (Dockerfile + k8s `config.env`), a sibling of `workspaces/`. The sweeper only walks `TYPST_D2_MCP_WORKSPACE`, so templates are safe. Dockerfile drops the baked-in `COPY templates/ …`.

## Why seed-if-absent (non-destructive)

That's the load-bearing property of step 2: an operator edits the template on the volume and it stays edited across restarts/upgrades. A destructive reseed would defeat the whole "change without a rebuild" goal.

## Verification (devcontainer)

`go test ./...`, `gofmt`, `golangci-lint` clean. New tests: seed writes the tree, is **non-destructive** (operator edit survives a re-seed), matches the repo source **byte-for-byte**, and the **seeded** package **compiles through real typst**.

**HTTP e2e against a fresh volume:**
```
{"msg":"seeded bundled templates onto the data volume","files":2,"dir":"/tmp/vol/data/typst/packages"}
/tmp/vol/data/typst/packages/house/templates/0.1.0/{lib.typ,typst.toml}   # beside workspaces/, not inside
initialize advertises @house templates: True
compile of #import "@house/templates:0.1.0": report  ->  Successfully compiled
```

## #63 ladder after this

- [x] 1. One owner, baked into the image
- [x] **2. Templates on the data volume** ← this PR
- [ ] 3. Owners become organisations in the schema
- [ ] 4. Per-owner resolution (namespace isolation)
- [ ] 5. Org-scoped template management in the admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)