### PR TITLE
fix(compile): stage the source in the workspace so assets resolve

### DIFF
--- a/cmd/typst-d2-mcp/compileassets_test.go
+++ b/cmd/typst-d2-mcp/compileassets_test.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// compile invokes the compile_typst_with_d2 handler and returns the raw
+// result for inspection.
+func compile(t *testing.T, ctx context.Context, factory workspace.Factory, path string) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "compile_typst_with_d2"
+	req.Params.Arguments = map[string]any{"file_path": path}
+	res, err := handleCompileTypst(factory, nil)(ctx, req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	return res
+}
+
+func resultText(res *mcp.CallToolResult) string {
+	var b strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+// A tiny standalone SVG — enough for typst to embed without pulling in
+// anything external.
+const testSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">` +
+	`<rect width="20" height="20" fill="#006566"/></svg>`
+
+const testPNG = "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89" +
+	"\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+
+// The bug in #91: a file pushed with put_file could not be referenced
+// from the document compiled against it, because the source was staged
+// in /tmp and every relative path resolved from there.
+func TestCompile_WorkspaceAssetIsReferenceable(t *testing.T) {
+	requireTypst(t)
+
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	if res := putFile(t, ctx, factory, "asset.svg", testSVG); res.IsError {
+		t.Fatalf("put_file svg: %s", resultText(res))
+	}
+	if res := putFile(t, ctx, factory, "doc.typ",
+		"= Title\n\n#image(\"asset.svg\", width: 20mm)\n"); res.IsError {
+		t.Fatalf("put_file typ: %s", resultText(res))
+	}
+
+	res := compile(t, ctx, factory, "doc.typ")
+	if res.IsError {
+		t.Fatalf("compile failed: %s", resultText(res))
+	}
+	assertPDF(t, filepath.Join(root, "user123", "doc.pdf"))
+}
+
+// Same for a raster asset, which travels through put_file as base64.
+func TestCompile_WorkspaceRasterAssetIsReferenceable(t *testing.T) {
+	requireTypst(t)
+
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "put_file"
+	req.Params.Arguments = map[string]any{
+		"path":     "dot.png",
+		"content":  base64.StdEncoding.EncodeToString([]byte(testPNG)),
+		"encoding": "base64",
+	}
+	res, err := handlePutFile(factory, nil)(ctx, req)
+	if err != nil {
+		t.Fatalf("put_file handler: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("put_file png: %s", resultText(res))
+	}
+
+	if res := putFile(t, ctx, factory, "doc.typ",
+		"#image(\"dot.png\", width: 5mm)\n"); res.IsError {
+		t.Fatalf("put_file typ: %s", resultText(res))
+	}
+
+	if res := compile(t, ctx, factory, "doc.typ"); res.IsError {
+		t.Fatalf("compile failed: %s", resultText(res))
+	}
+	assertPDF(t, filepath.Join(root, "user123", "doc.pdf"))
+}
+
+// A relative #import of another workspace file must resolve too — the
+// same defect, one construct over.
+func TestCompile_WorkspaceImportResolves(t *testing.T) {
+	requireTypst(t)
+
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	if res := putFile(t, ctx, factory, "style.typ",
+		"#let accent = rgb(\"#006566\")\n"); res.IsError {
+		t.Fatalf("put_file style: %s", resultText(res))
+	}
+	if res := putFile(t, ctx, factory, "doc.typ",
+		"#import \"style.typ\": accent\n#text(fill: accent)[Coloured.]\n"); res.IsError {
+		t.Fatalf("put_file doc: %s", resultText(res))
+	}
+
+	if res := compile(t, ctx, factory, "doc.typ"); res.IsError {
+		t.Fatalf("compile failed: %s", resultText(res))
+	}
+	assertPDF(t, filepath.Join(root, "user123", "doc.pdf"))
+}
+
+// An asset in a subdirectory, referenced both relatively and from the
+// workspace root. The root form only works because compile passes
+// --root for a bounded workspace.
+func TestCompile_AssetInSubdirectory(t *testing.T) {
+	requireTypst(t)
+
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	if res := putFile(t, ctx, factory, "assets/logo.svg", testSVG); res.IsError {
+		t.Fatalf("put_file asset: %s", resultText(res))
+	}
+	if res := putFile(t, ctx, factory, "docs/doc.typ",
+		"#image(\"../assets/logo.svg\", width: 10mm)\n"+
+			"#image(\"/assets/logo.svg\", width: 10mm)\n"); res.IsError {
+		t.Fatalf("put_file doc: %s", resultText(res))
+	}
+
+	if res := compile(t, ctx, factory, "docs/doc.typ"); res.IsError {
+		t.Fatalf("compile failed: %s", resultText(res))
+	}
+	assertPDF(t, filepath.Join(root, "user123", "docs", "doc.pdf"))
+}
+
+// Moving the compile root into the workspace must not open a way out of
+// it. typst is given --root at the tenant directory, so a document that
+// reaches above it is refused by typst itself.
+func TestCompile_CannotReadOutsideWorkspace(t *testing.T) {
+	requireTypst(t)
+
+	root := t.TempDir()
+	secret := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(secret, []byte("not yours"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	if res := putFile(t, ctx, factory, "doc.typ",
+		"#read(\"../secret.txt\")\n"); res.IsError {
+		t.Fatalf("put_file doc: %s", resultText(res))
+	}
+
+	res := compile(t, ctx, factory, "doc.typ")
+	if !res.IsError {
+		t.Fatal("expected the compile to fail; a document escaped its workspace")
+	}
+	if got := resultText(res); strings.Contains(got, "not yours") {
+		t.Errorf("secret contents leaked into the error: %s", got)
+	}
+}
+
+// One tenant's document must not see another tenant's files, by any
+// spelling of the path.
+func TestCompile_CannotReadAnotherTenant(t *testing.T) {
+	requireTypst(t)
+
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+
+	otherCtx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "other"})
+	if res := putFile(t, otherCtx, factory, "private.txt", "other tenant data"); res.IsError {
+		t.Fatalf("put_file other: %s", resultText(res))
+	}
+
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+	for _, ref := range []string{"../other/private.txt", "/../other/private.txt"} {
+		if res := putFile(t, ctx, factory, "doc.typ",
+			"#read(\""+ref+"\")\n"); res.IsError {
+			t.Fatalf("put_file doc: %s", resultText(res))
+		}
+		res := compile(t, ctx, factory, "doc.typ")
+		if !res.IsError {
+			t.Fatalf("%s: expected failure; one tenant read another's file", ref)
+		}
+		if got := resultText(res); strings.Contains(got, "other tenant data") {
+			t.Errorf("%s: another tenant's contents leaked: %s", ref, got)
+		}
+	}
+}
+
+// put_file itself still rejects traversal in the destination path; the
+// staging change must not have loosened it.
+func TestPutFile_TraversalStillRejected(t *testing.T) {
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	for _, p := range []string{"../escape.txt", "../../etc/passwd", "/etc/passwd"} {
+		if res := putFile(t, ctx, factory, p, "x"); !res.IsError {
+			t.Errorf("put_file %q was accepted", p)
+		}
+	}
+}
+
+// Preprocessing must still happen — the staging move is about where the
+// file lands, not what is in it.
+func TestCompile_D2StillPreprocessed(t *testing.T) {
+	requireTypst(t)
+	if _, err := exec.LookPath("d2"); err != nil {
+		t.Skip("d2 not installed")
+	}
+
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	if res := putFile(t, ctx, factory, "doc.typ",
+		"= Diagram\n\n#d2(layout: \"elk\", theme: \"0\")[\n  a -> b\n]\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	if res := compile(t, ctx, factory, "doc.typ"); res.IsError {
+		t.Fatalf("compile failed: %s", resultText(res))
+	}
+	assertPDF(t, filepath.Join(root, "user123", "doc.pdf"))
+}
+
+// The staged source is server scratch: it must be gone once the compile
+// returns, and must never have counted towards the tenant's usage.
+func TestCompile_StagedFileIsCleanedUp(t *testing.T) {
+	requireTypst(t)
+
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	if res := putFile(t, ctx, factory, "doc.typ", "= Title\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	if res := compile(t, ctx, factory, "doc.typ"); res.IsError {
+		t.Fatalf("compile failed: %s", resultText(res))
+	}
+
+	entries, err := os.ReadDir(filepath.Join(root, "user123"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), workspace.StagePrefix) {
+			t.Errorf("staged file left behind: %s", e.Name())
+		}
+	}
+}
+
+func requireTypst(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("typst"); err != nil {
+		t.Skip("typst not installed")
+	}
+}
+
+func assertPDF(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("no PDF at %s: %v", path, err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("empty PDF at %s", path)
+	}
+}

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -894,7 +894,14 @@ Quick rules (full strategy in the server's instructions):
   - A central node with 4+ children renders horizontally — use a chain.
 
 After compiling, inspect the PDF if you can; if a diagram looks cramped,
-split it, simplify it, or switch to 'direction: down'.`),
+split it, simplify it, or switch to 'direction: down'.
+
+A relative path in the document — #image("logo.svg"), #read("data.csv"),
+#import "style.typ" — resolves against the directory of the .typ file
+being compiled, so an asset pushed with put_file next to the document is
+referenced by its plain name. In scoped/hosted mode a leading slash
+addresses the workspace root ("/assets/logo.svg"), and typst cannot read
+outside the workspace.`),
 		mcp.WithString("file_path",
 			mcp.Required(),
 			mcp.Description("Path to the Typst source file (.typ) containing #d2[...] blocks. Absolute in local stdio mode; workspace-relative in scoped/hosted mode."),
@@ -917,8 +924,12 @@ may also have a cumulative byte budget — call workspace_info to check the
 limit and remaining space before a large push.
 
 Paths are workspace-relative in scoped/hosted mode (traversal rejected),
-any path in local mode. See the server instructions for the full file /
-upload guide.`,
+any path in local mode.
+
+A file pushed here IS referenceable from a document you then compile:
+put an asset beside the .typ that uses it and name it relatively —
+put_file "logo.svg" then #image("logo.svg"). See the server instructions
+for the full file / upload guide.`,
 			inputLimit, humanBytes(inputLimit))),
 		mcp.WithString("path",
 			mcp.Required(),
@@ -1048,7 +1059,19 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 			return mcp.NewToolResultErrorFromErr("Preprocessing failed", err), nil
 		}
 
