### PR TITLE
feat(templates): resolve only the namespaces a caller can see (#63 rung 4)

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -1173,8 +1173,28 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		// silent on success would mean a half-rendered PDF gets
 		// reported as a clean compile. We surface warnings to the
 		// caller so the LLM/operator can act on them.
+		// Rung 4 of #63: the typst child sees only the package
+		// namespaces this caller may import. Built as a symlink tree
+		// per compile rather than filtered at import time — a
+		// namespace that is not in the tree cannot be reached by any
+		// spelling of the import.
+		allowed, err := allowedNamespaces(ctx, store, id)
+		if err != nil {
+			metrics.CompileTotal.WithLabelValues(metrics.ResultFail).Inc()
+			log.Error("namespace resolution failed", "err", err)
+			return mcp.NewToolResultErrorFromErr("resolve template namespaces", err), nil
+		}
+		view, cleanupView, err := packageView(typstDataDir(), allowed)
+		if err != nil {
+			metrics.CompileTotal.WithLabelValues(metrics.ResultFail).Inc()
+			log.Error("package view failed", "err", err)
+			return mcp.NewToolResultErrorFromErr("prepare template namespaces", err), nil
+		}
+		defer cleanupView()
+
 		var stdoutBuf, stderrBuf bytes.Buffer
 		cmd := exec.CommandContext(ctx, "typst", typstArgs(resolver, tmpFile.Name(), resolvedOut)...)
+		cmd.Env = compileEnv(view)
 		cmd.Stdout = &stdoutBuf
 		cmd.Stderr = &stderrBuf
 		err = cmd.Run()

--- a/cmd/typst-d2-mcp/namespaces.go
+++ b/cmd/typst-d2-mcp/namespaces.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+)
+
+// Rung 4 of #63: a compile resolves only the package namespaces its
+// caller can see.
+//
+// typst resolves local packages from
+// $XDG_DATA_HOME/typst/packages/<namespace>/..., and the server spawns a
+// typst child per compile — so the isolation boundary is the child's
+// XDG_DATA_HOME. Each compile gets a directory containing a symlink per
+// permitted namespace and nothing else. A namespace the caller may not
+// see is not hidden behind a check that could be forgotten; it is simply
+// absent from the tree typst searches, and the import fails with
+// "package not found", the same as a typo.
+//
+// This is the discipline workspace.ScopedFS already applies to files:
+// construct the reachable set, rather than filter an unreachable one.
+//
+// Only $XDG_DATA_HOME is redirected. typst's @preview cache lives under
+// $XDG_CACHE_HOME, so the `@preview/based` import that every
+// preprocessed document carries is unaffected.
+
+// builtinNamespace is readable by every caller. It is the house style —
+// the default the templates exist to provide — so gating it on
+// membership would both break every document that already imports it and
+// leave a new user with no templates at all.
+const builtinNamespace = templateNamespace
+
+// allowedNamespaces returns the package namespaces a caller may import,
+// sorted and free of duplicates. Without a store (stdio, or an
+// unauthenticated deployment) there are no organisations to resolve and
+// the built-in is the whole answer.
+func allowedNamespaces(ctx context.Context, store *authdb.Store, id identity.Identity) ([]string, error) {
+	allowed := map[string]bool{builtinNamespace: true}
+
+	if store != nil && !id.IsAnonymous() {
+		orgs, err := store.OrgsForUser(ctx, id.UserID)
+		if err != nil {
+			// Fail closed. Falling back to "everything" on a database
+			// error would turn a transient fault into a cross-tenant
+			// read, which is the one outcome this function exists to
+			// prevent.
+			return nil, fmt.Errorf("resolve organisations: %w", err)
+		}
+		for _, slug := range orgs {
+			allowed[slug] = true
+		}
+	}
+
+	out := make([]string, 0, len(allowed))
+	for slug := range allowed {
+		out = append(out, slug)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// packageView builds a temporary XDG_DATA_HOME exposing only the given
+// namespaces from the real package store, and returns it with a cleanup
+// func. The view holds symlinks, so it costs no disk and nothing is
+// copied.
+//
+// A namespace with no directory in the store is skipped rather than
+// failing: an organisation exists in the schema before anyone publishes
+// a template to it (rung 5), and that is not an error.
+func packageView(dataDir string, allowed []string) (string, func(), error) {
+	viewRoot, err := os.MkdirTemp("", "typst-d2-pkgview-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create package view: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(viewRoot) }
+
+	pkgDir := filepath.Join(viewRoot, "typst", "packages")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("create package view: %w", err)
+	}
+
+	realPkgs := filepath.Join(dataDir, "typst", "packages")
+	for _, slug := range allowed {
+		src := filepath.Join(realPkgs, slug)
+		if _, statErr := os.Stat(src); statErr != nil {
+			continue // namespace exists, nothing published to it yet
+		}
+		if linkErr := os.Symlink(src, filepath.Join(pkgDir, slug)); linkErr != nil {
+			cleanup()
+			return "", nil, fmt.Errorf("link namespace %s: %w", slug, linkErr)
+		}
+	}
+	return viewRoot, cleanup, nil
+}
+
+// compileEnv returns the environment for a typst child, with
+// XDG_DATA_HOME pointed at view. Everything else is inherited, so the
+// @preview cache, PATH and locale are untouched.
+func compileEnv(view string) []string {
+	env := os.Environ()
+	out := env[:0:0]
+	for _, kv := range env {
+		if len(kv) >= len("XDG_DATA_HOME=") && kv[:len("XDG_DATA_HOME=")] == "XDG_DATA_HOME=" {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "XDG_DATA_HOME="+view)
+}

--- a/cmd/typst-d2-mcp/namespaces_test.go
+++ b/cmd/typst-d2-mcp/namespaces_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+)
+
+// writePackage puts a minimal typst package into a store, exporting a
+// mark() the test can look for in a compile.
+func writePackage(t *testing.T, dataDir, namespace, version string) {
+	t.Helper()
+	dir := filepath.Join(dataDir, "typst", "packages", namespace, "templates", version)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := "[package]\nname = \"templates\"\nversion = \"" + version + "\"\nentrypoint = \"lib.typ\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "typst.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lib := "#let mark() = [" + namespace + "-template]\n"
+	if err := os.WriteFile(filepath.Join(dir, "lib.typ"), []byte(lib), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The built-in namespace is the house style — the default the templates
+// exist to provide. Gating it on membership would break every document
+// that already imports it and leave a new user with nothing.
+// newTestStore opens a throwaway auth database.
+func newTestStore(t *testing.T) *authdb.Store {
+	t.Helper()
+	store, err := authdb.Open(filepath.Join(t.TempDir(), "auth.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// seedUser registers a GitHub user and returns the identity a request
+// from them would carry.
+func seedUser(t *testing.T, store *authdb.Store, login string, githubID int64) identity.Identity {
+	t.Helper()
+	if _, err := store.UpsertGitHubUser(t.Context(), githubID, login, login+"@example.com"); err != nil {
+		t.Fatalf("UpsertGitHubUser: %v", err)
+	}
+	return identity.Identity{UserID: fmt.Sprintf("gh:%d", githubID)}
+}
+
+func TestAllowedNamespaces_BuiltinAlwaysPresent(t *testing.T) {
+	got, err := allowedNamespaces(context.Background(), nil, identity.Identity{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != builtinNamespace {
+		t.Errorf("allowedNamespaces = %v, want just %q", got, builtinNamespace)
+	}
+}
+
+// An anonymous caller has no organisations to resolve, store or not.
+func TestAllowedNamespaces_AnonymousGetsBuiltinOnly(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	if err := store.CreateOrg(ctx, "admin", "acme", "Acme"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := allowedNamespaces(ctx, store, identity.Identity{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != builtinNamespace {
+		t.Errorf("allowedNamespaces = %v, want just %q", got, builtinNamespace)
+	}
+}
+
+// A member resolves their organisations; a non-member does not. This is
+// the isolation boundary rung 4 exists to draw.
+func TestAllowedNamespaces_MembershipDecides(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	for _, slug := range []string{"acme", "globex"} {
+		if err := store.CreateOrg(ctx, "admin", slug, slug); err != nil {
+			t.Fatal(err)
+		}
+	}
+	member := seedUser(t, store, "member", 1)
+	outsider := seedUser(t, store, "outsider", 2)
+	if err := store.AddOrgMember(ctx, "admin", "acme", "member"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := allowedNamespaces(ctx, store, member)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"acme", builtinNamespace}; !equalStrings(got, want) {
+		t.Errorf("member sees %v, want %v", got, want)
+	}
+
+	got, err = allowedNamespaces(ctx, store, outsider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{builtinNamespace}; !equalStrings(got, want) {
+		t.Errorf("outsider sees %v, want %v", got, want)
+	}
+}
+
+// The view exposes exactly the permitted namespaces and nothing else.
+func TestPackageView_ExposesOnlyAllowed(t *testing.T) {
+	data := t.TempDir()
+	writePackage(t, data, "house", "0.1.0")
+	writePackage(t, data, "acme", "1.0.0")
+	writePackage(t, data, "globex", "1.0.0")
+
+	view, cleanup, err := packageView(data, []string{"house", "acme"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	entries, err := os.ReadDir(filepath.Join(view, "typst", "packages"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	if want := []string{"acme", "house"}; !equalStrings(names, want) {
+		t.Errorf("view contains %v, want %v", names, want)
+	}
+}
+
+// An organisation exists in the schema before anyone publishes to it
+// (rung 5). That is not an error, and must not fail the compile.
+func TestPackageView_UnpublishedNamespaceIsSkipped(t *testing.T) {
+	data := t.TempDir()
+	writePackage(t, data, "house", "0.1.0")
+
+	view, cleanup, err := packageView(data, []string{"house", "brand-new-org"})
+	if err != nil {
+		t.Fatalf("an org with nothing published broke the view: %v", err)
+	}
+	defer cleanup()
+
+	if _, err := os.Stat(filepath.Join(view, "typst", "packages", "house")); err != nil {
+		t.Errorf("published namespace missing: %v", err)
+	}
+}
+
+func TestPackageView_CleanupRemovesIt(t *testing.T) {
+	data := t.TempDir()
+	writePackage(t, data, "house", "0.1.0")
+	view, cleanup, err := packageView(data, []string{"house"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup()
+	if _, err := os.Stat(view); !os.IsNotExist(err) {
+		t.Errorf("view survived cleanup: %v", err)
+	}
+}
+
+// compileEnv must replace an inherited XDG_DATA_HOME rather than append
+// a second one — the child would otherwise take whichever the OS
+// resolves first, which is not something to leave to chance on an
+// isolation boundary.
+func TestCompileEnv_ReplacesInheritedDataHome(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "/inherited/should/not/win")
+	env := compileEnv("/the/view")
+
+	var seen []string
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "XDG_DATA_HOME=") {
+			seen = append(seen, kv)
+		}
+	}
+	if len(seen) != 1 {
+		t.Fatalf("XDG_DATA_HOME appears %d times: %v", len(seen), seen)
+	}
+	if seen[0] != "XDG_DATA_HOME=/the/view" {
+		t.Errorf("XDG_DATA_HOME = %q, want the view", seen[0])
+	}
+}
+
+// End to end through the real typst binary: a permitted namespace
+// imports, and one the caller is not a member of does not resolve at
+// all — with the control showing the package itself is fine.
+func TestCompile_NamespaceIsolation(t *testing.T) {
+	requireTypst(t)
+
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+	writePackage(t, data, "house", "0.1.0")
+	writePackage(t, data, "acme", "1.0.0")
+
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+
+	// The caller belongs to no organisation, so acme is out of reach.
+	if res := putFile(t, ctx, factory, "denied.typ",
+		"#import \"@acme/templates:1.0.0\": mark\n#mark()\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	res := compile(t, ctx, factory, "denied.typ")
+	if !res.IsError {
+		t.Fatal("a caller compiled against an organisation it does not belong to")
+	}
+	if got := resultText(res); !strings.Contains(got, "package not found") {
+		t.Errorf("expected an unresolved package, got: %s", got)
+	}
+
+	// The built-in still resolves for the same caller.
+	if res := putFile(t, ctx, factory, "ok.typ",
+		"#import \"@house/templates:0.1.0\": mark\n#mark()\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	if res := compile(t, ctx, factory, "ok.typ"); res.IsError {
+		t.Fatalf("the built-in namespace stopped resolving: %s", resultText(res))
+	}
+
+	// Control: acme compiles when the whole store is visible, proving
+	// the package is sound and the view is what excluded it.
+	in := filepath.Join(t.TempDir(), "control.typ")
+	out := strings.TrimSuffix(in, ".typ") + ".pdf"
+	if err := os.WriteFile(in, []byte("#import \"@acme/templates:1.0.0\": mark\n#mark()\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("typst", "compile", in, out)
+	cmd.Env = append(os.Environ(), "XDG_DATA_HOME="+data)
+	if outBytes, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("control compile failed, so the isolation test proves nothing: %v\n%s", err, outBytes)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
**Rung 4 of #63.** Builds directly on rung 3 (#79), using its `OrgsForUser` primitive.

Every compile could reach every package namespace on the volume. With one built-in owner that was invisible; with organisations now in the schema it is a cross-tenant read waiting to happen.

## The boundary is the child's environment

typst resolves local packages from `$XDG_DATA_HOME/typst/packages/<namespace>/`, and the server spawns a typst child per compile. So each compile now gets a temporary directory holding **a symlink per permitted namespace and nothing else**, passed as that child's `XDG_DATA_HOME`.

A namespace the caller may not see isn't hidden behind a check that could be forgotten — it is absent from the tree typst searches, and the import fails with `package not found`, the same as a typo. That's the discipline `workspace.ScopedFS` already applies to files: construct the reachable set rather than filter an unreachable one.

## Three decisions worth naming

- **The built-in is readable by everyone.** #63 says "the caller's own namespace plus every organisation they belong to", which read strictly would exclude `house`. But `house` *is* the house style: gating it on membership would break every document that already imports it and leave a new user with no templates at all. Flagging in case you want it the other way.
- **An organisation with nothing published is skipped, not an error.** Orgs exist in the schema before rung 5 gives anyone a way to publish to them.
- **A database error fails the compile.** Falling back to the full store on a transient fault would turn it into exactly the cross-tenant read this prevents.

## Verified, including the assumptions

Both load-bearing assumptions were probed against the real binary before writing any code: typst follows symlinks for packages, and `@preview` resolves under a scoped `XDG_DATA_HOME` because that cache lives in `XDG_CACHE_HOME`. The second matters because the preprocessor adds `@preview/based` to every document — scoping the wrong variable would have broken every compile.

`TestCompile_NamespaceIsolation` drives the whole chain through real typst: a non-member's import of `@acme` fails to resolve, `@house` still works for the same caller, and a **control compile with the full store visible succeeds** — so the test proves the view did the excluding, not a broken fixture.

## Ladder after this

- [x] 1. One owner, baked into the image
- [x] 2. Templates on the data volume (#78)
- [x] 3. Owners become organisations in the schema (#79)
- [x] **4. Per-owner resolution** ← this PR
- [ ] 5. Organisation-scoped template management in the admin UI

Refers #63