### PR TITLE
fix(preprocessor): lex D2 code as D2, and find diagrams in code context

### DIFF
--- a/MCP_GUIDE.md
+++ b/MCP_GUIDE.md
@@ -199,6 +199,36 @@ The tool supports all D2 syntax features:
 ]
 ```
 
+### Captioned Diagrams (inside `#figure`)
+
+A captioned diagram is the common case, and both of these work:
+
+```typst
+// Code context — no hash on the d2 call, because #figure(...) has
+// already crossed into code.
+#figure(
+  d2(layout: "elk", theme: "0")[
+    client -> server
+  ],
+  caption: [Request path.],
+)
+
+// Markup context — the argument is a content block, so the call keeps
+// its hash.
+#figure(
+  [#d2(layout: "elk", theme: "0")[
+    client -> server
+  ]],
+  caption: [Request path.],
+)
+```
+
+Writing `#d2` directly inside the argument list — `#figure(#d2[a -> b],
+caption: [...])` — is strictly a Typst error, because `#` crosses from
+markup into code exactly once and inside `#figure(...)` you are already
+there. The preprocessor accepts it anyway and drops the extra hash, so
+all three spellings compile.
+
 ## Best Practices for Diagram Layout
 
 ### Understanding Page Constraints

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -260,6 +260,15 @@ SYNTAX EXAMPLES:
       backend  -> database: Queries
     ]
 
+  Captioned (the common case) — inside #figure the call is in code
+  context, so it carries no hash:
+    #figure(
+      d2(layout: "elk", theme: "0")[
+        client -> server
+      ],
+      caption: [Request path.],
+    )
+
 VERIFYING THE RESULT:
   After a successful compile, open the produced PDF if you can. Check that
   text labels are readable and the diagram fits within page margins. If a

--- a/internal/preprocessor/preprocessor.go
+++ b/internal/preprocessor/preprocessor.go
@@ -21,6 +21,12 @@ type D2Block struct {
 	End     int
 	Options d2.Options
 	Code    string
+
+	// CodeContext is true when the call was found in Typst code mode
+	// rather than markup — `#figure(d2(...)[...], caption: [...])`.
+	// The replacement must then omit the leading `#`, which typst
+	// rejects there ("the character `#` is not valid in code").
+	CodeContext bool
 }
 
 // PreprocessFile reads a Typst file from the local filesystem, processes all
