### PR TITLE
feat(instructions): put house templates where they can be found

### DIFF
--- a/cmd/typst-d2-mcp/discoverability_test.go
+++ b/cmd/typst-d2-mcp/discoverability_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installTemplates puts an empty package tree where typst (and
+// templateInstructions) look for one, and returns nothing: the point is
+// the side effect on XDG_DATA_HOME.
+func installTemplates(t *testing.T) {
+	t.Helper()
+	data := t.TempDir()
+	pkg := filepath.Join(data, "typst", "packages",
+		templateNamespace, templateName, templateVersion)
+	if err := os.MkdirAll(pkg, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Setenv("XDG_DATA_HOME", data)
+}
+
+// The templates are the server's main consistency mechanism, and they
+// used to be appended after the longest string in the server — so a
+// client with an instructions cap cut them entirely and a caller could
+// author a whole document without learning they existed. They must now
+// come first, and early enough to survive a modest cap.
+func TestInstructions_TemplatesComeFirst(t *testing.T) {
+	installTemplates(t)
+
+	full := templateInstructions() + serverInstructions
+
+	tmplAt := strings.Index(full, "HOUSE TEMPLATES")
+	if tmplAt < 0 {
+		t.Fatal("HOUSE TEMPLATES section missing from the instructions")
+	}
+	if tmplAt != 0 {
+		t.Errorf("HOUSE TEMPLATES starts at byte %d, want the very front", tmplAt)
+	}
+
+	importAt := strings.Index(full, "@house/templates:0.1.0")
+	if importAt < 0 {
+		t.Fatal("the import line is missing")
+	}
+	// A client that forwards only the first 2000 bytes must still see
+	// the import line and both template names. The number is a stand-in
+	// for "any plausible cap", not a measured limit.
+	const cap = 2000
+	head := full
+	if len(head) > cap {
+		head = head[:cap]
+	}
+	for _, want := range []string{"@house/templates:0.1.0", "report", "adr"} {
+		if !strings.Contains(head, want) {
+			t.Errorf("%q does not survive a %d-byte instructions cap", want, cap)
+		}
+	}
+}
+
+// Layout guidance moved out of the instructions and onto the tool,
+// which is never truncated and is read when it is relevant. Assert it
+// arrived, and that it did not stay behind in both places.
+func TestCompileToolDescription_CarriesLayoutGuidance(t *testing.T) {
+	desc := compileToolDescription()
+
+	for _, want := range []string{
+		"direction: down",
+		"STAR-TOPOLOGY",
+		"A4",
+		`theme "0"`,
+	} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("tool description missing layout guidance %q", want)
+		}
+	}
+
+	if strings.Contains(serverInstructions, "STAR-TOPOLOGY ANTI-PATTERN") {
+		t.Error("star-topology guidance is still duplicated in the server instructions")
+	}
+}
+
+// The nudge is the half of discoverability that does not depend on a
+// client forwarding anything: it fires at the one moment the server
+// knows both what was written and what was available.
+func TestTemplateNudge(t *testing.T) {
+	installTemplates(t)
+
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "self-styled with no template",
+			src:  "#set page(margin: 2cm)\n= Title\nBody.\n",
+			want: true,
+		},
+		{
+			name: "own heading rules",
+			src:  "#show heading: it => text(weight: 700, it.body)\n= Title\n",
+			want: true,
+		},
+		{
+			name: "own fonts",
+			src:  "#set text(font: \"Libertinus Serif\")\n= Title\n",
+			want: true,
+		},
+		{
+			name: "imports the template",
+			src:  "#import \"@house/templates:0.1.0\": report\n#show: report.with(title: \"T\")\n= Title\n",
+			want: false,
+		},
+		{
+			// Importing a template AND setting page rules is the
+			// caller overriding deliberately. Say nothing: they have
+			// clearly seen the templates.
+			name: "imports the template and still sets page rules",
+			src:  "#import \"@house/templates:0.1.0\": report\n#set page(margin: 2cm)\n",
+			want: false,
+		},
+		{
+			name: "plain document with no styling at all",
+			src:  "= Title\n\nJust prose and a diagram.\n",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := templateNudge(tc.src) != ""
+			if got != tc.want {
+				t.Errorf("templateNudge fired=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Same honesty rule the instructions follow: never point at a package
+// that is not installed, or the caller spends a compile finding out.
+func TestTemplateNudge_SilentWhenTemplatesAbsent(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if got := templateNudge("#set page(margin: 2cm)\n= Title\n"); got != "" {
+		t.Errorf("nudge advertised templates that are not installed: %s", got)
+	}
+}
+
+// The nudge has to name the import line, or it is just nagging.
+func TestTemplateNudge_IsActionable(t *testing.T) {
+	installTemplates(t)
+	got := templateNudge("#set page(margin: 2cm)\n= Title\n")
+	for _, want := range []string{"@house/templates:0.1.0", "report", "adr"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("nudge missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -202,46 +202,23 @@ func int64Env(key string, def int64) int64 {
 	return n
 }
 
-// serverInstructions is sent once at the MCP initialize handshake. Moving
-// this guidance out of the per-tool description keeps it available to the
-// model without re-spending tokens on every tool call. Keep it focused on
-// strategy and anti-patterns the model needs across multiple compiles;
-// the per-call rule lives in the tool description.
+// serverInstructions is sent once at the MCP initialize handshake, and
+// what it holds is chosen by what survives truncation. Clients cap the
+// instructions they forward, and this string had grown long enough that
+// the most consequential part of it — the house templates, appended at
+// the end — was being cut before it reached the model. So: strategy
+// that changes what the model DOES, near the front, and nothing that a
+// tool description could carry instead.
+//
+// Diagram layout guidance in particular now lives on
+// compile_typst_with_d2, which is never truncated and is read exactly
+// when it is relevant. templateInstructions() is prepended, not
+// appended, for the same reason.
 const serverInstructions = `You can author Typst documents containing #d2[...] blocks and compile them
-to PDF with the compile_typst_with_d2 tool. The notes below apply across
-every diagram in a session — the tool description itself stays brief.
-
-DIAGRAM LAYOUT — A4 PORTRAIT (Typst default):
-  Usable area is roughly 17cm wide × 25cm tall, so vertical layouts breathe
-  while horizontal layouts get cramped. Prefer "direction: down" inside the
-  D2 block whenever a diagram has more than a handful of nodes.
-
-STAR-TOPOLOGY ANTI-PATTERN:
-  A central node connecting to 5+ siblings forces the ELK layout engine to
-  spread the children horizontally even when "direction: down" is set. The
-  fix is a vertical chain:
-
-      // BAD (renders horizontally on A4 portrait)
-      center -> a
-      center -> b
-      center -> c
-      center -> d
-      center -> e
-
-      // GOOD
-      center -> a -> b -> c -> d -> e
-
-  Org charts with two or three direct reports can stay as a star; four or
-  more children means convert to a chain or split into multiple diagrams.
-
-A4 LANDSCAPE (#set page(flipped: true)):
-  Usable area becomes ~25cm × 17cm. Prefer "direction: right" for wide
-  hierarchies; vertical chains still work but waste horizontal space.
-
-PRINT-FRIENDLY DEFAULTS:
-  - layout: "elk"  (best automatic layout)
-  - theme: "0"     (white background, good contrast on paper)
-  - Avoid dark themes (100–200 range) for print.
+to PDF with the compile_typst_with_d2 tool. Diagram layout guidance —
+page geometry, the star-topology anti-pattern, print-friendly defaults —
+is on that tool's description; the notes below are what applies across a
+whole session.
 
 SYNTAX EXAMPLES:
   Basic:
@@ -382,12 +359,12 @@ func templateInstructions() string {
 	if _, err := os.Stat(pkg); err != nil {
 		return ""
 	}
-	return fmt.Sprintf(`
-
-HOUSE TEMPLATES:
+	return fmt.Sprintf(`HOUSE TEMPLATES — READ THIS FIRST:
   This server ships document templates. Prefer them over styling a
   document yourself — they exist so that documents from different
   people, written at different times, come out looking the same.
+  Reach for one whenever you are asked for a report, a memo, or a
+  decision record, before writing any #set or #show rules of your own.
 
     #import "@%[1]s/%[2]s:%[3]s": report, adr
 
@@ -419,8 +396,51 @@ HOUSE TEMPLATES:
 
   Do not override the template's fonts, colours or page setup. A
   document that restyles itself has opted out of the house style, which
-  is the one thing these templates exist to prevent.`,
+  is the one thing these templates exist to prevent.
+
+`,
 		templateNamespace, templateName, templateVersion)
+}
+
+// selfStyling marks a document as having taken its own look in hand.
+// Each is something a template would otherwise own.
+var selfStyling = []string{
+	"#set page(",
+	"#set text(",
+	"#set par(",
+	"#show heading",
+	"#set heading(",
+}
+
+// templateNudge returns a note to append to a successful compile when a
+// document styles itself but imports no house template, and "" when
+// there is nothing to say.
+//
+// The instructions already ask for templates to be preferred, but
+// instructions are advisory, arrive once, and get truncated by clients
+// — a caller can finish a whole document without ever having seen them.
+// A compile is the one moment the server knows both what was written
+// and what was available, so it is the honest place to mention it.
+// Deliberately a note on a success, not a warning or a failure: styling
+// a document by hand is allowed, just rarely what was wanted.
+func templateNudge(src string) string {
+	if templateInstructions() == "" {
+		return "" // no package installed; nothing to point at
+	}
+	importPath := fmt.Sprintf("@%s/%s:%s", templateNamespace, templateName, templateVersion)
+	if strings.Contains(src, importPath) {
+		return ""
+	}
+	for _, marker := range selfStyling {
+		if strings.Contains(src, marker) {
+			return fmt.Sprintf(
+				"NOTE: this document sets its own page/text/heading rules and imports no "+
+					"template. House templates are available and are what keeps documents "+
+					"consistent:\n  #import \"%s\": report, adr\n"+
+					"See the server instructions for their arguments.", importPath)
+		}
+	}
+	return ""
 }
 
 func main() {
@@ -455,7 +475,12 @@ func main() {
 		serverVersion,
 		server.WithToolCapabilities(false),
 		server.WithResourceCapabilities(false, false),
-		server.WithInstructions(serverInstructions+templateInstructions()),
+		// Templates FIRST. Appended, they sat behind the longest part
+		// of the instructions and were the first thing a client's
+		// truncation limit cut — which made the server's main
+		// consistency mechanism undiscoverable to the callers who
+		// most needed it.
+		server.WithInstructions(templateInstructions()+serverInstructions),
 	)
 
 	registerTools(s, factory, store)
@@ -875,12 +900,13 @@ func resolverFor(ctx context.Context, factory workspace.Factory) (workspace.Reso
 	return r, nil
 }
 
-func registerTools(s *server.MCPServer, factory workspace.Factory, store *authdb.Store) {
-	// The bulk of the layout strategy lives in server instructions above so
-	// it isn't re-sent on every tool call. The description below carries
-	// only the rules the model needs at the moment it decides to call.
-	compileTypstTool := mcp.NewTool("compile_typst_with_d2",
-		mcp.WithDescription(`Compile a Typst document containing #d2[...] diagram blocks to PDF.
+// Layout guidance lives HERE rather than in the server instructions.
+// It costs tokens on every call, which is why it used to sit in the
+// instructions — but the instructions are truncated by clients and
+// this is read at exactly the moment it applies, which is the better
+// trade. What stays in the instructions is what spans a session.
+func compileToolDescription() string {
+	return `Compile a Typst document containing #d2[...] diagram blocks to PDF.
 
 Each #d2(opts)[code] block is rendered to SVG via the d2 CLI,
 base64-embedded, and the source compiled with typst. The PDF is written
@@ -888,13 +914,40 @@ next to the input .typ in the active workspace; a resource_link in the
 result points at it (fetch with resources/read on its typst-d2://pdf/...
 URI).
 
-Quick rules (full strategy in the server's instructions):
-  - Default layout "elk", theme "0" for print-friendly diagrams.
-  - On A4 portrait, add 'direction: down' inside the D2 block.
-  - A central node with 4+ children renders horizontally — use a chain.
+DIAGRAM LAYOUT — A4 PORTRAIT (the Typst default):
+  Usable area is roughly 17cm wide × 25cm tall, so vertical layouts
+  breathe while horizontal ones get cramped. Prefer 'direction: down'
+  inside the D2 block for anything past a handful of nodes.
+
+STAR-TOPOLOGY ANTI-PATTERN:
+  A central node with 5+ siblings forces ELK to spread the children
+  horizontally even when 'direction: down' is set. Chain them instead:
+
+      center -> a    // BAD: renders horizontally on A4 portrait
+      center -> b
+      center -> c
+      center -> d
+
+      center -> a -> b -> c -> d    // GOOD
+
+  Two or three direct reports can stay a star; four or more means a
+  chain, or split into several diagrams.
+
+A4 LANDSCAPE (#set page(flipped: true)):
+  ~25cm × 17cm. Prefer 'direction: right' for wide hierarchies.
+
+PRINT-FRIENDLY DEFAULTS:
+  layout "elk" (best automatic layout), theme "0" (white background,
+  good contrast on paper). Avoid dark themes (100–200) for print.
 
 After compiling, inspect the PDF if you can; if a diagram looks cramped,
-split it, simplify it, or switch to 'direction: down'.`),
+add 'direction: down', split it, or simplify it. If you cannot view the
+PDF yourself, tell the user to check the layout.`
+}
+
+func registerTools(s *server.MCPServer, factory workspace.Factory, store *authdb.Store) {
+	compileTypstTool := mcp.NewTool("compile_typst_with_d2",
+		mcp.WithDescription(compileToolDescription()),
 		mcp.WithString("file_path",
 			mcp.Required(),
 			mcp.Description("Path to the Typst source file (.typ) containing #d2[...] blocks. Absolute in local stdio mode; workspace-relative in scoped/hosted mode."),
@@ -1107,6 +1160,14 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		successMsg += "   - Split large diagrams into multiple focused diagrams\n"
 		successMsg += "   - Reduce number of nodes or simplify structure\n"
 		successMsg += "\nIf you cannot view the PDF yourself, inform the user to check the layout."
+
+		// Instructions are advisory and get truncated; a warning on a
+		// successful compile is neither. If the document styled itself
+		// by hand while the house templates sat right there, say so
+		// where it cannot be missed.
+		if nudge := templateNudge(processed); nudge != "" {
+			successMsg += "\n\n" + nudge
+		}
 
 		// Typst exits 0 with warnings on stderr. Surface them or
 		// they get silently dropped — and a "successful" compile


### PR DESCRIPTION
The house templates are the server's main consistency mechanism, and a caller talking to the hosted server could not discover they existed. `templateInstructions()` was appended after `serverInstructions` — the longest string in the server — so a client with an instructions cap cut the whole section: the import line, both signatures, and the rule against restyling.

I can confirm the truncation first-hand: in a session with this server connected, the instructions I received end mid-sentence at `...split it in… [truncated]`, with everything after it gone.

Three changes, in increasing order of how much they can be relied on:

1. **Templates come first.** Ahead of everything tactical, leading with *when* to reach for one. A test asserts the import line and both names survive a 2000-byte cap.

2. **Layout guidance moves onto `compile_typst_with_d2`.** It costs tokens per call, which is why it lived in the instructions — but a tool description is never truncated and is read at exactly the moment it applies. That is the better trade, and it shortens the instructions at the same time.

3. **A nudge at compile time.** A successful compile of a document that set its own page/text/heading rules while importing no template now returns a note naming the import line. Instructions are advisory, arrive once, and can be cut; a compile result is none of those. It stays silent when the caller has clearly seen the templates (imported one, or wrote no styling at all) and when no package is installed — the same honesty rule `templateInstructions` already follows.

**Not addressed here, deliberately** — both are product decisions rather than defects:

- A `list_templates` tool. Worth doing, and more so once #63 makes the answer per-owner.
- Whether `report()` should accept a bounded set of brand parameters (accent, mark, org name) while keeping ownership of geometry and type scale. This is the sharper question: "make this Stormlantern-themed" has no good answer today, and all-or-nothing styling reliably produces "nothing".

Refers #90
Refers #63