### PR TITLE
feat(fonts): ship a proportional sans, and say what the renderer has

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,19 @@ ARG TYPST_VERSION=v0.14.2
 # curl for the HEALTHCHECK probe, ca-certificates so the typst child
 # trusts TLS roots if it needs them, tini as a minimal PID 1 so signals
 # reach the Go process cleanly.
+#
+# Fonts, because typst ships only three families and none of them is a
+# proportional sans — so a document asking for one got a silent
+# substitution and a PDF that looks fine and is wrong. DejaVu brings a
+# proportional sans and serif; Liberation adds faces metric-compatible
+# with Arial / Times / Courier, which is what a document written
+# elsewhere will name. Both are freely redistributable and together add
+# roughly 2.5MB compressed. An organisation's own faces belong in its
+# workspace fonts/ directory, where the licensing stays with the tenant.
 RUN apt-get update \
  && apt-get install --no-install-recommends -y \
       ca-certificates curl tini xz-utils \
+      fonts-dejavu-core fonts-liberation2 \
  && rm -rf /var/lib/apt/lists/*
 
 # Install d2 via its official install script, pinned to D2_VERSION.

--- a/cmd/typst-d2-mcp/capabilities.go
+++ b/cmd/typst-d2-mcp/capabilities.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+)
+
+// FontsDir is the workspace subdirectory a tenant puts its own typefaces
+// in. Passing it to typst as a --font-path is what makes an organisation
+// template an organisation template: a brand that cannot use its own
+// typeface is a house style with a different accent colour, and
+// typography carries more identity than palette does.
+//
+// Licensing sits with the tenant, which is the right place for it — the
+// server ships only faces it may redistribute.
+const FontsDir = "fonts"
+
+// workspaceFontPath returns the tenant's font directory when it exists
+// and is usable, or "" otherwise. Absent is the normal case and not an
+// error: most workspaces have no fonts of their own.
+func workspaceFontPath(r workspace.Resolver) string {
+	b, ok := r.(workspace.Bounded)
+	if !ok {
+		return "" // stdio mode: system fonts are already the user's own
+	}
+	dir := filepath.Join(b.WorkspaceRoot(), FontsDir)
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+	return dir
+}
+
+// probeTimeout bounds the version/font probes. They shell out to the
+// same binaries a compile uses, and workspace_info must not be the tool
+// that hangs.
+const probeTimeout = 5 * time.Second
+
+// fontFamilies lists the font families typst can resolve, including any
+// the tenant supplied. The list is what a caller needs to avoid the
+// failure this exists to prevent: typst substitutes silently for an
+// unknown family, so the PDF looks fine and is wrong.
+func fontFamilies(fontPath string) []string {
+	args := []string{"fonts"}
+	if fontPath != "" {
+		args = append(args, "--font-path", fontPath)
+	}
+	out, err := runProbe("typst", args...)
+	if err != nil {
+		return nil
+	}
+	var families []string
+	sc := bufio.NewScanner(strings.NewReader(out))
+	for sc.Scan() {
+		if line := strings.TrimSpace(sc.Text()); line != "" {
+			families = append(families, line)
+		}
+	}
+	return families
+}
+
+var (
+	versionOnce sync.Once
+	typstVer    string
+	d2Ver       string
+)
+
+// toolVersions reports the typst and d2 versions this image actually
+// runs. They cannot change while the process does, so probe once.
+func toolVersions() (typstVersion, d2Version string) {
+	versionOnce.Do(func() {
+		typstVer = firstLine(mustProbe("typst", "--version"))
+		d2Ver = firstLine(mustProbe("d2", "--version"))
+	})
+	return typstVer, d2Ver
+}
+
+func mustProbe(name string, args ...string) string {
+	out, err := runProbe(name, args...)
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+func runProbe(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	done := make(chan struct{})
+	var out []byte
+	var err error
+	go func() {
+		out, err = cmd.Output()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return string(out), err
+	case <-time.After(probeTimeout):
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		<-done
+		return "", os.ErrDeadlineExceeded
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
+}

--- a/cmd/typst-d2-mcp/capabilities_test.go
+++ b/cmd/typst-d2-mcp/capabilities_test.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func wsInfo(t *testing.T, ctx context.Context, factory workspace.Factory) workspaceInfo {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "workspace_info"
+	res, err := handleWorkspaceInfo(factory, nil)(ctx, req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("workspace_info failed: %s", resultText(res))
+	}
+	var info workspaceInfo
+	if err := json.Unmarshal([]byte(resultText(res)), &info); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return info
+}
+
+// Nothing reported what this environment could do, so the only way to
+// discover the font situation was to spend a compile on a probe
+// document — and typst substitutes silently, so a caller who did not
+// think to probe shipped a PDF with the wrong faces and no warning.
+func TestWorkspaceInfo_ReportsCapabilities(t *testing.T) {
+	requireTypst(t)
+
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	info := wsInfo(t, ctx, factory)
+
+	if info.TypstVersion == "" {
+		t.Error("typst_version not reported")
+	}
+	if _, err := exec.LookPath("d2"); err == nil && info.D2Version == "" {
+		t.Error("d2_version not reported")
+	}
+	if len(info.FontFamilies) == 0 {
+		t.Fatal("font_families not reported")
+	}
+	if info.FontsDir != FontsDir {
+		t.Errorf("fonts_dir = %q, want %q", info.FontsDir, FontsDir)
+	}
+}
+
+// The reason this issue exists: typst's bundled set has no proportional
+// sans at all, so a document asking for one silently got a serif or a
+// monospace. Guard the property rather than a package list, so the test
+// still means something if the chosen faces change.
+func TestRenderEnvironment_HasProportionalSans(t *testing.T) {
+	requireTypst(t)
+
+	families := fontFamilies("")
+	if len(families) == 0 {
+		t.Fatal("typst reported no font families at all")
+	}
+
+	for _, f := range families {
+		lower := strings.ToLower(f)
+		if strings.Contains(lower, "mono") || strings.Contains(lower, "math") {
+			continue
+		}
+		if strings.Contains(lower, "sans") {
+			return // found one
+		}
+	}
+	t.Skipf("no proportional sans in this environment (have %v); "+
+		"the runtime image installs one, this host may not", families)
+}
+
+// A tenant's own typefaces have to reach the compiler, or an
+// organisation template cannot use the organisation's typeface.
+func TestTypstArgs_IncludesWorkspaceFontPath(t *testing.T) {
+	root := t.TempDir()
+	tenant := filepath.Join(root, "user123")
+	if err := os.MkdirAll(tenant, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r, err := workspace.NewScopedFS(tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Absent is the normal case: no flag, no error.
+	if got := strings.Join(typstArgs(r, "in.typ", "out.pdf"), " "); strings.Contains(got, "--font-path") {
+		t.Errorf("font path passed for a workspace with no fonts dir: %s", got)
+	}
+
+	if err := os.MkdirAll(filepath.Join(tenant, FontsDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(typstArgs(r, "in.typ", "out.pdf"), " ")
+	want := "--font-path " + filepath.Join(tenant, FontsDir)
+	if !strings.Contains(got, want) {
+		t.Errorf("args = %s, want it to contain %s", got, want)
+	}
+}
+
+// One tenant's fonts must not be visible to another. The font path is
+// derived from the resolver's own root, so this is a property of the
+// construction rather than of a check somewhere.
+func TestWorkspaceFontPath_IsPerTenant(t *testing.T) {
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+
+	mine, err := factory.Resolver(identity.Identity{UserID: "mine"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	theirs, err := factory.Resolver(identity.Identity{UserID: "theirs"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(root, "theirs", FontsDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := workspaceFontPath(mine); got != "" {
+		t.Errorf("one tenant saw another's font directory: %s", got)
+	}
+	if got := workspaceFontPath(theirs); got == "" {
+		t.Error("the owning tenant did not see its own font directory")
+	}
+}
+
+// stdio mode has no bounded workspace; the user's system fonts are
+// already their own, so there is nothing to add and nothing to report.
+func TestWorkspaceFontPath_UnboundedIsEmpty(t *testing.T) {
+	if got := workspaceFontPath(workspace.LocalFS{}); got != "" {
+		t.Errorf("font path in local mode = %q, want empty", got)
+	}
+}
+
+// End to end: push a font, name it, compile. The warning path matters
+// as much as the success — typst exits 0 on an unknown family, and
+// those warnings are the only signal a caller gets.
+func TestCompile_WorkspaceFontIsUsable(t *testing.T) {
+	requireTypst(t)
+
+	src := findSystemFont(t)
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "put_file"
+	req.Params.Arguments = map[string]any{
+		"path":     FontsDir + "/" + filepath.Base(src),
+		"content":  base64.StdEncoding.EncodeToString(raw),
+		"encoding": "base64",
+	}
+	res, err := handlePutFile(factory, nil)(ctx, req)
+	if err != nil {
+		t.Fatalf("put_file handler: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("put_file font: %s", resultText(res))
+	}
+
+	resolver, err := factory.Resolver(identity.Identity{UserID: "user123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fontPath := workspaceFontPath(resolver)
+	if fontPath == "" {
+		t.Fatal("pushing into fonts/ did not produce a font path")
+	}
+
+	// Ask typst what the pushed file alone provides, with system and
+	// embedded fonts excluded. Comparing against the full list would
+	// prove nothing when the face is also installed system-wide, which
+	// it usually is on a machine with any fonts at all.
+	own := familiesFromPathOnly(t, fontPath)
+	if len(own) == 0 {
+		t.Fatalf("typst read no families from the pushed font at %s", fontPath)
+	}
+
+	// And the workspace's full list must include them.
+	all := fontFamilies(fontPath)
+	for _, want := range own {
+		if !contains(all, want) {
+			t.Errorf("family %q from the pushed font is missing from the workspace list %v", want, all)
+		}
+	}
+
+	// Finally, a document setting that family must compile without an
+	// unknown-family warning.
+	if res := putFile(t, ctx, factory, "doc.typ",
+		"#set text(font: \""+own[0]+"\")\n= Title\nBody.\n"); res.IsError {
+		t.Fatalf("put_file doc: %s", resultText(res))
+	}
+	res = compile(t, ctx, factory, "doc.typ")
+	if res.IsError {
+		t.Fatalf("compile failed: %s", resultText(res))
+	}
+	if got := resultText(res); strings.Contains(strings.ToLower(got), "unknown font family") {
+		t.Errorf("pushed font %q was not resolved:\n%s", own[0], got)
+	}
+}
+
+// familiesFromPathOnly lists the families a directory provides, with
+// system and typst-embedded fonts excluded.
+func familiesFromPathOnly(t *testing.T, dir string) []string {
+	t.Helper()
+	out, err := exec.Command("typst", "fonts",
+		"--font-path", dir,
+		"--ignore-system-fonts",
+		"--ignore-embedded-fonts",
+	).Output()
+	if err != nil {
+		t.Skipf("typst fonts --ignore-*-fonts unavailable: %v", err)
+	}
+	var families []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			families = append(families, line)
+		}
+	}
+	return families
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// An unknown family must still surface as a warning on a successful
+// compile. That behaviour is what made diagnosing the font situation
+// possible at all, and is worth pinning.
+func TestCompile_UnknownFontStillWarns(t *testing.T) {
+	requireTypst(t)
+
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	if res := putFile(t, ctx, factory, "doc.typ",
+		"#set text(font: \"No Such Family At All\")\n= Title\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	res := compile(t, ctx, factory, "doc.typ")
+	if res.IsError {
+		t.Fatalf("compile failed: %s", resultText(res))
+	}
+	if got := resultText(res); !strings.Contains(strings.ToLower(got), "unknown font family") {
+		t.Errorf("no unknown-font warning surfaced:\n%s", got)
+	}
+}
+
+// findSystemFont picks any font file on the host to stand in for a
+// tenant's own face.
+func findSystemFont(t *testing.T) string {
+	t.Helper()
+	roots := []string{"/usr/share/fonts", "/usr/local/share/fonts"}
+	var found string
+	for _, root := range roots {
+		_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil || found != "" || info == nil || info.IsDir() {
+				return nil //nolint:nilerr // an unreadable font dir just means "look elsewhere"
+			}
+			switch strings.ToLower(filepath.Ext(path)) {
+			case ".ttf", ".otf":
+				found = path
+			}
+			return nil
+		})
+		if found != "" {
+			return found
+		}
+	}
+	t.Skip("no system font file to use as a stand-in")
+	return ""
+}

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -285,6 +285,13 @@ WORKSPACE, FILES & LIMITS (put_file / workspace_info):
   remaining slice with mode "append". Each slice must be within the
   per-call limit; the slices concatenate verbatim on disk.
 
+  FONTS: the render environment has a small fixed set of families, and
+  typst SUBSTITUTES an unknown one silently while still exiting 0 — the
+  PDF looks fine and is wrong. Check workspace_info.font_families before
+  setting a font. To use your own typefaces, put_file the .ttf/.otf into
+  the workspace "fonts/" directory; they are visible only to your
+  workspace and are not aged out.
+
   A hosted workspace may also have a cumulative byte budget across all
   its files. Call workspace_info first — it returns per_call_limit_bytes,
   used_bytes, and (when a budget is set) budget_bytes / available_bytes —
@@ -962,6 +969,14 @@ No arguments; returns JSON:
   - budget_bytes / available_bytes (+ *_human): the cumulative cap and
     remaining space, present only when a budget is configured (absent =
     no cap). A put_file over available_bytes is rejected.
+  - typst_version / d2_version: the binaries this server actually runs.
+  - font_families: every font family a compile can resolve, including
+    any you have pushed. Typst SUBSTITUTES an unknown family silently
+    and still exits 0, so a document naming one produces a PDF that
+    looks fine and is wrong — check this list before setting a font.
+  - fonts_dir: push .ttf/.otf files here (via put_file) to use your own
+    typefaces; they are visible only to your workspace. Present only
+    where the workspace is bounded.
 
 See the server instructions for the full file / upload guide.`),
 	)
@@ -1197,10 +1212,18 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 // tenant's own directory. An unbounded resolver (stdio mode, where the
 // "workspace" is the user's filesystem) gets no --root, leaving typst's
 // default of the input file's own directory.
+//
+// A workspace fonts/ directory, if present, is added as a font path so
+// a tenant can set documents in its own typefaces. The path is inside
+// the tenant's own root, so one workspace's fonts are not visible to
+// another.
 func typstArgs(r workspace.Resolver, in, out string) []string {
 	args := []string{"compile"}
 	if b, ok := r.(workspace.Bounded); ok {
 		args = append(args, "--root", b.WorkspaceRoot())
+	}
+	if fonts := workspaceFontPath(r); fonts != "" {
+		args = append(args, "--font-path", fonts)
 	}
 	return append(args, in, out)
 }
@@ -1404,6 +1427,16 @@ type workspaceInfo struct {
 	BudgetHuman       string `json:"budget_human,omitempty"`
 	AvailableBytes    *int64 `json:"available_bytes,omitempty"`
 	AvailableHuman    string `json:"available_human,omitempty"`
+
+	// What this environment can actually do, as opposed to how much of
+	// it is left. A caller had no way to learn any of this short of
+	// spending a compile on a probe document — and typst substitutes a
+	// missing font silently, so the probe was the only way to find out
+	// at all.
+	TypstVersion string   `json:"typst_version,omitempty"`
+	D2Version    string   `json:"d2_version,omitempty"`
+	FontFamilies []string `json:"font_families,omitempty"`
+	FontsDir     string   `json:"fonts_dir,omitempty"`
 }
 
 func handleWorkspaceInfo(factory workspace.Factory, store *authdb.Store) server.ToolHandlerFunc {
@@ -1417,10 +1450,17 @@ func handleWorkspaceInfo(factory workspace.Factory, store *authdb.Store) server.
 		if err != nil {
 			return mcp.NewToolResultErrorFromErr("measure workspace", err), nil
 		}
+		typstVersion, d2Version := toolVersions()
 		info := workspaceInfo{
 			PerCallLimitBytes: limit,
 			PerCallLimitHuman: humanBytes(limit),
 			UsageTracked:      tracked,
+			TypstVersion:      typstVersion,
+			D2Version:         d2Version,
+			FontFamilies:      fontFamilies(workspaceFontPath(resolver)),
+		}
+		if _, ok := resolver.(workspace.Bounded); ok {
+			info.FontsDir = FontsDir
 		}
 		if tracked {
 			u := used

--- a/internal/sweeper/sweeper.go
+++ b/internal/sweeper/sweeper.go
@@ -5,9 +5,13 @@
 // Workspaces are treated as scratch space. Everything in them is
 // reproducible — the source can be re-uploaded and recompiled — so files
 // are purged on age alone, with no distinction between put_file uploads
-// and generated PDFs. The one exception is a file with an unexpired
-// download link pointing at it: those are kept however old they are, so
-// a URL already in someone's hands never breaks.
+// and generated PDFs. There are two exceptions: a file with an unexpired
+// download link pointing at it, kept however old it is so a URL already
+// in someone's hands never breaks; and the workspace's fonts/ directory,
+// which is configuration rather than scratch. A tenant's typefaces are
+// pushed once and referenced by every document afterwards, so ageing
+// them out would break a workspace's typography at a distance, long
+// after the last put_file and with nothing to connect cause to effect.
 //
 // The same pass records each user's total workspace size. The walk is
 // already happening, and caching the result means the admin UI never
@@ -22,6 +26,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -192,6 +197,11 @@ func (s *Sweeper) sweepUser(ctx context.Context, userID string, protected map[st
 		}
 		rel = filepath.Clean(rel)
 
+		if isConfig(rel) {
+			totalBytes += info.Size()
+			return nil
+		}
+
 		if s.cfg.FileTTL > 0 && info.ModTime().Before(cutoff) && !protected[rel] {
 			size := info.Size()
 			if err := os.Remove(path); err != nil {
@@ -221,6 +231,23 @@ func (s *Sweeper) sweepUser(ctx context.Context, userID string, protected map[st
 		return res, fmt.Errorf("record usage: %w", err)
 	}
 	return res, nil
+}
+
+// configDirs are workspace subdirectories the sweeper never purges.
+// They hold things a tenant sets up once and expects to stay set up,
+// as opposed to the documents and PDFs that make up the scratch space
+// around them.
+var configDirs = []string{"fonts"}
+
+// isConfig reports whether a workspace-relative path lives under one of
+// the configuration directories.
+func isConfig(rel string) bool {
+	for _, dir := range configDirs {
+		if rel == dir || strings.HasPrefix(rel, dir+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
 }
 
 // pruneEmptyDirs removes directories left empty by the purge, deepest

--- a/internal/sweeper/sweeper_test.go
+++ b/internal/sweeper/sweeper_test.go
@@ -305,3 +305,41 @@ func TestSweepOnce_MissingRootIsNotAnError(t *testing.T) {
 		t.Errorf("SweepOnce with missing root: %v", err)
 	}
 }
+
+// A tenant's typefaces are pushed once and referenced by every document
+// afterwards. Ageing them out would break a workspace's typography long
+// after the last put_file, with nothing connecting cause to effect — so
+// fonts/ is configuration, not scratch, and survives whatever its age.
+func TestSweepOnce_KeepsWorkspaceFonts(t *testing.T) {
+	store := newStore(t)
+	root := t.TempDir()
+
+	font := writeFile(t, root, "gh:1", filepath.Join("fonts", "Brand-Regular.ttf"), 30*24*time.Hour)
+	nested := writeFile(t, root, "gh:1", filepath.Join("fonts", "brand", "Brand-Bold.otf"), 30*24*time.Hour)
+	doc := writeFile(t, root, "gh:1", "old.pdf", 48*time.Hour)
+
+	// A file merely NAMED like the directory is still scratch.
+	decoy := writeFile(t, root, "gh:1", "fonts-notes.txt", 48*time.Hour)
+
+	sw := New(store, Config{Root: root, FileTTL: 24 * time.Hour, Interval: time.Hour})
+	res, err := sw.SweepOnce(t.Context(), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if !exists(t, font) {
+		t.Error("a workspace font was purged")
+	}
+	if !exists(t, nested) {
+		t.Error("a font in a fonts/ subdirectory was purged")
+	}
+	if exists(t, doc) {
+		t.Error("an aged-out PDF survived; the exemption is too broad")
+	}
+	if exists(t, decoy) {
+		t.Error("a file merely prefixed 'fonts' was treated as configuration")
+	}
+	if res.FilesDeleted != 2 {
+		t.Errorf("FilesDeleted = %d, want 2", res.FilesDeleted)
+	}
+}


### PR DESCRIPTION
> **Stacked on #94** — based on `fix/compile-root-in-workspace` because both touch `typstArgs`. Merge #94 first and this retargets to `main` cleanly.

typst was invoked with no font path and the image installed no fonts, so a document could use Libertinus Serif, New Computer Modern, or DejaVu Sans Mono — and nothing else, with no proportional sans at all. typst substitutes a missing family silently and still exits 0, so the failure shape is a PDF that looks fine and is wrong.

**The image gains DejaVu and Liberation.** A proportional sans and serif, plus faces metric-compatible with Arial / Times / Courier — what a document written elsewhere will name. Verified against a throwaway image matching the runtime stage:

```
before: DejaVu Sans Mono · Libertinus Serif · New Computer Modern · New Computer Modern Math
after:  + DejaVu Sans · DejaVu Serif · Liberation Mono · Liberation Sans · Liberation Serif
```

Image size, as the issue's test plan asks: **144MB → 151MB** (~2.5MB compressed download).

**A workspace `fonts/` directory** is passed as `--font-path`. This is what makes an organisation template an organisation template — typography carries more brand identity than palette does. Licensing stays with the tenant. The path derives from the tenant's own root, so one workspace's fonts are invisible to another.

**The sweeper had to learn about it.** It purges on age alone, so pushed typefaces would have aged out on the file TTL and broken every later document at a distance — long after the last `put_file`, with nothing connecting cause to effect. `fonts/` is now configuration, not scratch. This was not in the issue; it turned up while implementing it.

**`workspace_info` reports capabilities**, not just remaining room: `font_families`, `typst_version`, `d2_version`, `fonts_dir`. Discovering any of this previously meant spending a compile on a probe document — and only worked because unknown-family warnings reach stderr on a successful compile. That behaviour is now pinned by a test.

Two tests skip in the devcontainer (no system fonts there — it reports the same four families as the issue). Both were run and pass in a container mirroring the runtime image; `TestCompile_WorkspaceFontIsUsable` proves the mechanism by asking typst what the pushed file alone provides, with system and embedded fonts excluded, so it means something even when the face is also installed system-wide.

Refers #92
Refers #63