@@ -53,7 +59,21 @@ func Preprocess(ctx context.Context, r workspace.Resolver, inputPath string) (st
 	content = regexp.MustCompile(`#import\s+["'].*?lib\.typ["'].*?\n`).ReplaceAllString(content, "")
 
 	// Find all D2 calls
-	d2Blocks := extractD2Calls(content)
+	d2Blocks, skipped := extractD2Calls(content)
+
+	// A call site the scanner recognised but could not extract used to
+	// be left in the source for typst to trip over, several layers
+	// later, with an error naming the wrong construct — usually
+	// "unclosed delimiter" at a bracket that was in fact balanced.
+	// Failing here instead costs nothing and names the actual cause.
+	if len(skipped) > 0 {
+		site := skipped[0]
+		line, col := lineCol(content, site.Offset)
+		return "", fmt.Errorf(
+			"preprocessor: %s:%d:%d: found a d2 diagram block but could not extract it (%s). "+
+				"It was left unprocessed, so typst would fail on the D2 source with a misleading error",
+			inputPath, line, col, site.Reason)
+	}
 
 	if len(d2Blocks) == 0 {
 		slog.DebugContext(ctx, "no d2 blocks in input")
@@ -73,7 +93,7 @@ func Preprocess(ctx context.Context, r workspace.Resolver, inputPath string) (st
 		}
 
 		// Convert to Typst image
-		typstImg := svgToTypstImage(svg, block.Options)
+		typstImg := svgToTypstImage(svg, block.Options, block.CodeContext)
 
 		// Replace in content
 		content = content[:block.Start] + typstImg + content[block.End:]
@@ -89,8 +109,19 @@ func Preprocess(ctx context.Context, r workspace.Resolver, inputPath string) (st
 // content. Delegates to the Typst-aware scanner in scan.go; see the
 // commentary there for what we recognise and what we deliberately
 // don't.
-func extractD2Calls(content string) []D2Block {
+func extractD2Calls(content string) ([]D2Block, []SkipSite) {
 	return scanD2Calls(content)
+}
+
+// lineCol converts a byte offset into 1-based line and column numbers,
+// so preprocessor errors point at the same coordinates typst would.
+func lineCol(content string, offset int) (int, int) {
+	if offset > len(content) {
+		offset = len(content)
+	}
+	line := 1 + strings.Count(content[:offset], "\n")
+	col := offset - (strings.LastIndex(content[:offset], "\n") + 1) + 1
+	return line, col
 }
 
 // parseOptions extracts key-value pairs from the options string.
@@ -129,7 +160,15 @@ func parseOptions(optionsStr string) d2.Options {
 // the literal "intrinsic" disables the constraint entirely so the SVG
 // renders at its natural size (rarely what you want, but supported for
 // callers who know).
-func svgToTypstImage(svgContent string, options d2.Options) string {
+//
+// The expression is built without a hash and gets one only at the very
+// end, and only in markup. Typst allows `#` exactly once, to cross from
+// markup into code: inside an argument list we are already in code, and
+// a second one is a hard error. That applies both to a call found in
+// code context (codeContext, e.g. inside #figure(...)) and to the pad
+// wrapper, which used to nest one unconditionally — `#pad(4pt,
+// #image(...))` never compiled.
+func svgToTypstImage(svgContent string, options d2.Options, codeContext bool) string {
 	b64 := base64.StdEncoding.EncodeToString([]byte(svgContent))
 
 	width, ok := options["width"]
@@ -138,16 +177,19 @@ func svgToTypstImage(svgContent string, options d2.Options) string {
 	}
 	var typstCode string
 	if width == "none" || width == "intrinsic" {
-		typstCode = fmt.Sprintf(`#image(decode64("%s"), format: "svg")`, b64)
+		typstCode = fmt.Sprintf(`image(decode64("%s"), format: "svg")`, b64)
 	} else {
-		typstCode = fmt.Sprintf(`#image(decode64("%s"), format: "svg", width: %s)`, b64, width)
+		typstCode = fmt.Sprintf(`image(decode64("%s"), format: "svg", width: %s)`, b64, width)
 	}
 
 	if pad, ok := options["pad"]; ok && pad != "none" {
-		typstCode = fmt.Sprintf(`#pad(%s, %s)`, pad, typstCode)
+		typstCode = fmt.Sprintf(`pad(%s, %s)`, pad, typstCode)
 	}
 
-	return typstCode
+	if codeContext {
+		return typstCode
+	}
+	return "#" + typstCode
 }
 
 // addBasedImport adds the based package import at the top of the file.

--- a/internal/preprocessor/preprocessor_test.go
+++ b/internal/preprocessor/preprocessor_test.go
@@ -1,10 +1,14 @@
 package preprocessor
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/dlouwers/typst-d2-mcp/internal/d2"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
 )
 
 func TestExtractD2Calls(t *testing.T) {
@@ -49,7 +53,7 @@ Some text.
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blocks := extractD2Calls(tt.content)
+			blocks, _ := extractD2Calls(tt.content)
 			if len(blocks) != tt.wantLen {
 				t.Errorf("extractD2Calls() got %d blocks, want %d", len(blocks), tt.wantLen)
 			}
@@ -111,10 +115,11 @@ func TestParseOptions(t *testing.T) {
 
 func TestSvgToTypstImage(t *testing.T) {
 	tests := []struct {
-		name    string
-		svg     string
-		options d2.Options
-		want    string
+		name        string
+		svg         string
+		options     d2.Options
+		codeContext bool
+		want        string
 	}{
 		{
 			// Default: cap at 100% width so wide D2 diagrams scale to
@@ -138,10 +143,14 @@ func TestSvgToTypstImage(t *testing.T) {
 			want:    `#image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg")`,
 		},
 		{
+			// Exactly one hash, on the outside. The nested `#image`
+			// this used to emit is a hard typst error ("the character
+			// `#` is not valid in code"), so the pad option never
+			// produced a document that compiled.
 			name:    "svg with padding",
 			svg:     "<svg>test</svg>",
 			options: d2.Options{"pad": "10pt"},
-			want:    `#pad(10pt, #image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg", width: 100%))`,
+			want:    `#pad(10pt, image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg", width: 100%))`,
 		},
 		{
 			name:    "svg with none padding",
@@ -149,11 +158,27 @@ func TestSvgToTypstImage(t *testing.T) {
 			options: d2.Options{"pad": "none"},
 			want:    `#image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg", width: 100%)`,
 		},
+		{
+			// Code context: the caller is already inside an argument
+			// list (#figure(d2(...)[...])), so no hash at all.
+			name:        "code context omits the hash",
+			svg:         "<svg>test</svg>",
+			options:     d2.Options{},
+			codeContext: true,
+			want:        `image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg", width: 100%)`,
+		},
+		{
+			name:        "code context with padding",
+			svg:         "<svg>test</svg>",
+			options:     d2.Options{"pad": "10pt"},
+			codeContext: true,
+			want:        `pad(10pt, image(decode64("PHN2Zz50ZXN0PC9zdmc+"), format: "svg", width: 100%))`,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := svgToTypstImage(tt.svg, tt.options)
+			got := svgToTypstImage(tt.svg, tt.options, tt.codeContext)
 			if got != tt.want {
 				t.Errorf("svgToTypstImage() = %q, want %q", got, tt.want)
 			}
@@ -220,7 +245,7 @@ Middle text
 ]
 Suffix text`
 
-	blocks := extractD2Calls(content)
+	blocks, _ := extractD2Calls(content)
 	if len(blocks) != 2 {
 		t.Fatalf("Expected 2 blocks, got %d", len(blocks))
 	}
@@ -243,12 +268,80 @@ func TestExtractD2CallsWithNestedBrackets(t *testing.T) {
   }
 ]`
 
-	blocks := extractD2Calls(content)
+	blocks, _ := extractD2Calls(content)
 	if len(blocks) != 1 {
 		t.Fatalf("Expected 1 block, got %d", len(blocks))
 	}
 
 	if !strings.Contains(blocks[0].Code, "shape: person") {
 		t.Errorf("Code doesn't contain expected content: %q", blocks[0].Code)
+	}
+}
+
+// A d2 call the scanner recognises but cannot extract must fail here,
+// naming the preprocessor. Leaving it in the source meant typst saw D2
+// syntax it was never handed deliberately, and reported a parse error
+// pointing at the wrong construct — the reason this class of bug took
+// twenty minutes to diagnose rather than one line.
+func TestPreprocess_UnextractableCallFailsHere(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.typ")
+	content := "= Title\n\n#d2(layout: \"elk\")[\n  a -> b\n\nTrailing prose.\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Preprocess(context.Background(), workspace.LocalFS{}, path)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "preprocessor:") {
+		t.Errorf("error does not name the preprocessor: %q", msg)
+	}
+	// Line 3 is where the #d2 starts; the coordinates let a caller
+	// jump straight to it the way a typst error would.
+	if !strings.Contains(msg, ":3:1:") {
+		t.Errorf("error lacks line:col coordinates for the call site: %q", msg)
+	}
+}
+
+// The counterpart: a document with no d2 blocks at all must pass
+// through untouched rather than trip the new guard.
+func TestPreprocess_NoBlocksIsNotAnError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.typ")
+	content := "= Title\n\nProse mentioning #d2 and d2(...) but calling neither.\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Preprocess(context.Background(), workspace.LocalFS{}, path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "Prose mentioning") {
+		t.Errorf("content did not survive: %q", got)
+	}
+}
+
+func TestLineCol(t *testing.T) {
+	src := "one\ntwo\nthree"
+	cases := []struct {
+		offset    int
+		line, col int
+	}{
+		{0, 1, 1},
+		{3, 1, 4},
+		{4, 2, 1},
+		{8, 3, 1},
+		{12, 3, 5},
+		{9999, 3, 6}, // clamped to end
+	}
+	for _, tc := range cases {
+		line, col := lineCol(src, tc.offset)
+		if line != tc.line || col != tc.col {
+			t.Errorf("lineCol(%d) = %d:%d, want %d:%d", tc.offset, line, col, tc.line, tc.col)
+		}
 	}
 }

--- a/internal/preprocessor/scan.go
+++ b/internal/preprocessor/scan.go
@@ -1,6 +1,6 @@
 package preprocessor
 
-// Typst-aware scanner for #d2 call sites.
+// Typst-aware scanner for d2 call sites.
 //
 // The previous regex approach kept hitting the same class of bugs: a
 // `#d2` substring could appear inside a comment, a string, or another
@@ -8,27 +8,57 @@ package preprocessor
 // any regex pattern that ignores those contexts will eventually be
 // surprised by a new edge case. We instead walk the source one byte at
 // a time tracking which lexical context we're in, and only consider
-// `#d2(...)` or `#d2[...]` as a real call when we encounter it in
-// normal markup.
+// `d2(...)` or `d2[...]` as a real call when we encounter it somewhere
+// Typst would actually evaluate it.
 //
-// Lexical contexts we recognise (and ignore #d2 inside):
+// Two languages, two lexers
+// ------------------------
+// The important distinction — and the source of two production bugs —
+// is that a `#d2` call's *argument* is D2 source, not Typst markup.
+// D2 has no `//` line comments and no `/* */` block comments; it uses
+// `#` for comments instead. Applying Typst's comment rules while
+// walking D2 code meant a perfectly ordinary label containing a glob
 //
-//   - // line comments              (until newline)
-//   - /* block comments */          (no nesting; matches Typst)
-//   - "..." double-quoted strings   (with \ escapes)
-//   - `...` short raw               (terminated by next ` )
+//     a: vault/*.md
+//
+// opened a "block comment" that ran to EOF, swallowing the closing `]`
+// and everything after it. What the user saw was `unclosed delimiter`
+// from typst, pointing at a bracket that was in fact balanced. So:
+// Typst contexts use Typst's rules (scanRegion, skipBalancedParens),
+// and the D2 body uses D2's (skipD2Brackets).
+//
+// Markup mode and code mode
+// -------------------------
+// We also track Typst's two syntactic modes, because the natural way
+// to caption a diagram puts the call in code mode, without the hash:
+//
+//     #figure(d2(...)[...], caption: [A diagram])
+//
+// Matching only the literal `#d2` left that block in the source for
+// typst to choke on (`unknown variable: d2`, or stranger things once
+// hex colours in the D2 body started being evaluated as numbers).
+// scanRegion therefore recurses: `(` after a `#name` opens code mode,
+// `[` inside code mode opens markup mode again, and `d2` is a call in
+// either. Blocks found in code mode are flagged CodeContext so the
+// replacement omits the leading `#`, which is not valid there.
+//
+// Lexical contexts we recognise (and ignore d2 inside):
+//
+//   - // line comments              (until newline)      [Typst only]
+//   - /* block comments */          (no nesting)         [Typst only]
+//   - "..." double-quoted strings   (with \ escapes)     [both]
+//   - `...` short raw               (terminated by next `)
 //   - ```...``` raw block           (triple backticks)
-//
-// Inside the argument of a recognised #d2 call we apply the same
-// context-tracking to count balanced ( ) or [ ] — so D2 code that
-// happens to contain a closing bracket inside a quoted label, or a
-// nested function call, is captured correctly instead of cutting the
-// match short or running on past it.
+//   - # line comments               (until newline)      [D2 only]
 //
 // What we deliberately don't do:
-//   - Parse Typst expressions, scopes, or `code-mode` semantics.
-//   - Distinguish markup mode from code mode (no need; markup-mode
-//     `#d2` is the only call shape LLMs emit in practice).
+//   - Parse Typst expressions or scopes beyond the mode switching
+//     described above.
+//   - Treat `'` as a string delimiter inside D2 code. D2 accepts
+//     single-quoted strings, but an apostrophe in an ordinary label
+//     ("don't") is far more common than one, and treating it as a
+//     delimiter would resurrect exactly the swallowed-bracket bug
+//     this scanner exists to prevent.
 //   - Support 4+ backtick raw fences (Typst allows them; LLMs rarely
 //     produce them, and adding the open-count tracking is easy to add
 //     later if it ever matters).
@@ -39,17 +69,54 @@ import (
 	"github.com/dlouwers/typst-d2-mcp/internal/d2"
 )
 
-type scanner struct {
-	src string
-	i   int
+// Typst's two syntactic modes. The mode decides what a bare `d2`
+// means and which delimiters open a nested region.
+const (
+	modeMarkup = iota
+	modeCode
+)
+
+// maxScanDepth bounds scanRegion's recursion. Real documents nest a
+// handful of levels; anything past this is pathological input, and we
+// would rather stop descending than grow the stack without limit.
+const maxScanDepth = 256
+
+// SkipSite records a position where the scanner saw something that
+// unambiguously looked like a d2 call — the name immediately followed
+// by `(` or `[` — but could not extract it.
+//
+// Without this the scanner had no way to say "I recognised this and
+// failed": it just declined, left the block in the source, and the
+// failure surfaced several layers later as a Typst syntax error
+// naming the wrong construct. Callers turn a non-empty slice into an
+// error that names the preprocessor.
+type SkipSite struct {
+	Offset int
+	Reason string
 }
 
-// scanD2Calls returns every #d2 call site in src as a D2Block, in
-// source-order. Each block's Start / End span the full call (from `#`
-// through the final `)` or `]`); Code is the extracted D2 source.
-func scanD2Calls(src string) []D2Block {
+type scanner struct {
+	src     string
+	i       int
+	blocks  []D2Block
+	skipped []SkipSite
+}
+
+// scanD2Calls returns every d2 call site in src as a D2Block, in
+// source-order. Each block's Start / End span the full call (from the
+// `#` or the `d`, through the final `)` or `]`); Code is the extracted
+// D2 source. The second return value lists call sites that looked real
+// but could not be extracted — see SkipSite.
+func scanD2Calls(src string) ([]D2Block, []SkipSite) {
 	s := &scanner{src: src}
-	var out []D2Block
+	s.scanRegion(modeMarkup, 0, 0)
+	return s.blocks, s.skipped
+}
+
+// scanRegion walks src from the current position collecting d2 call
+// sites, until EOF or — when stop is non-zero — the matching close
+// delimiter, which it consumes before returning.
+func (s *scanner) scanRegion(mode int, stop byte, depth int) {
 	for s.i < len(s.src) {
 		switch {
 		case s.peek("//"):
@@ -62,25 +129,117 @@ func scanD2Calls(src string) []D2Block {
 			s.skipRawBlock()
 		case s.cur() == '`':
 			s.skipShortRaw()
-		case s.peek("#d2"):
-			if block, ok := s.tryD2(); ok {
-				out = append(out, block)
-			}
-			// tryD2 always advances at least past the `#d2` substring
-			// (whether it matched a real call or not), so we make
-			// monotonic progress.
+
+		case stop != 0 && s.cur() == stop:
+			s.i++
+			return
+
+		// A `#` in markup opens code. `#d2(` / `#d2[` is the call we
+		// want; any other `#name(` opens an argument list whose
+		// contents are code, and a d2 call can be nested in there.
+		case mode == modeMarkup && s.cur() == '#':
+			s.markupHash(depth)
+
+		// In code mode a bare `d2` is the call. Anything else that
+		// starts an identifier is consumed whole so that a name
+		// merely *containing* d2 — or a field access like `a.d2` —
+		// is not mistaken for one.
+		case mode == modeCode && s.atIdentStart():
+			s.codeIdent()
+
+		// `#d2` in code mode is a mistake — typst rejects a second
+		// hash there ("the character `#` is not valid in code"). It is
+		// an easy one to make, since every example writes the call
+		// with a hash, so accept it and drop the hash on replacement
+		// rather than passing a document through that cannot compile.
+		case mode == modeCode && s.peek("#d2") && !isIdentChar(s.at(s.i+3)):
+			s.tryD2(s.i, s.i+3, true)
+
+		// Nested regions. `[` is always markup; `(` in code mode is
+		// more code. (`(` in markup mode is ordinary text.)
+		case s.cur() == '[' && depth < maxScanDepth:
+			s.i++
+			s.scanRegion(modeMarkup, ']', depth+1)
+		case mode == modeCode && s.cur() == '(' && depth < maxScanDepth:
+			s.i++
+			s.scanRegion(modeCode, ')', depth+1)
+
 		default:
 			s.i++
 		}
 	}
-	return out
+}
+
+// markupHash handles a `#` in markup mode. It always advances at
+// least one byte, so the caller makes progress.
+func (s *scanner) markupHash(depth int) {
+	hash := s.i
+	j := s.i + 1
+	for j < len(s.src) && isIdentChar(s.src[j]) {
+		j++
+	}
+	name := s.src[hash+1 : j]
+
+	switch name {
+	case "d2":
+		s.tryD2(hash, j, false)
+	case "":
+		// `#(`, `#[`, an escaped `#`, or a stray one in prose.
+		s.i++
+	default:
+		s.i = j
+		if s.cur() == '(' && depth < maxScanDepth {
+			s.i++
+			s.scanRegion(modeCode, ')', depth+1)
+		}
+	}
+}
+
+// codeIdent handles an identifier in code mode, which is a d2 call
+// only when the name is exactly `d2` and a `(` or `[` follows.
+func (s *scanner) codeIdent() {
+	start := s.i
+	j := s.i
+	for j < len(s.src) && isIdentChar(s.src[j]) {
+		j++
+	}
+	if s.src[start:j] == "d2" {
+		s.tryD2(start, j, true)
+		return
+	}
+	s.i = j
+}
+
+// atIdentStart reports whether the current byte begins an identifier
+// rather than continuing one. The `.` check keeps a field access —
+// `shape.d2(...)` — from reading as a call to `d2`.
+func (s *scanner) atIdentStart() bool {
+	if !isIdentChar(s.cur()) {
+		return false
+	}
+	if s.i == 0 {
+		return true
+	}
+	prev := s.src[s.i-1]
+	return !isIdentChar(prev) && prev != '.'
+}
+
+func isIdentChar(c byte) bool {
+	return c == '_' || c == '-' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
 }
 
 func (s *scanner) cur() byte {
-	if s.i >= len(s.src) {
+	return s.at(s.i)
+}
+
+func (s *scanner) at(i int) byte {
+	if i < 0 || i >= len(s.src) {
 		return 0
 	}
-	return s.src[s.i]
+	return s.src[i]
 }
 
 func (s *scanner) peek(prefix string) bool {
@@ -89,6 +248,10 @@ func (s *scanner) peek(prefix string) bool {
 
 func (s *scanner) skipLineComment() {
 	s.i += 2 // past //
+	s.skipToEOL()
+}
+
+func (s *scanner) skipToEOL() {
 	for s.i < len(s.src) && s.src[s.i] != '\n' {
 		s.i++
 	}
@@ -144,71 +307,90 @@ func (s *scanner) skipRawBlock() {
 	}
 }
 
-// tryD2 attempts to match a #d2 call starting at the current `#`
-// position. On success returns the parsed block and leaves s.i past
-// the end. On failure returns false and leaves s.i three past the `#`
-// (i.e. past the `#d2` substring) so the outer loop makes progress.
-func (s *scanner) tryD2() (D2Block, bool) {
-	start := s.i
-	s.i += 3 // past #d2
+// tryD2 attempts to match a d2 call whose name spans [start, afterName)
+// — `#d2` in markup, or `d2` in code. On success it appends a block and
+// leaves s.i past the end. On failure it leaves s.i at afterName so the
+// caller makes progress, and records a SkipSite when the text looked
+// like a call it should have handled.
+func (s *scanner) tryD2(start, afterName int, codeContext bool) {
+	s.i = afterName
 
 	switch s.cur() {
 	case '(':
 		// Two sub-shapes inside parens:
-		//   #d2(```code```)              — raw-block-only args, no opts
-		//   #d2(opts)[code]              — opts then a content block
+		//   d2(```code```)              — raw-block-only args, no opts
+		//   d2(opts)[code]              — opts then a content block
 		argsOpen := s.i + 1
 		if !s.skipBalancedParens() {
-			return D2Block{}, false
+			s.skip(start, "unbalanced parentheses in the option list")
+			return
 		}
 		args := s.src[argsOpen : s.i-1]
 
 		if rawCode, ok := extractSingleRawBlock(args); ok {
-			return D2Block{
-				Start:   start,
-				End:     s.i,
-				Options: d2.Options{},
-				Code:    rawCode,
-			}, true
+			s.emit(D2Block{
+				Start:       start,
+				End:         s.i,
+				Options:     d2.Options{},
+				Code:        rawCode,
+				CodeContext: codeContext,
+			})
+			return
 		}
 
 		// Treat the args as options; require a content block to follow.
 		if s.cur() != '[' {
-			return D2Block{}, false
+			s.skip(start, "options are not followed by a [ ... ] diagram block")
+			return
 		}
 		codeOpen := s.i + 1
-		if !s.skipBalancedBrackets() {
-			return D2Block{}, false
+		if !s.skipD2Brackets() {
+			s.skip(start, "unbalanced brackets in the diagram block")
+			return
 		}
-		return D2Block{
-			Start:   start,
-			End:     s.i,
-			Options: parseOptions(args),
-			Code:    s.src[codeOpen : s.i-1],
-		}, true
+		s.emit(D2Block{
+			Start:       start,
+			End:         s.i,
+			Options:     parseOptions(args),
+			Code:        s.src[codeOpen : s.i-1],
+			CodeContext: codeContext,
+		})
 
 	case '[':
-		// #d2[code] — bracket-only form.
+		// d2[code] — bracket-only form.
 		codeOpen := s.i + 1
-		if !s.skipBalancedBrackets() {
-			return D2Block{}, false
+		if !s.skipD2Brackets() {
+			s.skip(start, "unbalanced brackets in the diagram block")
+			return
 		}
-		return D2Block{
-			Start:   start,
-			End:     s.i,
-			Options: d2.Options{},
-			Code:    s.src[codeOpen : s.i-1],
-		}, true
+		s.emit(D2Block{
+			Start:       start,
+			End:         s.i,
+			Options:     d2.Options{},
+			Code:        s.src[codeOpen : s.i-1],
+			CodeContext: codeContext,
+		})
 
 	default:
-		// Not a #d2 call (could be #d2foo, or #d2 alone in prose).
-		return D2Block{}, false
+		// Not a call at all: `#d2` alone in prose, or a variable that
+		// happens to be named d2. Nothing to report.
 	}
+}
+
+func (s *scanner) emit(b D2Block) {
+	s.blocks = append(s.blocks, b)
+}
+
+func (s *scanner) skip(offset int, reason string) {
+	s.skipped = append(s.skipped, SkipSite{Offset: offset, Reason: reason})
 }
 
 // skipBalancedParens consumes a `(...)` starting at the current `(`,
 // counting nested parens and treating strings/raws/comments inside as
 // opaque. Returns true on a clean close, false if EOF is hit first.
+//
+// This walks Typst code (a d2 option list), so Typst's comment rules
+// apply here — unlike skipD2Brackets below.
 func (s *scanner) skipBalancedParens() bool {
 	if s.cur() != '(' {
 		return false
@@ -243,45 +425,60 @@ func (s *scanner) skipBalancedParens() bool {
 	return false
 }
 
-// skipBalancedBrackets is skipBalancedParens for `[...]`. Same shape,
-// different delimiters — kept as separate methods rather than param-
-// eterised so each one's hot path is a tight set of byte comparisons.
-func (s *scanner) skipBalancedBrackets() bool {
+// skipD2Brackets consumes a `[...]` whose contents are D2 source
+// rather than Typst markup, counting nested brackets to find the
+// close. Returns true on a clean close, false if EOF is hit first.
+//
+// D2's lexer is not Typst's, and the difference is not cosmetic:
+//
+//   - `/*` and `//` are ordinary characters. A glob in a label
+//     (`a: vault/*.md`) or a bare URL (`a: https://example.com`) must
+//     not open a comment — treating them as one swallowed the closing
+//     bracket and produced a bogus "unclosed delimiter" from typst.
+//   - `#` starts a line comment, but only as the first non-blank
+//     character of a line. Mid-line it is ordinary text (`a: C#`), and
+//     a hex colour lives inside a string ("#5e5e5e") which is skipped
+//     as a string before the `#` is ever considered.
+func (s *scanner) skipD2Brackets() bool {
 	if s.cur() != '[' {
 		return false
 	}
 	s.i++
 	depth := 1
+	lineBlank := true // nothing but whitespace seen on this line yet
 	for s.i < len(s.src) {
-		switch {
-		case s.peek("//"):
-			s.skipLineComment()
-		case s.peek("/*"):
-			s.skipBlockComment()
-		case s.cur() == '"':
+		switch c := s.cur(); {
+		case c == '"':
 			s.skipString()
-		case s.peek("```"):
-			s.skipRawBlock()
-		case s.cur() == '`':
-			s.skipShortRaw()
-		case s.cur() == '[':
+			lineBlank = false
+		case c == '#' && lineBlank:
+			s.skipToEOL()
+		case c == '\n':
+			s.i++
+			lineBlank = true
+		case c == ' ' || c == '\t' || c == '\r':
+			s.i++
+		case c == '[':
 			depth++
 			s.i++
-		case s.cur() == ']':
+			lineBlank = false
+		case c == ']':
 			depth--
 			s.i++
 			if depth == 0 {
 				return true
 			}
+			lineBlank = false
 		default:
 			s.i++
+			lineBlank = false
 		}
 	}
 	return false
 }
 
 // extractSingleRawBlock decides whether args (the text between the
-// parens of a #d2(...) call) is, ignoring surrounding whitespace, a
+// parens of a d2(...) call) is, ignoring surrounding whitespace, a
 // single ```...``` raw block. If so it returns the block's body with
 // the optional language tag (e.g. ```d2) and one leading/trailing
 // newline stripped. Otherwise it returns false, signalling "treat

--- a/internal/preprocessor/scan_test.go
+++ b/internal/preprocessor/scan_test.go
@@ -152,6 +152,102 @@ Tail #text[footnote].`,
 			wantCodes: []string{"real"},
 		},
 
+		// --- D2 code is not Typst: no // or /* comments ---
+		// Each of these used to open a "comment" that ran past the
+		// closing bracket, so the block was never extracted and typst
+		// reported `unclosed delimiter` on a balanced bracket.
+
+		{
+			name:      "glob in a label is not a block comment",
+			src:       "#d2(layout: \"elk\")[\n  a: vault/*.md\n  a -> b\n]\n\nAfter.",
+			wantCount: 1,
+			wantCodes: []string{"\n  a: vault/*.md\n  a -> b\n"},
+		},
+		{
+			name:      "two globs do not pair into a comment",
+			src:       "#d2[\n  a: src/*.go\n  b: logs/*.json\n  a -> b\n]",
+			wantCount: 1,
+			wantCodes: []string{"\n  a: src/*.go\n  b: logs/*.json\n  a -> b\n"},
+		},
+		{
+			// Same line as the closing bracket, which is where the
+			// `//` bug actually bites: skipping to end-of-line ate
+			// the `]` too.
+			name:      "bare URL on the same line as the close bracket",
+			src:       "#d2[a: https://example.com]",
+			wantCount: 1,
+			wantCodes: []string{"a: https://example.com"},
+		},
+		{
+			name:      "bare URL in a label is not a line comment",
+			src:       "#d2[\n  a: https://example.com\n  a -> b\n]",
+			wantCount: 1,
+			wantCodes: []string{"\n  a: https://example.com\n  a -> b\n"},
+		},
+		{
+			name:      "hex colours in D2 code are opaque",
+			src:       "#d2[\n  x.style.stroke: \"#5e5e5e\"\n  x.style.fill: \"#006566\"\n]",
+			wantCount: 1,
+			wantCodes: []string{"\n  x.style.stroke: \"#5e5e5e\"\n  x.style.fill: \"#006566\"\n"},
+		},
+		{
+			// D2's own comment syntax. A `]` inside one must not close
+			// the block early.
+			name:      "D2 line comment does not affect bracket depth",
+			src:       "#d2[\n  # a stray ] in a comment\n  a -> b\n]",
+			wantCount: 1,
+			wantCodes: []string{"\n  # a stray ] in a comment\n  a -> b\n"},
+		},
+		{
+			// Only at the start of a line. Mid-line `#` is ordinary
+			// text in a label and must not eat the rest of the line.
+			name:      "mid-line hash is not a D2 comment",
+			src:       "#d2[\n  lang: C#\n  lang -> b\n]",
+			wantCount: 1,
+			wantCodes: []string{"\n  lang: C#\n  lang -> b\n"},
+		},
+
+		// --- code context: a diagram inside another call ---
+
+		{
+			name:      "figure with a bare d2 call",
+			src:       "#figure(\n  d2(layout: \"elk\")[\n    a -> b\n  ],\n  caption: [A diagram.],\n)",
+			wantCount: 1,
+			wantCodes: []string{"\n    a -> b\n  "},
+		},
+		{
+			name:      "figure with the wrapped markup form still works",
+			src:       "#figure([#d2(layout: \"elk\")[a -> b]], caption: [A diagram.])",
+			wantCount: 1,
+			wantCodes: []string{"a -> b"},
+		},
+		{
+			name:      "d2 in a figure caption",
+			src:       "#figure(rect(), caption: [see #d2[a -> b] here])",
+			wantCount: 1,
+			wantCodes: []string{"a -> b"},
+		},
+		{
+			name:      "identifier merely containing d2 is not a call",
+			src:       "#figure(myd2(x), caption: [none])\n#d2[real]",
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+		{
+			name:      "field access .d2 is not a call",
+			src:       "#figure(shape.d2(x), caption: [none])\n#d2[real]",
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+		{
+			// Bare d2( in markup is literal text, not a call — only
+			// code context promotes it.
+			name:      "bare d2( in prose is not a call",
+			src:       "The d2(...) helper is described below.\n\n#d2[real]",
+			wantCount: 1,
+			wantCodes: []string{"real"},
+		},
+
 		// --- non-#d2 things starting with #d2 ---
 
 		{
@@ -170,7 +266,14 @@ Tail #text[footnote].`,
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			blocks := scanD2Calls(tc.src)
+			blocks, skipped := scanD2Calls(tc.src)
+			// None of these are malformed, so none may be reported as
+			// a call the scanner recognised and failed to extract.
+			// Guards against a "fix" that trades a silent skip for a
+			// spurious hard error.
+			if len(skipped) != 0 {
+				t.Errorf("unexpected skipped call sites: %+v", skipped)
+			}
 			if len(blocks) != tc.wantCount {
 				t.Fatalf("count=%d, want=%d (got %+v)", len(blocks), tc.wantCount, blocks)
 			}
@@ -182,11 +285,16 @@ Tail #text[footnote].`,
 					t.Errorf("blocks[%d].Code = %q, want %q", i, b.Code, tc.wantCodes[i])
 				}
 				// And the captured span MUST round-trip — i.e. the
-				// substring at [Start:End] starts with #d2 and ends
-				// with ) or ].
+				// substring at [Start:End] starts with the call name
+				// and ends with ) or ]. A call found in code context
+				// has no hash: #figure(d2(...)[...]) spans from the d.
 				span := tc.src[b.Start:b.End]
-				if !strings.HasPrefix(span, "#d2") {
-					t.Errorf("blocks[%d] span doesn't start with #d2: %q", i, span)
+				wantPrefix := "#d2"
+				if b.CodeContext {
+					wantPrefix = "d2"
+				}
+				if !strings.HasPrefix(span, wantPrefix) {
+					t.Errorf("blocks[%d] span doesn't start with %s: %q", i, wantPrefix, span)
 				}
 				last := span[len(span)-1]
 				if last != ')' && last != ']' {
@@ -203,7 +311,7 @@ Tail #text[footnote].`,
 // in production — verify it directly.
 func TestScanD2Calls_ReplacementRoundTrip(t *testing.T) {
 	src := "intro #d2[A -> B] mid1 #d2(```\nC -> D\n```) mid2 #d2(layout: \"elk\")[E -> F] tail"
-	blocks := scanD2Calls(src)
+	blocks, _ := scanD2Calls(src)
 	if len(blocks) != 3 {
 		t.Fatalf("expected 3 blocks, got %d", len(blocks))
 	}
@@ -218,5 +326,109 @@ func TestScanD2Calls_ReplacementRoundTrip(t *testing.T) {
 	want := "intro <X> mid1 <X> mid2 <X> tail"
 	if out != want {
 		t.Errorf("reverse replace produced %q, want %q", out, want)
+	}
+}
+
+// The scanner must flag a call site it recognised but could not
+// extract. Before this existed the block was left in the source and
+// typst reported the failure several layers later, naming the wrong
+// construct — usually "unclosed delimiter" on a balanced bracket.
+func TestScanD2Calls_SkippedSites(t *testing.T) {
+	cases := []struct {
+		name      string
+		src       string
+		wantSkips int
+	}{
+		{
+			name:      "unterminated diagram block",
+			src:       "#d2[\n  a -> b\n",
+			wantSkips: 1,
+		},
+		{
+			name:      "unterminated option list",
+			src:       "#d2(layout: \"elk\"\n",
+			wantSkips: 1,
+		},
+		{
+			name:      "options with no diagram block",
+			src:       "#d2(layout: \"elk\")\n\nProse.",
+			wantSkips: 1,
+		},
+		{
+			name:      "code-context call that cannot be extracted",
+			src:       "#figure(d2(layout: \"elk\")[\n  a -> b\n, caption: [x])",
+			wantSkips: 1,
+		},
+		{
+			// Not a call, so not a failure to extract — mentioning
+			// #d2 in prose must stay silent.
+			name:      "bare #d2 in prose is not a skipped call",
+			src:       "Write your diagram with #d2 and compile.",
+			wantSkips: 0,
+		},
+		{
+			// A malformed call inside a comment is still a comment.
+			name:      "malformed call inside a Typst comment",
+			src:       "// #d2[ never closed\n\nProse.",
+			wantSkips: 0,
+		},
+		{
+			name:      "malformed call inside a raw block",
+			src:       "```\n#d2[ never closed\n```\n\nProse.",
+			wantSkips: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, skipped := scanD2Calls(tc.src)
+			if len(skipped) != tc.wantSkips {
+				t.Fatalf("skipped=%d, want %d (got %+v)", len(skipped), tc.wantSkips, skipped)
+			}
+			for _, sk := range skipped {
+				if sk.Reason == "" {
+					t.Errorf("skip site at %d has no reason", sk.Offset)
+				}
+				if sk.Offset < 0 || sk.Offset >= len(tc.src) {
+					t.Errorf("skip site offset %d out of range for %d-byte source", sk.Offset, len(tc.src))
+				}
+			}
+		})
+	}
+}
+
+// A call written in code context (inside another call's argument list)
+// must be flagged, because its replacement may not carry a leading `#`.
+func TestScanD2Calls_CodeContextFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"markup form", "#d2[a -> b]", false},
+		{"markup form inside a content block", "#figure([#d2[a -> b]], caption: [c])", false},
+		{"code form inside figure", "#figure(d2[a -> b], caption: [c])", true},
+		{"code form with options", "#figure(d2(layout: \"elk\")[a -> b], caption: [c])", true},
+		{"code form with a raw body", "#figure(d2(```\na -> b\n```), caption: [c])", true},
+		{"markup form in a caption is still markup", "#figure(rect(), caption: [#d2[a -> b]])", false},
+		// A stray hash inside an argument list. Typst would reject it;
+		// we accept it and drop the hash rather than emit a document
+		// that cannot compile.
+		{"stray hash in code context", "#figure(#d2[a -> b], caption: [c])", true},
+		{"stray hash with options", "#figure(#d2(layout: \"elk\")[a -> b], caption: [c])", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks, skipped := scanD2Calls(tc.src)
+			if len(skipped) != 0 {
+				t.Fatalf("unexpected skips: %+v", skipped)
+			}
+			if len(blocks) != 1 {
+				t.Fatalf("blocks=%d, want 1", len(blocks))
+			}
+			if blocks[0].CodeContext != tc.want {
+				t.Errorf("CodeContext=%v, want %v", blocks[0].CodeContext, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Three reported defects and one found on the way, all downstream of the same decision: the scanner applied Typst's lexical rules to everything, including the D2 source inside a diagram block.

**D2 is not Typst.** It has no `//` or `/* */` comments. A label containing a glob — `a: vault/*.md` — opened a "block comment" that ran to EOF and swallowed the closing bracket, so the block was left in the source and typst reported `unclosed delimiter` on a bracket that was in fact balanced. A bare URL did the same, one line at a time. The D2 body now has its own walker: strings, bracket depth, and D2's own `#` line comments.

**Markup mode and code mode.** Matching only the literal `#d2` meant `#figure(d2(...)[...], caption: [...])` never preprocessed, failing as `unknown variable: d2`. `scanRegion` now tracks both Typst modes and recurses between them. A call found in code context is flagged so its replacement omits the leading `#`, which typst rejects there; a stray `#d2` inside an argument list is accepted and the hash dropped rather than emitting a document that cannot compile.

**A third bug, found while checking that rule.** The `pad` option nested a hash unconditionally, so `#d2(pad: 4pt)[...]` had always emitted `#pad(4pt, #image(...))` — `error: the character `#` is not valid in code`. The expression is now built hashless and gets exactly one, outermost, in markup. This was never reported; the option simply never worked.

**Failing loudly.** The scanner had no way to say "I recognised this and could not extract it" — it declined, and the failure surfaced several layers later naming the wrong construct. Unextractable call sites are now recorded and `Preprocess` fails on them with the preprocessor named and `line:col` coordinates.

Docs: `MCP_GUIDE.md` gains a captioned-diagram section, and the server instructions gain a captioned example.

Refers #89