### PR TITLE
docs(templates): correct the storage path, document authoring on the volume

### DIFF
--- a/cmd/typst-d2-mcp/volumetemplates_test.go
+++ b/cmd/typst-d2-mcp/volumetemplates_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The operator path documented in templates/README.md: because seeding
+// never overwrites, an edit made on the data volume survives a restart
+// and an image upgrade, and is what typst actually compiles against.
+// The README is the only place this is written down, so pin it.
+func TestVolumeTemplates_OperatorEditSurvivesSeeding(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+	pkgDir := filepath.Join(data, "typst", "packages",
+		templateNamespace, templateName, templateVersion)
+
+	// First boot seeds the bundled tree.
+	seedBundledTemplates()
+	libPath := filepath.Join(pkgDir, "lib.typ")
+	seeded, err := os.ReadFile(libPath)
+	if err != nil {
+		t.Fatalf("seed did not produce lib.typ: %v", err)
+	}
+
+	// An operator edits it in place, adding a document type.
+	edited := string(seeded) + "\n#let memo(title: \"Untitled\", body) = {\n" +
+		"  show: _page-setup\n  heading(title)\n  body\n}\n"
+	if err := os.WriteFile(libPath, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A restart (or an image upgrade) re-runs the seed. The edit stands.
+	seedBundledTemplates()
+	after, err := os.ReadFile(libPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != edited {
+		t.Fatal("re-seeding overwrote the operator's edit")
+	}
+	if !strings.Contains(string(after), "#let memo(") {
+		t.Error("the added document type did not survive")
+	}
+}
+
+// And the edited template is what typst resolves — an operator-added
+// type is importable exactly like a bundled one.
+func TestVolumeTemplates_OperatorAddedTypeCompiles(t *testing.T) {
+	if _, err := exec.LookPath("typst"); err != nil {
+		t.Skip("typst not installed")
+	}
+
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+	seedBundledTemplates()
+
+	libPath := filepath.Join(data, "typst", "packages",
+		templateNamespace, templateName, templateVersion, "lib.typ")
+	lib, err := os.ReadFile(libPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	added := string(lib) + "\n#let memo(title: \"Untitled\", body) = {\n" +
+		"  show: _page-setup\n  heading(title)\n  body\n}\n"
+	if err := os.WriteFile(libPath, []byte(added), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	in := filepath.Join(dir, "doc.typ")
+	out := filepath.Join(dir, "doc.pdf")
+	src := "#import \"@" + templateNamespace + "/" + templateName + ":" + templateVersion + "\": memo\n" +
+		"#show: memo.with(title: \"A memo\")\nBody text.\n"
+	if err := os.WriteFile(in, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("typst", "compile", in, out)
+	cmd.Env = append(os.Environ(), "XDG_DATA_HOME="+data)
+	if outBytes, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("operator-added type did not compile: %v\n%s", err, outBytes)
+	}
+	if info, err := os.Stat(out); err != nil || info.Size() == 0 {
+		t.Errorf("no PDF produced: %v", err)
+	}
+}

--- a/templates/README.md
+++ b/templates/README.md
@@ -25,10 +25,9 @@ possible. The seed target is a sibling of the workspace tree
 never sees it. typst's writable `@preview` cache stays under `$HOME`.
 
 Importing by package name rather than by file path is not a stylistic
-choice. Templates are shared across every tenant and versioned
-independently of any document, so they are not a per-workspace file to
-be copied into each workspace and kept in sync. The package namespace
-also carries the owner (below), which a relative path could not.
+choice: the compile root is the staged `.typ` file's temporary
+directory, not the caller's workspace, so a relative import of a
+workspace file would not resolve at all.
 
 ## Why `house` is a namespace and not a folder name
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,8 @@
 # House document templates
 
-Typst packages, baked into the image, that documents import by name:
+Typst packages that documents import by name. They are embedded in the
+binary and seeded onto the data volume on startup, so an operator can
+change them there without an image rebuild:
 
 ```typst
 #import "@house/templates:0.1.0": report, adr
@@ -10,24 +12,32 @@ Typst packages, baked into the image, that documents import by name:
 
 typst resolves local packages from
 `$XDG_DATA_HOME/typst/packages/<namespace>/<name>/<version>`, so this
-directory tree *is* the import path. `XDG_DATA_HOME` is set to
-`/usr/local/share` in the image, which is why templates ship read-only
-alongside the binary while typst's writable `@preview` cache stays under
-`$HOME` on the data volume.
+directory tree *is* the import path.
+
+In the image `XDG_DATA_HOME` is `/var/lib/typst-d2-mcp/data`, which sits
+on the data volume. This tree is embedded in the binary and **seeded**
+there on startup rather than shipped read-only: `seedBundledTemplates`
+copies any file that is not already present and never overwrites one
+that is. That is step 2 of #63 — house style changes on the volume
+without an image rebuild — and it is what makes the operator path below
+possible. The seed target is a sibling of the workspace tree
+(`/var/lib/typst-d2-mcp/workspaces`), not inside it, so the sweeper
+never sees it. typst's writable `@preview` cache stays under `$HOME`.
 
 Importing by package name rather than by file path is not a stylistic
-choice: the compile root is the staged `.typ` file's temporary
-directory, not the caller's workspace, so a relative import of a
-workspace file would not resolve at all.
+choice. Templates are shared across every tenant and versioned
+independently of any document, so they are not a per-workspace file to
+be copied into each workspace and kept in sync. The package namespace
+also carries the owner (below), which a relative path could not.
 
 ## Why `house` is a namespace and not a folder name
 
-`house` is an **owner slug**. Today there is one owner and its packages
-are baked into the image. The intended path is:
+`house` is an **owner slug**. Today there is one owner. The intended
+path is:
 
-1. one owner, in the image — where this is now
+1. one owner, in the image — done
 2. owners' packages on the data volume, so house style changes without
-   an image rebuild
+   an image rebuild — **where this is now** (see the seeding note above)
 3. owners become organisations in the schema, with users able to belong
    to more than one
 4. each compile resolves only the namespaces its caller can see — the
@@ -41,7 +51,44 @@ document already says which one it means.
 
 ## Adding a document type
 
-Export a function from `lib.typ`. Two shapes exist deliberately:
+There are two paths, and they differ in who can take them and how long
+the result lasts.
+
+### In the repo (permanent)
+
+Export a function from `lib.typ`. This is the path for a type that
+should exist for everyone, on every deployment: it ships in the binary,
+is covered by the tests below, and seeds onto every volume.
+
+### On the data volume (operator, immediate)
+
+Because seeding never overwrites, anything already at
+`$XDG_DATA_HOME/typst/packages/` wins. An operator can edit
+`house/templates/0.1.0/lib.typ` in place, or drop in an entirely new
+namespace or version, and it survives restarts and image upgrades. This
+is the intended way to change house style without a redeploy.
+
+Four things to know before using it:
+
+- **Nothing validates the result.** A syntax error in `lib.typ` breaks
+  every compile that imports it, and the first sign is a failing user
+  compile. Check the edit by compiling a document that imports it
+  before walking away.
+- **Files must be readable by uid 65532** (`nonroot`), which the server
+  runs as.
+- **A new package is not advertised.** `templateInstructions()` names
+  exactly `@house/templates:0.1.0` (see the `templateNamespace` /
+  `templateName` / `templateVersion` constants), so a type added under a
+  different namespace or version compiles fine but no caller is told it
+  exists. Callers have to be told out of band until a `list_templates`
+  tool lands (#90).
+- **Edits are invisible to the repo.** Anything worth keeping should
+  come back here as a change to `lib.typ`, or the next volume will not
+  have it.
+
+### Either way
+
+Two shapes exist deliberately:
 
 - `report` owns the **look**. The author writes what they like.
 - `adr` owns the **structure** too — its sections are arguments, not


### PR DESCRIPTION
`templates/README.md` described step 1 of #63 while the code is at step 2.

It said `XDG_DATA_HOME` was `/usr/local/share` and that templates *"ship read-only alongside the binary"*. The image sets it to `/var/lib/typst-d2-mcp/data` on the data volume, and `seedBundledTemplates` (`main.go:328`) copies the embedded tree there, skipping any file that already exists.

That is not a cosmetic slip. **Never-overwrite *is* the authoring affordance** — an operator can edit `lib.typ` on the volume, or drop in a whole namespace, and it survives restarts and image upgrades. The document that should have described that instead described the templates as read-only, so the one path not needing a redeploy was invisible.

## What's now documented

"Adding a document type" covers both routes:

- **In the repo** — for a type everyone should have, on every deployment.
- **On the data volume** — for a change that has to land now.

With the four things the volume route does *not* give you: nothing validates the edit (a syntax error breaks every compile that imports it, and the first sign is a failing user compile); files must be readable by uid 65532; `templateInstructions()` names exactly one package, so a type added under a new namespace or version compiles fine but no caller is ever told it exists (#90); and an edit not brought back to the repo is gone on the next volume.

The #63 progress marker also moves from step 1 to step 2, which is where the code actually is.

## Two tests

The README was the only place this behaviour was written down, so it is now pinned: an operator edit survives re-seeding, and an operator-added document type imports and compiles like a bundled one — confirming `_page-setup` is reachable from a function added inside `lib.typ`, which is what makes the route usable at all.

## One rationale rewritten

The package-vs-relative-path paragraph argued from the compile root being a temp directory — which #94 changes, and after which a relative workspace import *does* resolve. Rewritten to the reason that holds either way: templates are shared across tenants and versioned independently of any document, so they are not a per-workspace file to copy into each workspace and keep in sync.

Refers #63