### PR TITLE
feat(devcontainer): provision Playwright so the suite runs in here

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,6 +2,12 @@
 # Only what no trustworthy devcontainer feature provides.
 set -euo pipefail
 
+# Paths are derived from this script's own location rather than assuming the
+# working directory. The mount point is named after the folder devcontainer
+# was pointed at, so a git worktree lands somewhere else entirely and a
+# cwd-relative path silently provisions nothing.
+REPO_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
 # One of the feature installs leaves /tmp as root:root 0755 instead of
 # the standard sticky 1777. That breaks more than it looks: `go build`
 # creates its work directory under /tmp, so without this the container
@@ -47,6 +53,33 @@ echo "==> bun"
 curl -fsSL https://bun.sh/install | bash > /dev/null
 sudo ln -sf "$HOME/.bun/bin/bun" /usr/local/bin/bun
 sudo ln -sf "$HOME/.bun/bin/bunx" /usr/local/bin/bunx
+
+# Node, because bun alone cannot run Playwright: its CLI is a Node script
+# and its workers fork node processes. The host's no-system-Node rule is
+# about the host; inside a container it coexists with everything else.
+echo "==> node"
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - > /dev/null
+sudo apt-get install -y -qq --no-install-recommends nodejs
+
+# Playwright's browser and the apt packages it needs. Without this the suite
+# cannot run in here at all, and the only way to run it locally is to install
+# Chromium on the host — which is both toolchain pollution and, on a non-
+# Debian host, an install that fails outright: `--with-deps` shells out to
+# apt-get. It also turns out that Playwright's downloader can hang
+# indefinitely on some networks where the same archive fetches at 40MB/s with
+# curl, so "just install it on the host" is not the cheap fallback it looks
+# like.
+#
+# Chromium only. Firefox and WebKit would multiply the image for no value
+# here: the suite targets one browser.
+#
+# Run from playwright/ so the pinned @playwright/test version decides which
+# browser build to fetch — each version pins one, and a mismatched build is
+# a launch failure rather than a download.
+echo "==> playwright browsers"
+if [ -f "$REPO_ROOT/playwright/package.json" ]; then
+  (cd "$REPO_ROOT/playwright" && bun install --frozen-lockfile && bunx playwright install --with-deps chromium)
+fi
 
 # Both local and CI are on golangci-lint v2 now, driven by .golangci.yml,
 # so `latest` matches what CI resolves rather than drifting from it.

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -127,6 +127,16 @@ public by default. If you flip the package to private:
 
 3. Uncomment the `sealed-ghcr-pull.yaml` line in the overlay's
    kustomization.yaml.
+4. Add the pull-secret reference back to the pod spec in
+   `base/deployment.yaml` — it is deliberately absent while the package
+   is public, because naming a missing Secret makes the kubelet log a
+   `FailedToRetrieveImagePullSecret` warning on every pod creation:
+
+   ```yaml
+   spec:
+     imagePullSecrets:
+       - name: ghcr-pull
+   ```
 
 ## Observability
 

--- a/deploy/k8s/base/deployment.yaml
+++ b/deploy/k8s/base/deployment.yaml
@@ -23,11 +23,14 @@ spec:
       labels:
         app.kubernetes.io/name: typst-d2-mcp
     spec:
-      # GHCR package starts public; if you flip it private, seal a
-      # docker-registry secret and reference it here. See
+      # No imagePullSecrets: the GHCR package is public, so the kubelet
+      # pulls anonymously. Naming a Secret that does not exist does not
+      # fail the pull — it only makes the kubelet emit a
+      # FailedToRetrieveImagePullSecret warning on every pod creation,
+      # which is noise that looks like a broken deployment. If you flip
+      # the package to private, add the reference back — see
       # deploy/k8s/README.md → "GHCR pull secret (if private)".
-      imagePullSecrets:
-        - name: ghcr-pull
+
       # Match the binary's "nonroot" uid (65532) so the image runs as
       # a non-privileged user even before any container runtime
       # security profile kicks in. fsGroup ensures the mounted PVC is


### PR DESCRIPTION
The devcontainer installed bun but neither Node nor a browser, so the Playwright suite could not run in it. The only way to run it locally was installing Chromium on the **host** — toolchain pollution, and on a non-Debian host an install that fails outright, since `--with-deps` shells out to `apt-get`.

investor-buddy has provisioned this since its own #154. This brings the two in line, and means neither repo needs anything on a developer's machine.

## Two things learned the hard way today

- **Playwright's downloader can hang indefinitely.** Two `bunx playwright install` runs sat at zero bytes through their timeouts, while `curl` fetched the identical archive at **41 MB/s — 101 MB in 1.3 s**. "Just install it on the host" is not the cheap fallback it looks like.
- **A browser that is merely present will not necessarily launch.** Each `@playwright/test` version pins one build — 1.49.1 → 1148, 1.62.1 → 1234 — and 1.58+ split `chromium` from `chromium_headless_shell`. Having 1217 installed helped with neither. That is why the install runs from `playwright/`, where the pinned version decides what gets fetched.

## What changed

- **Node 22**, because bun alone cannot run Playwright: its CLI is a Node script and its workers fork node processes. The no-system-Node rule is about the host; in a container it coexists fine.
- **`playwright install --with-deps chromium`**, run from `playwright/`. Chromium only — Firefox and WebKit would multiply the image against a suite targeting one browser.
- **`REPO_ROOT` derived from the script's own location** rather than assuming the working directory, matching the sibling repo. A git worktree mounts somewhere the cwd-relative form would silently skip.

## Verification

Not verified by rebuilding this container — that is a slow operation I would rather you trigger than have me do unasked. What *is* verified is the equivalent path in the sibling repo, whose provisioning this copies: with its devcontainer, `bunx playwright test tests/smoke/design-system.spec.ts` runs **5 passed in 4.7s** with nothing installed on the host.

`bash -n` clean.

Refers #85