### PR TITLE
docs(ci): record the design-system app's setup and rotation

### DIFF
--- a/.github/actions/design-system-auth/action.yml
+++ b/.github/actions/design-system-auth/action.yml
@@ -8,6 +8,64 @@ description: >
 # these steps is two things to keep in step — and a copy that silently falls
 # behind is exactly the failure that made this repo serve a stale design
 # system for a day (#80).
+#
+# ---------------------------------------------------------------------------
+# The app
+# ---------------------------------------------------------------------------
+#
+# `stormlantern-actions-read` — app id 4634915, client id
+# Iv23lixvWvv974Iv2bPY. One permission, Repository -> Contents -> Read-only,
+# installed on dlouwers/stormlantern-design-system only.
+#
+# A GitHub App rather than a personal access token: the token is minted per
+# run and expires in an hour, it belongs to the account rather than to a
+# person whose access it would otherwise inherit, and there is no annual
+# expiry to renew by hand.
+#
+# These notes lived in scripts/sync-vendor.sh, which #80 deleted along with
+# the copy step. They are here now because this is where the credential is
+# used, and because losing them cost a key rotation: the .pem is downloadable
+# exactly once, and nothing recorded how the app was set up.
+#
+# ---------------------------------------------------------------------------
+# Setting it up in a NEW consumer repo
+# ---------------------------------------------------------------------------
+#
+#   gh variable set DS_APP_CLIENT_ID -R <owner>/<repo> --body Iv23lixvWvv974Iv2bPY
+#   gh secret set DS_APP_PRIVATE_KEY -R <owner>/<repo> --app actions    < key.pem
+#   gh secret set DS_APP_PRIVATE_KEY -R <owner>/<repo> --app dependabot < key.pem
+#
+# The app needs no further installation — it is installed on the repository
+# being READ, so a consumer only holds credentials.
+#
+# Both secret stores, not one. Dependabot-triggered runs never see Actions
+# secrets, and since the design system became a Go module a run without the
+# key cannot resolve the dependency at all — so a missing Dependabot secret
+# is a Dependabot PR that fails at `go mod download`, every time.
+#
+# The client id is a repository variable because it is not secret. Only the
+# private key is.
+#
+# ---------------------------------------------------------------------------
+# Rotating the key
+# ---------------------------------------------------------------------------
+#
+# Generate a new private key on the app (Settings -> Developer settings ->
+# GitHub Apps -> stormlantern-actions-read -> Private keys). Generating ADDS a
+# key; the old one keeps working, so there is no outage window.
+#
+# Then set it in every store that holds it. To find them all rather than
+# trusting a list that will go stale:
+#
+#   for r in $(gh repo list <owner> --limit 40 --json nameWithOwner -q '.[].nameWithOwner'); do
+#     for app in actions dependabot codespaces; do
+#       gh secret list -R "$r" --app "$app" 2>/dev/null | grep -q DS_APP_PRIVATE_KEY \
+#         && echo "$r [$app]"
+#     done
+#   done
+#
+# Finally DELETE the old key on the app and remove the local .pem. Skipping
+# that turns a rotation into an accumulation.
 
 inputs:
   client-id:


### PR DESCRIPTION
Follow-up to #82. It landed while I was pushing this, so the commit ended up orphaned on the recreated branch rather than in the PR — hence a separate one. The stale branch is deleted.

## What this restores

#82 deleted `scripts/sync-vendor.sh` along with the copy step it drove. That header was the **only** place documenting the GitHub App behind the credential: which app, which permission, where it is installed, and the commands to wire it into a repo.

That cost a key rotation almost immediately. The `.pem` is downloadable exactly once, and with the notes gone nothing recorded that the app was `stormlantern-actions-read` (id 4634915), Contents read-only, installed on the design system only.

The notes now live in the composite action — where the credential is consumed, rather than in a script that no longer exists.

## Extended with two things the original couldn't have known

**Both secret stores are needed, not one.** Dependabot runs never see Actions secrets, and since the design system became a Go module a run without the key cannot resolve the dependency at all. A missing Dependabot secret is a Dependabot PR that fails at `go mod download`, every time.

**How to rotate.** Including a command that *finds* every store holding the key rather than a hand-written list that goes stale — the same reasoning as everything else in this thread — and the reminder to delete the old key afterwards. A rotation that only adds is an accumulation.

## Already done outside this PR

The key has been rotated into all four stores, and `DS_APP_CLIENT_ID` set on investor-buddy ahead of its own migration:

| Repo | Actions | Dependabot | Variable |
|---|---|---|---|
| typst-d2-mcp | ✅ rotated | ✅ added | ✅ |
| investor-buddy | ✅ added | ✅ added | ✅ added |

Still outstanding on your side: **delete the old private key** on the app, and remove the local `.pem`.

Refers #80