### PR TITLE
fix(web): re-sync design-system assets to 0.2.0, adopt accent-text

### DIFF
--- a/internal/web/static/app.css
+++ b/internal/web/static/app.css
@@ -1,6 +1,11 @@
 /* Admin UI layout. Colour, type and spacing all come from the
    Stormlantern tokens; nothing here invents a value that a token
-   already defines. */
+   already defines.
+
+   Note the accent split: --sl-color-accent is the brand orange as a
+   FILL, and measures 2.73 against a light surface when used as text.
+   Anything that colours text with the accent wants --sl-color-accent-text
+   (orange.700 light, orange.300 dark). See stormlantern-design-system#18. */
 
 body {
   margin: 0;
@@ -31,7 +36,7 @@ body {
 }
 .topbar nav { display: flex; align-items: center; gap: var(--sl-space-4); }
 .topbar nav a { color: var(--sl-color-ink); text-decoration: none; }
-.topbar nav a:hover { color: var(--sl-color-accent); }
+.topbar nav a:hover { color: var(--sl-color-accent-text); }
 .who { color: var(--sl-color-muted); font-size: var(--sl-font-size-sm); }
 form.inline { display: inline-flex; align-items: center; gap: var(--sl-space-2); margin: 0; }
 
@@ -93,7 +98,7 @@ input.narrow { width: 6rem; }
 
 /* Per-row management uses <details> rather than a modal: it needs no
    JavaScript, and the confirm field stays in the normal tab order. */
-td.actions details > summary { cursor: pointer; color: var(--sl-color-accent); }
+td.actions details > summary { cursor: pointer; color: var(--sl-color-accent-text); }
 td.actions .panel {
   display: flex;
   flex-direction: column;

--- a/internal/web/static/vendor/sl-badge.js
+++ b/internal/web/static/vendor/sl-badge.js
@@ -38,11 +38,11 @@ class SlBadge extends HTMLElement {
         }
         :host([variant="info"]) .pill {
           background: var(--sl-color-accent-tint);
-          color: var(--sl-color-accent-hover);
+          color: var(--sl-color-on-accent-tint);
         }
         :host([variant="neutral"]) .pill {
-          background: var(--sl-color-gray-100);
-          color: var(--sl-color-muted);
+          background: var(--sl-color-neutral-tint);
+          color: var(--sl-color-on-neutral-tint);
         }
       </style>
       <span class="pill" part="pill"><slot></slot></span>

--- a/internal/web/static/vendor/stormlantern-tokens.css
+++ b/internal/web/static/vendor/stormlantern-tokens.css
@@ -17,6 +17,7 @@
   --sl-color-orange-300: #ffa055;
   --sl-color-orange-500: #fb7600;
   --sl-color-orange-700: #b35400;
+  --sl-color-orange-800: #472a12;
   --sl-color-orange-900: #703500;
   --sl-color-gray-0: #ffffff;
   --sl-color-gray-50: #fafaf7;
@@ -25,6 +26,7 @@
   --sl-color-gray-300: #c7c7c4;
   --sl-color-gray-400: #a3a3a0;
   --sl-color-gray-500: #787878;
+  --sl-color-gray-550: #6e6e6e;
   --sl-color-gray-600: #5e5e5e;
   --sl-color-gray-700: #444444;
   --sl-color-gray-800: #2a2a2a;
@@ -34,11 +36,18 @@
   --sl-color-tinted-800: #0e2528;
   --sl-color-tinted-900: #06181a;
   --sl-color-green-100: #def0e3;
+  --sl-color-green-300: #6ecf8f;
   --sl-color-green-500: #1a7a3e;
+  --sl-color-green-800: #14402f;
   --sl-color-red-100: #f3dad7;
+  --sl-color-red-300: #f28b82;
   --sl-color-red-500: #b3271f;
+  --sl-color-red-800: #4a2622;
   --sl-color-amber-100: #f5e6b3;
+  --sl-color-amber-300: #e8bd57;
   --sl-color-amber-500: #b58400;
+  --sl-color-amber-600: #7d5600;
+  --sl-color-amber-800: #423616;
   --sl-motion-duration-instant: 0ms;
   --sl-motion-duration-fast: 120ms;
   --sl-motion-duration-base: 180ms;
@@ -102,9 +111,12 @@
   --sl-color-accent: var(--sl-color-orange-500);
   --sl-color-accent-hover: var(--sl-color-orange-700);
   --sl-color-accent-tint: var(--sl-color-orange-100);
+  --sl-color-on-accent: var(--sl-color-gray-900); /** Foreground on the accent fill. Deliberately the gray.900 primitive and not the `ink` role: `ink` flips to white in dark, while the accent fill stays orange.500 in both themes, so a themed foreground would break the pairing it exists to fix. gray.0 on accent measured 2.73. */
+  --sl-color-accent-text: var(--sl-color-orange-700); /** The accent used AS text on a page surface — links, standalone affordances. Separate from `accent` because the brand orange is a fill colour: orange.500 as text on white is 2.73. */
+  --sl-color-on-accent-tint: var(--sl-color-orange-900); /** Foreground on accent-tint. accent-hover on accent-tint measured 4.06. */
   --sl-color-ink: var(--sl-color-gray-900);
   --sl-color-body: var(--sl-color-gray-700);
-  --sl-color-muted: var(--sl-color-gray-500);
+  --sl-color-muted: var(--sl-color-gray-550);
   --sl-color-line: var(--sl-color-gray-200);
   --sl-color-surface: var(--sl-color-gray-0);
   --sl-color-paper: var(--sl-color-gray-50);
@@ -114,41 +126,102 @@
   --sl-color-line-dark: var(--sl-color-tinted-600);
   --sl-color-surface-dark: var(--sl-color-tinted-800);
   --sl-color-paper-dark: var(--sl-color-tinted-900);
+  --sl-color-accent-text-dark: var(--sl-color-orange-300);
+  --sl-color-accent-tint-dark: var(--sl-color-orange-800);
+  --sl-color-on-accent-tint-dark: var(--sl-color-orange-300);
   --sl-color-gain: var(--sl-color-green-500);
   --sl-color-gain-tint: var(--sl-color-green-100);
+  --sl-color-on-gain: var(--sl-color-gray-0);
+  --sl-color-gain-dark: var(--sl-color-green-300);
+  --sl-color-gain-tint-dark: var(--sl-color-green-800);
+  --sl-color-on-gain-dark: var(--sl-color-gray-900);
   --sl-color-loss: var(--sl-color-red-500);
   --sl-color-loss-tint: var(--sl-color-red-100);
-  --sl-color-warn: var(--sl-color-amber-500);
+  --sl-color-on-loss: var(--sl-color-gray-0);
+  --sl-color-loss-dark: var(--sl-color-red-300);
+  --sl-color-loss-tint-dark: var(--sl-color-red-800);
+  --sl-color-on-loss-dark: var(--sl-color-gray-900);
+  --sl-color-warn: var(--sl-color-amber-600);
   --sl-color-warn-tint: var(--sl-color-amber-100);
+  --sl-color-on-warn: var(--sl-color-gray-0);
+  --sl-color-warn-dark: var(--sl-color-amber-300);
+  --sl-color-warn-tint-dark: var(--sl-color-amber-800);
+  --sl-color-on-warn-dark: var(--sl-color-gray-900);
+  --sl-color-neutral-tint: var(--sl-color-gray-100); /** Quiet neutral container — muted pills, ghost-button hover. Exists because those surfaces were reading the gray.100 primitive directly, which does not move between themes: a light patch stayed light on a dark page, taking ghost-hover to 1.14 and the neutral pill to 2.22. */
+  --sl-color-on-neutral-tint: var(--sl-color-gray-600);
+  --sl-color-neutral-tint-dark: var(--sl-color-tinted-700);
+  --sl-color-on-neutral-tint-dark: var(--sl-color-gray-400);
   --sl-color-focus: var(--sl-color-orange-500);
 }
 
-/* ── Dark-mode primitive aliasing (post-build append, see build.ts) ── */
+/* ── Theme aliasing (post-build append, see build.ts) ── */
 @media (prefers-color-scheme: dark) {
   :root {
-    --sl-color-ink:     var(--sl-color-ink-dark);
-    --sl-color-body:    var(--sl-color-body-dark);
-    --sl-color-muted:   var(--sl-color-muted-dark);
-    --sl-color-line:    var(--sl-color-line-dark);
-    --sl-color-surface: var(--sl-color-surface-dark);
-    --sl-color-paper:   var(--sl-color-paper-dark);
+    --sl-color-ink:             var(--sl-color-ink-dark);
+    --sl-color-body:            var(--sl-color-body-dark);
+    --sl-color-muted:           var(--sl-color-muted-dark);
+    --sl-color-line:            var(--sl-color-line-dark);
+    --sl-color-surface:         var(--sl-color-surface-dark);
+    --sl-color-paper:           var(--sl-color-paper-dark);
+    --sl-color-accent-text:     var(--sl-color-accent-text-dark);
+    --sl-color-accent-tint:     var(--sl-color-accent-tint-dark);
+    --sl-color-on-accent-tint:  var(--sl-color-on-accent-tint-dark);
+    --sl-color-neutral-tint:    var(--sl-color-neutral-tint-dark);
+    --sl-color-on-neutral-tint: var(--sl-color-on-neutral-tint-dark);
+    --sl-color-gain:            var(--sl-color-gain-dark);
+    --sl-color-gain-tint:       var(--sl-color-gain-tint-dark);
+    --sl-color-on-gain:         var(--sl-color-on-gain-dark);
+    --sl-color-loss:            var(--sl-color-loss-dark);
+    --sl-color-loss-tint:       var(--sl-color-loss-tint-dark);
+    --sl-color-on-loss:         var(--sl-color-on-loss-dark);
+    --sl-color-warn:            var(--sl-color-warn-dark);
+    --sl-color-warn-tint:       var(--sl-color-warn-tint-dark);
+    --sl-color-on-warn:         var(--sl-color-on-warn-dark);
   }
 }
 
-:root[data-theme="dark"] {
-  --sl-color-ink:     var(--sl-color-ink-dark);
-  --sl-color-body:    var(--sl-color-body-dark);
-  --sl-color-muted:   var(--sl-color-muted-dark);
-  --sl-color-line:    var(--sl-color-line-dark);
-  --sl-color-surface: var(--sl-color-surface-dark);
-  --sl-color-paper:   var(--sl-color-paper-dark);
+[data-theme="dark"] {
+  --sl-color-ink:             var(--sl-color-ink-dark);
+  --sl-color-body:            var(--sl-color-body-dark);
+  --sl-color-muted:           var(--sl-color-muted-dark);
+  --sl-color-line:            var(--sl-color-line-dark);
+  --sl-color-surface:         var(--sl-color-surface-dark);
+  --sl-color-paper:           var(--sl-color-paper-dark);
+  --sl-color-accent-text:     var(--sl-color-accent-text-dark);
+  --sl-color-accent-tint:     var(--sl-color-accent-tint-dark);
+  --sl-color-on-accent-tint:  var(--sl-color-on-accent-tint-dark);
+  --sl-color-neutral-tint:    var(--sl-color-neutral-tint-dark);
+  --sl-color-on-neutral-tint: var(--sl-color-on-neutral-tint-dark);
+  --sl-color-gain:            var(--sl-color-gain-dark);
+  --sl-color-gain-tint:       var(--sl-color-gain-tint-dark);
+  --sl-color-on-gain:         var(--sl-color-on-gain-dark);
+  --sl-color-loss:            var(--sl-color-loss-dark);
+  --sl-color-loss-tint:       var(--sl-color-loss-tint-dark);
+  --sl-color-on-loss:         var(--sl-color-on-loss-dark);
+  --sl-color-warn:            var(--sl-color-warn-dark);
+  --sl-color-warn-tint:       var(--sl-color-warn-tint-dark);
+  --sl-color-on-warn:         var(--sl-color-on-warn-dark);
 }
 
-:root[data-theme="light"] {
-  --sl-color-ink:     var(--sl-color-gray-900);
-  --sl-color-body:    var(--sl-color-gray-700);
-  --sl-color-muted:   var(--sl-color-gray-500);
-  --sl-color-line:    var(--sl-color-gray-200);
-  --sl-color-surface: var(--sl-color-gray-0);
-  --sl-color-paper:   var(--sl-color-gray-50);
+[data-theme="light"] {
+  --sl-color-ink:             var(--sl-color-gray-900);
+  --sl-color-body:            var(--sl-color-gray-700);
+  --sl-color-muted:           var(--sl-color-gray-550);
+  --sl-color-line:            var(--sl-color-gray-200);
+  --sl-color-surface:         var(--sl-color-gray-0);
+  --sl-color-paper:           var(--sl-color-gray-50);
+  --sl-color-accent-text:     var(--sl-color-orange-700);
+  --sl-color-accent-tint:     var(--sl-color-orange-100);
+  --sl-color-on-accent-tint:  var(--sl-color-orange-900);
+  --sl-color-neutral-tint:    var(--sl-color-gray-100);
+  --sl-color-on-neutral-tint: var(--sl-color-gray-600);
+  --sl-color-gain:            var(--sl-color-green-500);
+  --sl-color-gain-tint:       var(--sl-color-green-100);
+  --sl-color-on-gain:         var(--sl-color-gray-0);
+  --sl-color-loss:            var(--sl-color-red-500);
+  --sl-color-loss-tint:       var(--sl-color-red-100);
+  --sl-color-on-loss:         var(--sl-color-gray-0);
+  --sl-color-warn:            var(--sl-color-amber-600);
+  --sl-color-warn-tint:       var(--sl-color-amber-100);
+  --sl-color-on-warn:         var(--sl-color-gray-0);
 }

--- a/scripts/sync-vendor.sh
+++ b/scripts/sync-vendor.sh
@@ -28,6 +28,25 @@
 # build would otherwise need a token. Point STORMLANTERN_DS at the
 # checkout if it is not the default sibling directory.
 #
+# NOTHING HERE PINS A VERSION. This copies from whatever commit the
+# checkout is on, and CI checks out the design system's default branch
+# HEAD, so the vendored bytes are "whatever main was when someone last
+# ran this". There is no tag, version or SHA recorded anywhere in this
+# repo, which is why staleness is invisible rather than reported: the CI
+# check only fires once main moves past what is committed here, and if
+# nothing pushes to this repo in the meantime, nobody finds out.
+#
+# That is how this repo ended up serving ten WCAG failures for a day
+# after they were fixed upstream (#80).
+#
+# A provenance stamp written into vendor/ was considered and rejected:
+# recording the design system's HEAD would fail this repo's CI on every
+# unrelated commit there, and recording its nearest tag would be a lie
+# whenever main is ahead of it. The real fix is to consume a versioned
+# artifact instead of copying files —
+# dlouwers/stormlantern-design-system#21 proposes publishing a Go module,
+# after which go.mod pins the version and `go mod vendor` verifies it.
+#
 # htmx is NOT synced here. It is pinned and vendored once by hand
 # (currently 2.0.3, matching investor-buddy); bumping it is a deliberate
 # act, not a side effect of syncing the design system.


### PR DESCRIPTION
## What was wrong

The vendored assets predated `stormlantern-design-system` **0.2.0**, so the admin UI has been serving all ten WCAG 2 AA failures that release fixed ([#18](https://github.com/dlouwers/stormlantern-design-system/issues/18), [#13](https://github.com/dlouwers/stormlantern-design-system/issues/13)).

Worse than it sounds, because `app.css` styles from `--sl-color-paper` / `--sl-color-ink` directly and the tokens rebind those under `prefers-color-scheme: dark`. This UI **does** render dark for anyone with a dark OS preference — and was doing it with the pre-0.2.0 palette: light pastel badge patches on a near-black surface, and status colours below AA.

The re-sync rewrites `stormlantern-tokens.css` and `sl-badge.js`. The rest of the vendor directory was already current.

## The one thing the re-sync can't fix

0.2.0 splits the accent role. `--sl-color-accent` is the brand orange as a **fill**; used as text it measures **2.73** on a light surface. Two rules did exactly that:

- `.topbar nav a:hover`
- `td.actions details > summary`

Both now use `--sl-color-accent-text` — orange.700 light, orange.300 dark.

## Verification

Measured in Chromium against the real `app.css`, in all four theme states — explicit light, explicit dark, and system default under **both** OS preferences, since that un-stamped state is where most users actually are.

| Pairing | Before | After |
|---|---|---|
| nav hover / summary | 2.73 light | **5.02** light · 7.92 dark |
| btn-danger label | 2.46 dark | 6.51 light · **6.69** dark |
| btn-danger hover | — | 4.90 light · 5.52 dark |
| muted text on surface | 4.42 | **5.10** |
| muted on page ground | — | 4.88 |

**0 failing pairings.** `go vet ./...` and `go test ./...` clean. `sync-vendor.sh` is idempotent — a second run produces no diff.

## Provenance, and what I deliberately did not add

The synced content corresponds exactly to `tokens-v0.2.0` / `components-v0.2.0` — but only because the design system's `main` happens to sit on those tags right now. **Nothing in this repo pins a version.** `sync-vendor.sh` copies from whatever commit the local checkout is on, and CI checks out the design system's default-branch HEAD.

That is why this was invisible rather than reported: the drift check only fires once upstream `main` moves past what is committed here, and if nothing pushes to *this* repo in the meantime, nobody finds out. Which is precisely what happened — the fix landed upstream and this repo carried on serving the bugs.

I considered writing a provenance stamp into `vendor/` and rejected it, for reasons now recorded in the script: stamping upstream `HEAD` would fail this repo's CI on every unrelated commit there, and stamping its nearest tag would be a lie whenever `main` is ahead of it. Neither is better than the gap it papers over.

The durable fix is consuming a versioned artifact rather than copying files — [stormlantern-design-system#21](https://github.com/dlouwers/stormlantern-design-system/issues/21) proposes publishing a Go module, after which `go.mod` pins the version and `go mod vendor` verifies it. This repo being a second Go consumer hand-rolling the same copy step is a good part of the argument there.

Refers #80