-		tmpFile, err := os.CreateTemp("", "typst-d2-*.typ")
+		// Stage the preprocessed source NEXT TO the input rather than in
+		// /tmp. typst resolves a document's relative paths against the
+		// directory of the file it is handed, so staging in /tmp made
+		// every asset pushed with put_file unreachable: put_file
+		// reported success, and the failure surfaced later as
+		// "file not found (searched at /tmp/logo.svg)", which reads
+		// like a document bug rather than a server one.
+		//
+		// The staged file is removed on the way out, and the workspace
+		// sweeper would collect it anyway if a crash left one behind.
+		// workspace.DirBytes skips the prefix so a compile in flight
+		// does not inflate reported usage or eat into a byte budget.
+		tmpFile, err := os.CreateTemp(filepath.Dir(resolvedIn), workspace.StagePrefix+"*.typ")
 		if err != nil {
 			return mcp.NewToolResultErrorFromErr("Failed to create temp file", err), nil
 		}
@@ -1074,7 +1097,7 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		// reported as a clean compile. We surface warnings to the
 		// caller so the LLM/operator can act on them.
 		var stdoutBuf, stderrBuf bytes.Buffer
-		cmd := exec.CommandContext(ctx, "typst", "compile", tmpFile.Name(), resolvedOut)
+		cmd := exec.CommandContext(ctx, "typst", typstArgs(resolver, tmpFile.Name(), resolvedOut)...)
 		cmd.Stdout = &stdoutBuf
 		cmd.Stderr = &stderrBuf
 		err = cmd.Run()
