### PR TITLE
fix(image): give the container build access to the private Go module

### DIFF
--- a/.github/actions/design-system-auth/action.yml
+++ b/.github/actions/design-system-auth/action.yml
@@ -75,6 +75,15 @@ inputs:
     description: GitHub App private key (a secret).
     required: true
 
+outputs:
+  token:
+    description: >
+      The minted installation token. Exposed for callers that need the raw
+      value rather than a configured git — the container build passes it to
+      BuildKit as a secret, because `go mod download` runs inside the image
+      build where the runner's git config does not reach.
+    value: ${{ steps.token.outputs.token }}
+
 runs:
   using: composite
   steps:

--- a/.github/actions/design-system-auth/action.yml
+++ b/.github/actions/design-system-auth/action.yml
@@ -8,6 +8,64 @@ description: >
 # these steps is two things to keep in step — and a copy that silently falls
 # behind is exactly the failure that made this repo serve a stale design
 # system for a day (#80).
+#
+# ---------------------------------------------------------------------------
+# The app
+# ---------------------------------------------------------------------------
+#
+# `stormlantern-actions-read` — app id 4634915, client id
+# Iv23lixvWvv974Iv2bPY. One permission, Repository -> Contents -> Read-only,
+# installed on dlouwers/stormlantern-design-system only.
+#
+# A GitHub App rather than a personal access token: the token is minted per
+# run and expires in an hour, it belongs to the account rather than to a
+# person whose access it would otherwise inherit, and there is no annual
+# expiry to renew by hand.
+#
+# These notes lived in scripts/sync-vendor.sh, which #80 deleted along with
+# the copy step. They are here now because this is where the credential is
+# used, and because losing them cost a key rotation: the .pem is downloadable
+# exactly once, and nothing recorded how the app was set up.
+#
+# ---------------------------------------------------------------------------
+# Setting it up in a NEW consumer repo
+# ---------------------------------------------------------------------------
+#
+#   gh variable set DS_APP_CLIENT_ID -R <owner>/<repo> --body Iv23lixvWvv974Iv2bPY
+#   gh secret set DS_APP_PRIVATE_KEY -R <owner>/<repo> --app actions    < key.pem
+#   gh secret set DS_APP_PRIVATE_KEY -R <owner>/<repo> --app dependabot < key.pem
+#
+# The app needs no further installation — it is installed on the repository
+# being READ, so a consumer only holds credentials.
+#
+# Both secret stores, not one. Dependabot-triggered runs never see Actions
+# secrets, and since the design system became a Go module a run without the
+# key cannot resolve the dependency at all — so a missing Dependabot secret
+# is a Dependabot PR that fails at `go mod download`, every time.
+#
+# The client id is a repository variable because it is not secret. Only the
+# private key is.
+#
+# ---------------------------------------------------------------------------
+# Rotating the key
+# ---------------------------------------------------------------------------
+#
+# Generate a new private key on the app (Settings -> Developer settings ->
+# GitHub Apps -> stormlantern-actions-read -> Private keys). Generating ADDS a
+# key; the old one keeps working, so there is no outage window.
+#
+# Then set it in every store that holds it. To find them all rather than
+# trusting a list that will go stale:
+#
+#   for r in $(gh repo list <owner> --limit 40 --json nameWithOwner -q '.[].nameWithOwner'); do
+#     for app in actions dependabot codespaces; do
+#       gh secret list -R "$r" --app "$app" 2>/dev/null | grep -q DS_APP_PRIVATE_KEY \
+#         && echo "$r [$app]"
+#     done
+#   done
+#
+# Finally DELETE the old key on the app and remove the local .pem. Skipping
+# that turns a rotation into an accumulation.
 
 inputs:
   client-id:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -79,11 +79,25 @@ jobs:
             type=semver,pattern=v{{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
+      # Same app, same read-only scope as CI. The image build cannot use the
+      # runner's git config, so it needs the raw token to pass to BuildKit.
+      - name: Authenticate to the design system
+        id: ds_auth
+        uses: ./.github/actions/design-system-auth
+        with:
+          client-id: ${{ vars.DS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DS_APP_PRIVATE_KEY }}
+
       - name: Build & push image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile
+          # The build resolves a private Go module; see the Dockerfile.
+          # BuildKit keeps this out of the image layers and out of the
+          # build cache exported to GHA.
+          secrets: |
+            gh_token=${{ steps.ds_auth.outputs.token }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,25 @@ WORKDIR /src
 
 # Download deps separately so the layer is reused across source-only edits.
 COPY go.mod go.sum ./
-RUN go mod download
+
+# github.com/dlouwers/stormlantern-design-system is a private module (#80), so
+# this needs a credential. It arrives as a BuildKit secret, which is mounted
+# for the life of the RUN and never written to a layer.
+#
+# The credential is passed through GIT_CONFIG_COUNT/KEY/VALUE rather than
+# `git config --global`, deliberately: the latter writes the token into
+# /root/.gitconfig, and that file IS part of the layer. Env vars set on a
+# single RUN are not.
+#
+# A build without the secret fails here rather than later, which is the right
+# place: without it the module cannot be resolved at all. Locally:
+#   podman build --secret id=gh_token,env=GH_TOKEN .
+RUN --mount=type=secret,id=gh_token \
+    GOPRIVATE=github.com/dlouwers/* \
+    GIT_CONFIG_COUNT=1 \
+    GIT_CONFIG_KEY_0="url.https://x-access-token:$(cat /run/secrets/gh_token)@github.com/.insteadOf" \
+    GIT_CONFIG_VALUE_0="https://github.com/" \
+    go mod download
 
 COPY . .
 


### PR DESCRIPTION
**The image build has been broken since #82 merged.** Two releases produced no image:

```
#16 1.462 fatal: could not read Username for 'https://github.com'
ERROR: process "/bin/sh -c go mod download" did not complete successfully
```

## Why nobody noticed

`image.yml` runs on push to `main` and on tags — **never on `pull_request`**. So #82 and #83 were green throughout review, and the failure only appeared after merge, on a workflow nobody was watching. The check that would have caught it doesn't run where the change is reviewed.

Worth stating plainly: this is my miss. Moving to a private module changed what every build path needs, and I checked the two CI jobs while the release path had the same dependency and no credential.

## The fix

The Dockerfile takes the credential as a **BuildKit secret**, mounted for the life of the `RUN` and absent from every layer.

Passed through `GIT_CONFIG_COUNT`/`KEY`/`VALUE` rather than `git config --global`, deliberately — the latter writes the token into `/root/.gitconfig`, and **that file is part of the layer**. Env vars on a single `RUN` are not.

Verified on a local build: the image has no `/root/.gitconfig` at all, and no `/run/secrets`.

`image.yml` mints the token from the same read-only app CI uses, via the same composite action — which now exposes the token as an output, because the image build runs inside BuildKit and cannot see the runner's git config.

## Verified before merge

Dispatched on this branch rather than hoping:

```
✓ success
#26 pushing manifest for ghcr.io/dlouwers/typst-d2-mcp:sha-c83a970
```

Safe to dispatch on a branch, checked first: the tag rules give `latest` and the Flux-watched timestamp tag only on the default branch, so a branch build produces just `sha-*` and a branch tag and cannot disturb the cluster.

## Applies to investor-buddy too

Its `Containerfile` and `release.yml` have exactly the same shape, and its migration is next. Same fix, now known rather than discovered post-merge.

Refers #80