@@ -1166,6 +1189,22 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 // factory, and streams the PDF bytes. There is intentionally no
 // Bearer/auth check: the random token IS the credential, by design
 // (RFC-7239 §1 capability URL pattern).
+// typstArgs builds the typst invocation for a staged source file.
+//
+// A bounded workspace becomes typst's root, which does two things: it
+// lets a document address an asset from the workspace root ("/logo.svg")
+// as well as relatively, and it stops typst reading anything outside the
+// tenant's own directory. An unbounded resolver (stdio mode, where the
+// "workspace" is the user's filesystem) gets no --root, leaving typst's
+// default of the input file's own directory.
+func typstArgs(r workspace.Resolver, in, out string) []string {
+	args := []string{"compile"}
+	if b, ok := r.(workspace.Bounded); ok {
+		args = append(args, "--root", b.WorkspaceRoot())
+	}
+	return append(args, in, out)
+}
+
 func handlePDFDownload(factory workspace.Factory, store *authdb.Store) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := strings.TrimPrefix(r.URL.Path, "/d/")

--- a/internal/typst/typst.go
+++ b/internal/typst/typst.go
@@ -11,9 +11,20 @@ import (
 
 // Compile takes preprocessed Typst content and compiles it to PDF.
 // Creates a temporary .typ file, runs typst compile, then cleans up.
+//
+// The temporary file is staged in the OUTPUT directory, not in /tmp.
+// typst resolves a document's relative paths against the directory of
+// the file it is handed, so staging elsewhere breaks every
+// #image("logo.png") in the document — with an error that names /tmp
+// and reads like a bug in the document rather than in this function.
 func Compile(content, outputFile string) error {
+	stageDir := filepath.Dir(outputFile)
+	if stageDir == "" {
+		stageDir = "."
+	}
+
 	// Create temporary file
-	tmpFile, err := os.CreateTemp("", "typst-d2-*.typ")
+	tmpFile, err := os.CreateTemp(stageDir, ".typst-d2-stage-*.typ")
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -144,12 +144,22 @@ func Usage(r Resolver) (bytes int64, tracked bool, err error) {
 	return total, true, nil
 }
 
+// StagePrefix marks a file the server staged inside a workspace for the
+// duration of one compile. The preprocessed source has to live next to
+// the document's assets for typst to resolve their relative paths, which
+// means it lands in the workspace — but it is server scratch, not the
+// tenant's data, so it does not count towards usage and must not be
+// mistaken for something the caller put there.
+const StagePrefix = ".typst-d2-stage-"
+
 // DirBytes returns the summed size of the regular files under dir,
 // walking recursively. Symlinks and other irregular entries are skipped
 // (their size is meaningless and WalkDir does not follow them), matching
-// how the sweeper measures a workspace. A dir that does not exist counts
-// as zero: a user who has written nothing yet has an empty workspace, not
-// an error.
+// how the sweeper measures a workspace. Files staged by an in-flight
+// compile are skipped too — counting them would let a large document
+// briefly inflate reported usage, or push its own compile over a byte
+// budget. A dir that does not exist counts as zero: a user who has
+// written nothing yet has an empty workspace, not an error.
 func DirBytes(dir string) (int64, error) {
 	var total int64
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
@@ -170,6 +180,9 @@ func DirBytes(dir string) (int64, error) {
 			return err
 		}
 		if !info.Mode().IsRegular() {
+			return nil
+		}
+		if strings.HasPrefix(d.Name(), StagePrefix) {
 			return nil
 		}
 		total += info.Size()

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -296,3 +296,48 @@ func TestAppendFile_CreatesParentDirs(t *testing.T) {
 		t.Errorf("appended file not created: %v", err)
 	}
 }
+
+// A file staged by an in-flight compile is server scratch, not tenant
+// data: counting it would let a large document briefly inflate reported
+// usage, or push its own compile over a byte budget.
+func TestDirBytes_SkipsStagedFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "real.txt"), make([]byte, 100), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := DirBytes(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 100 {
+		t.Fatalf("baseline = %d, want 100", got)
+	}
+
+	staged := filepath.Join(dir, StagePrefix+"123.typ")
+	if err := os.WriteFile(staged, make([]byte, 5000), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err = DirBytes(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 100 {
+		t.Errorf("with a staged file DirBytes = %d, want 100", got)
+	}
+
+	// A nested one, too — documents live in subdirectories.
+	sub := filepath.Join(dir, "docs")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, StagePrefix+"456.typ"), make([]byte, 5000), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err = DirBytes(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 100 {
+		t.Errorf("with a nested staged file DirBytes = %d, want 100", got)
+	}
+}

--- a/templates/README.md
+++ b/templates/README.md
@@ -16,9 +16,10 @@ alongside the binary while typst's writable `@preview` cache stays under
 `$HOME` on the data volume.
 
 Importing by package name rather than by file path is not a stylistic
-choice: the compile root is the staged `.typ` file's temporary
-directory, not the caller's workspace, so a relative import of a
-workspace file would not resolve at all.
+choice. Templates are shared across every tenant and versioned
+independently of any document, so they are not a per-workspace file to
+be copied into each workspace and kept in sync. The package namespace
+also carries the owner (below), which a relative path could not.
 
 ## Why `house` is a namespace and not a folder name
 


### PR DESCRIPTION
typst resolves a document's relative paths against the directory of the file it is handed. The preprocessed source was staged with `os.CreateTemp("", ...)`, so every compile ran out of `/tmp` and nothing pushed with `put_file` could be referenced from the document compiled against it:

```
put_file  logo.svg   -> ok
put_file  doc.typ    -> #image("logo.svg")
compile              -> error: file not found (searched at /tmp/logo.svg)
```

Both calls succeeded, the file was in the workspace, and the compiler never looked there. Because the error names `/tmp` it reads as a document bug rather than a server one — and the workflow the tool descriptions recommend (push the asset, compile on the server, per #69) walked straight into it.

**The fix.** The staged file lands next to the input, and a bounded workspace is passed as typst's `--root`. Relative assets resolve, `/assets/logo.svg` addresses the workspace root, and typst refuses to read outside the tenant's directory — which the `/tmp` root had been providing by accident rather than design. `--root` alone would not have been enough: it governs absolute-from-root paths, not relative ones, which resolve from the input file either way.

**Keeping the workspace honest.** Staged files carry a reserved prefix (`workspace.StagePrefix`) and are skipped by `DirBytes`, so a compile in flight cannot inflate reported usage or eat into its own byte budget. They are removed on the way out, and the sweeper collects any a crash leaves behind.

The `typst-d2-prep` CLI staged in `/tmp` for the same reason and gets the same fix.

Docs: `put_file` now states that pushed files are referenceable at compile time, and `compile_typst_with_d2` states what relative paths resolve against — until now that meant reading `main.go`.

Verified the four asset tests fail on the parent commit and pass here; the tenant-isolation and traversal tests pass on both, which is the point of including them.

Refers #91
Refers #69