### PR TITLE
feat(templates): publish a template, gated on it compiling (#63 rung 5)

### DIFF
--- a/cmd/typst-d2-mcp/capabilities_test.go
+++ b/cmd/typst-d2-mcp/capabilities_test.go
@@ -273,27 +273,47 @@ func TestCompile_UnknownFontStillWarns(t *testing.T) {
 	}
 }
 
-// findSystemFont picks any font file on the host to stand in for a
+// findSystemFont picks a font file on the host to stand in for a
 // tenant's own face.
+//
+// It has to fit through put_file, which caps one call at
+// maxInputBytes. Taking the first font found is not enough: a CJK or
+// emoji face runs to several megabytes and the test then fails on the
+// upload rather than on anything it is trying to prove. Pick the
+// smallest candidate under the limit.
 func findSystemFont(t *testing.T) string {
 	t.Helper()
+	limit := maxInputBytes()
 	roots := []string{"/usr/share/fonts", "/usr/local/share/fonts"}
-	var found string
+
+	var best string
+	var bestSize int64
 	for _, root := range roots {
 		_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-			if err != nil || found != "" || info == nil || info.IsDir() {
+			if err != nil || info == nil || info.IsDir() {
 				return nil //nolint:nilerr // an unreadable font dir just means "look elsewhere"
 			}
 			switch strings.ToLower(filepath.Ext(path)) {
 			case ".ttf", ".otf":
-				found = path
+			default:
+				return nil
+			}
+			// Walk reports symlinks with Lstat, so a link to a 6MB face
+			// looks tiny and then fails the upload. Only regular files.
+			if !info.Mode().IsRegular() {
+				return nil
+			}
+			if info.Size() > limit {
+				return nil
+			}
+			if best == "" || info.Size() < bestSize {
+				best, bestSize = path, info.Size()
 			}
 			return nil
 		})
-		if found != "" {
-			return found
-		}
 	}
-	t.Skip("no system font file to use as a stand-in")
-	return ""
+	if best == "" {
+		t.Skipf("no system font under %d bytes to use as a stand-in", limit)
+	}
+	return best
 }

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -388,6 +388,10 @@ func templateInstructions() string {
   returns the exact import string and what each package exports; this
   section can only describe the built-in ones.
 
+  If the look someone wants does not exist yet, write it once and
+  publish_template it into your own namespace rather than restyling
+  each document. Everyone has a namespace, so nothing needs granting.
+
     #import "@%[1]s/%[2]s:%[3]s": report, adr
 
   report — owns the look; you write whatever content suits.
@@ -1080,6 +1084,45 @@ An empty list means no template is installed for you — style the
 document yourself, or ask an administrator to publish one.`),
 	)
 	s.AddTool(listTemplatesTool, handleListTemplates(store))
+
+	publishTemplateTool := mcp.NewTool("publish_template",
+		mcp.WithDescription(`Publish a document template into a namespace you own.
+
+Everyone has their own namespace, so you can publish without anyone
+granting you anything. list_templates shows which namespaces are yours.
+
+Put the package's files in a workspace directory with put_file first:
+
+  my-template/typst.toml       [package] name/version/entrypoint
+  my-template/lib.typ          #let report(title: "Untitled", body) = { … }
+  my-template/assets/logo.svg  optional — a package may ship its own files
+  my-template/fonts/Brand.ttf  optional — and its own typefaces
+
+Then publish that directory. THE TEMPLATE IS COMPILED BEFORE IT IS
+ACCEPTED: if it does not compile, nothing is published and you get the
+typst error. That check exists because a broken template does not fail
+for you — it fails for everyone who imports it afterwards.
+
+A published version is IMMUTABLE. Documents pin what they import, so
+replacing 1.0.0 would change how already-written documents render.
+Publish 1.0.1 instead; the old version keeps working.`),
+		mcp.WithString("source",
+			mcp.Required(),
+			mcp.Description("Workspace directory holding typst.toml and the entrypoint."),
+		),
+		mcp.WithString("namespace",
+			mcp.Required(),
+			mcp.Description("Namespace name to publish into. Must be one you own — see list_templates."),
+		),
+		mcp.WithString("version",
+			mcp.Required(),
+			mcp.Description(`Package version, major.minor.patch (e.g. "1.0.0"). typst rejects any other shape.`),
+		),
+		mcp.WithString("name",
+			mcp.Description(`Package name within the namespace; defaults to "templates", giving @you/templates:1.0.0.`),
+		),
+	)
+	s.AddTool(publishTemplateTool, handlePublishTemplate(factory, store))
 }
 
 func registerResources(s *server.MCPServer, factory workspace.Factory) {

--- a/cmd/typst-d2-mcp/publish.go
+++ b/cmd/typst-d2-mcp/publish.go
@@ -1,0 +1,477 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Publishing a template — rung 5 of #63.
+//
+// A published template styles other people's documents, so two rules do
+// most of the work here.
+//
+// It must compile before it is accepted. A template that fails to
+// compile does not fail for whoever published it; it fails for everyone
+// who imports it afterwards, at a time and place unrelated to the cause.
+// Checking at publish time is the difference between one person seeing a
+// clear error and everybody seeing a confusing one.
+//
+// And a version, once published, is immutable. That is not a policy so
+// much as the consequence of documents pinning what they import: if
+// 1.0.0 could be replaced, a bad publish would retroactively break
+// documents that were compiling yesterday. A new version cannot.
+//
+// Who may publish is settled by namespace ownership, which for a
+// personal namespace is true by construction — so this needs no
+// permission model beyond the role that already exists.
+
+// maxPackageBytes bounds one published package. Templates are read on
+// every compile that imports them and live on the server's volume, so
+// this is deliberately far below what a workspace may hold.
+const maxPackageBytes = 4 << 20
+
+var (
+	packageNamePattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	// typst requires a three-part version and rejects anything else, so
+	// reject it here rather than at every later import.
+	versionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+)
+
+func handlePublishTemplate(factory workspace.Factory, store *authdb.Store) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		source, err := request.RequireString("source")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		namespace, err := request.RequireString("namespace")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		version, err := request.RequireString("version")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		pkgName := request.GetString("name", "templates")
+
+		if !packageNamePattern.MatchString(pkgName) {
+			return mcp.NewToolResultError(
+				"name must be lowercase letters, digits and hyphens (e.g. \"templates\")"), nil
+		}
+		if !versionPattern.MatchString(version) {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"version %q is not major.minor.patch (e.g. \"1.0.0\") — typst rejects anything else",
+				version)), nil
+		}
+
+		id, _ := identity.FromContext(ctx)
+		if store == nil || id.IsAnonymous() {
+			return mcp.NewToolResultError(
+				"publishing needs a signed-in caller and a server that tracks namespaces"), nil
+		}
+
+		// You may publish only to a namespace you own. Everyone owns
+		// their own, so this is not a barrier to a first template — it
+		// is a barrier to publishing into someone else's.
+		nsID, err := namespaceForPublish(ctx, store, id, namespace)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		resolver, err := resolverFor(ctx, factory)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("workspace setup", err), nil
+		}
+		// Resolve rather than MustExist: a package is a directory, and
+		// MustExist requires a regular file. Resolve still rejects
+		// traversal, which is the part that matters.
+		srcDir, err := resolver.Resolve(source)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if info, statErr := os.Stat(srcDir); statErr != nil || !info.IsDir() {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"source %q must be a directory holding typst.toml and the entrypoint", source)), nil
+		}
+
+		files, total, err := collectPackage(srcDir)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("read package", err), nil
+		}
+		if total > maxPackageBytes {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"package is %s; the limit is %s", humanBytes(total), humanBytes(maxPackageBytes))), nil
+		}
+		if !containsFile(files, "typst.toml") {
+			return mcp.NewToolResultError(
+				"no typst.toml in " + source + " — a template is a typst package and needs one"), nil
+		}
+
+		// Immutable versions. Refuse before doing any work, and say what
+		// to do instead.
+		dest := filepath.Join(typstDataDir(), "typst", "packages", nsID, pkgName, version)
+		if _, statErr := os.Stat(dest); statErr == nil {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"@%s/%s:%s already exists. Published versions are immutable, because documents "+
+					"pin what they import — publish a new version instead",
+				namespace, pkgName, version)), nil
+		}
+
+		if err := compileCheck(ctx, srcDir, files, nsID, pkgName, version); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"the template did not compile, so it was not published:\n\n%s", err.Error())), nil
+		}
+
+		if err := installPackage(srcDir, files, dest); err != nil {
+			return mcp.NewToolResultErrorFromErr("install package", err), nil
+		}
+
+		msg := fmt.Sprintf("Published @%s/%s:%s (%s, %d file(s)).\n\nImport it with:\n  #import \"@%s/%s:%s\": …\n",
+			namespace, pkgName, version, humanBytes(total), len(files), namespace, pkgName, version)
+		msg += "\nThis version is now immutable. Publish a new version to change it; " +
+			"documents importing this one keep rendering the same way."
+		return mcp.NewToolResultText(msg), nil
+	}
+}
+
+// namespaceForPublish resolves a namespace name the caller may use and
+// confirms they own it.
+func namespaceForPublish(ctx context.Context, store *authdb.Store, id identity.Identity, name string) (string, error) {
+	if name == builtinNamespace {
+		return "", fmt.Errorf("@%s is the server's built-in namespace and cannot be published to", name)
+	}
+	allowed, err := allowedNamespaces(ctx, store, id)
+	if err != nil {
+		return "", fmt.Errorf("resolve namespaces: %w", err)
+	}
+	nsID, ok := allowed[name]
+	if !ok {
+		return "", fmt.Errorf("you cannot see a namespace called @%s — call list_templates to see yours", name)
+	}
+	role, err := store.RoleFor(ctx, nsID, id.UserID)
+	if err != nil {
+		return "", fmt.Errorf("check ownership: %w", err)
+	}
+	if role != authdb.RoleOwner {
+		return "", fmt.Errorf("you are a member of @%s but not an owner, so you cannot publish to it", name)
+	}
+	return nsID, nil
+}
+
+// collectPackage lists the package's files, relative to its root.
+func collectPackage(dir string) ([]string, int64, error) {
+	var files []string
+	var total int64
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Skip anything the server staged: a compile in the same
+		// directory would otherwise get published along with it.
+		if strings.HasPrefix(d.Name(), workspace.StagePrefix) {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if !info.Mode().IsRegular() {
+			return nil // symlinks and friends are not part of a package
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		files = append(files, filepath.ToSlash(rel))
+		total += info.Size()
+		return nil
+	})
+	sort.Strings(files)
+	return files, total, err
+}
+
+func containsFile(files []string, want string) bool {
+	for _, f := range files {
+		if f == want {
+			return true
+		}
+	}
+	return false
+}
+
+// compileCheck stages the candidate into a throwaway package root and
+// compiles a document against it. A failure here is returned as an
+// error and the publish is refused; softer findings come back as
+// warnings the caller can read but that do not block.
+//
+// The check runs in the same shape as a real compile — the package
+// reached only through XDG_DATA_HOME — so a template that resolves here
+// resolves for everyone importing it later.
+func compileCheck(ctx context.Context, srcDir string, files []string, nsID, pkgName, version string) error {
+	stage, err := os.MkdirTemp("", "typst-d2-publish-*")
+	if err != nil {
+		return fmt.Errorf("stage package: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(stage) }()
+
+	pkgRoot := filepath.Join(stage, "data", "typst", "packages", nsID, pkgName, version)
+	if err := installPackage(srcDir, files, pkgRoot); err != nil {
+		return fmt.Errorf("stage package: %w", err)
+	}
+
+	work := filepath.Join(stage, "work")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		return fmt.Errorf("stage package: %w", err)
+	}
+
+	importPath := fmt.Sprintf("@%s/%s:%s", nsID, pkgName, version)
+	dataHome := filepath.Join(stage, "data")
+
+	// The gate: the package imports and a document using it compiles.
+	// This is what catches the failures that actually reach users — a
+	// syntax error, a missing asset, a typst.toml that does not match
+	// the directory it sits in.
+	doc := fmt.Sprintf("#import %q: *\n= Compile check\nBody text.\n", importPath)
+	if out, err := runTypst(ctx, work, dataHome, "check.typ", doc); err != nil {
+		return errors.New(out)
+	}
+
+	// Importing is not enough on its own. typst evaluates lazily, so a
+	// function that references a file the package does not ship — a
+	// logo the author forgot to include — imports cleanly and only
+	// fails when somebody calls it. Which is to say: it fails for the
+	// people who import the template, not for the person publishing it.
+	// That is precisely the failure this check exists to prevent, so
+	// document templates are also APPLIED, the way a caller writes
+	// `#show: report.with(...)` with the arguments left out.
+	//
+	// Only document templates, though — a package may reasonably export
+	// helpers that are not meant to be applied to a document, and
+	// refusing to publish those would block legitimate work. See
+	// isDocumentTemplate for how the two are told apart.
+	for _, name := range documentTemplateExports(filepath.Join(srcDir, "lib.typ")) {
+		showDoc := fmt.Sprintf("#import %q: %s\n#show: %s.with()\n= Heading\nBody.\n",
+			importPath, name, name)
+		if out, err := runTypst(ctx, work, dataHome, "show-"+name+".typ", showDoc); err != nil {
+			return fmt.Errorf(
+				"%s is a document template but fails when applied to a document with its "+
+					"default arguments:\n\n%s", name, out)
+		}
+	}
+	return nil
+}
+
+// documentTemplateExports returns the exports that are document
+// templates — the ones a caller applies with `#show: name.with(...)`.
+//
+// The rule is structural: a document template's final parameter is
+// positional and named `body`, because that is the argument `#show:`
+// supplies. It is a convention, but a load-bearing one — the house
+// templates follow it and so does every template in the typst
+// ecosystem, and the alternative was reading typst's error text to
+// guess whether a failure meant "broken" or "not that kind of thing".
+// That guess is not decidable: `swatch(colour)` and `report(.., body)`
+// have the same shape, and a helper misapplied as a show rule fails
+// with a type error indistinguishable from a real defect.
+//
+// The cost of the rule is that a template naming its body something
+// else is not applied, so it is checked less thoroughly. The benefit is
+// that no legitimate package is ever refused for exporting a helper.
+func documentTemplateExports(libPath string) []string {
+	content, err := os.ReadFile(libPath)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, decl := range letDeclarations(string(content)) {
+		if isDocumentTemplate(decl.params) {
+			out = append(out, decl.name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+type letDecl struct {
+	name   string
+	params string
+}
+
+// letDeclarations finds top-level `#let name(params)` bindings. Parens
+// are balanced across lines, because a template's parameter list
+// usually spans several.
+func letDeclarations(src string) []letDecl {
+	var out []letDecl
+	for i := 0; i < len(src); {
+		idx := strings.Index(src[i:], "#let ")
+		if idx < 0 {
+			break
+		}
+		i += idx + len("#let ")
+		j := i
+		for j < len(src) && (isIdentByte(src[j])) {
+			j++
+		}
+		name := src[i:j]
+		if name == "" || strings.HasPrefix(name, "_") {
+			i = j + 1
+			continue
+		}
+		if j >= len(src) || src[j] != '(' {
+			i = j + 1
+			continue // a value binding, not a function
+		}
+		params, end, ok := balancedParens(src, j)
+		if !ok {
+			i = j + 1
+			continue
+		}
+		out = append(out, letDecl{name: name, params: params})
+		i = end
+	}
+	return out
+}
+
+func isIdentByte(c byte) bool {
+	return c == '-' || c == '_' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// balancedParens returns the contents of the parenthesised group
+// starting at open, and the index just past its close.
+func balancedParens(src string, open int) (string, int, bool) {
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '"':
+			for i++; i < len(src); i++ {
+				if src[i] == '\\' {
+					i++
+					continue
+				}
+				if src[i] == '"' {
+					break
+				}
+			}
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return src[open+1 : i], i + 1, true
+			}
+		}
+	}
+	return "", 0, false
+}
+
+// isDocumentTemplate reports whether a parameter list ends in a
+// positional `body`.
+func isDocumentTemplate(params string) bool {
+	parts := splitTopLevel(params)
+	if len(parts) == 0 {
+		return false
+	}
+	last := strings.TrimSpace(parts[len(parts)-1])
+	return last == "body"
+}
+
+// splitTopLevel splits a parameter list on commas that are not nested
+// inside parens, brackets or strings — a default value may contain any
+// of those.
+func splitTopLevel(s string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			for i++; i < len(s); i++ {
+				if s[i] == '\\' {
+					i++
+					continue
+				}
+				if s[i] == '"' {
+					break
+				}
+			}
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case ',':
+			if depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if rest := strings.TrimSpace(s[start:]); rest != "" {
+		parts = append(parts, s[start:])
+	}
+	return parts
+}
+
+// runTypst compiles one document against a staged package root.
+func runTypst(ctx context.Context, workDir, dataHome, file, content string) (string, error) {
+	in := filepath.Join(workDir, file)
+	if err := os.WriteFile(in, []byte(content), 0o600); err != nil {
+		return "", err
+	}
+	out := strings.TrimSuffix(in, ".typ") + ".pdf"
+	cmd := exec.CommandContext(ctx, "typst", "compile", in, out)
+	cmd.Env = compileEnv(dataHome)
+	combined, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(combined)), err
+}
+
+// installPackage copies a package's files into dest.
+func installPackage(srcDir string, files []string, dest string) error {
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return err
+	}
+	for _, rel := range files {
+		if err := copyFile(filepath.Join(srcDir, filepath.FromSlash(rel)),
+			filepath.Join(dest, filepath.FromSlash(rel))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/cmd/typst-d2-mcp/publish_test.go
+++ b/cmd/typst-d2-mcp/publish_test.go
@@ -1,0 +1,444 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// publishFixture is a signed-in caller with their own namespace, a
+// workspace, and a template staged in it ready to publish.
+type publishFixture struct {
+	store   *authdb.Store
+	factory workspace.Factory
+	ctx     context.Context
+	user    identity.Identity
+	nsName  string
+	data    string
+	root    string
+}
+
+func newPublishFixture(t *testing.T) *publishFixture {
+	t.Helper()
+	requireTypst(t)
+
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+
+	store := newTestStore(t)
+	user := seedUser(t, store, "author", 1)
+	if _, err := store.EnsurePersonalNamespace(t.Context(), user.UserID, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	return &publishFixture{
+		store:   store,
+		factory: workspace.TenantFactory{Root: root},
+		ctx:     identity.WithIdentity(context.Background(), user),
+		user:    user,
+		nsName:  authdb.DerivedName(1),
+		data:    data,
+		root:    root,
+	}
+}
+
+// stage writes a candidate package into the caller's workspace.
+func (f *publishFixture) stage(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		if res := putFileStore(t, f.ctx, f.factory, f.store, dir+"/"+rel, content); res.IsError {
+			t.Fatalf("put_file %s: %s", rel, resultText(res))
+		}
+	}
+}
+
+func (f *publishFixture) publish(t *testing.T, source, namespace, version string) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "publish_template"
+	req.Params.Arguments = map[string]any{
+		"source": source, "namespace": namespace, "version": version,
+	}
+	res, err := handlePublishTemplate(f.factory, f.store)(f.ctx, req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	return res
+}
+
+const goodTOML = "[package]\nname = \"templates\"\nversion = \"1.0.0\"\nentrypoint = \"lib.typ\"\n"
+const goodLib = "#let report(title: \"Untitled\", body) = {\n  set page(margin: 2cm)\n  heading(title)\n  body\n}\n"
+
+// The happy path, end to end: publish, then compile a document that
+// imports what was just published.
+func TestPublish_ThenImport(t *testing.T) {
+	f := newPublishFixture(t)
+	t.Setenv(envQuotaPerDay, "100")
+	f.stage(t, "tpl", map[string]string{"typst.toml": goodTOML, "lib.typ": goodLib})
+
+	res := f.publish(t, "tpl", f.nsName, "1.0.0")
+	if res.IsError {
+		t.Fatalf("publish failed: %s", resultText(res))
+	}
+	if got := resultText(res); !strings.Contains(got, "@"+f.nsName+"/templates:1.0.0") {
+		t.Errorf("result does not give the import line: %s", got)
+	}
+
+	doc := "#import \"@" + f.nsName + "/templates:1.0.0\": report\n" +
+		"#show: report.with(title: \"Hello\")\nBody.\n"
+	if r := putFileStore(t, f.ctx, f.factory, f.store, "doc.typ", doc); r.IsError {
+		t.Fatalf("put_file: %s", resultText(r))
+	}
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "compile_typst_with_d2"
+	req.Params.Arguments = map[string]any{"file_path": "doc.typ"}
+	cres, err := handleCompileTypst(f.factory, f.store)(f.ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cres.IsError {
+		t.Fatalf("a just-published template did not import: %s", resultText(cres))
+	}
+}
+
+// The gate. A template that does not compile must not reach anyone
+// else's documents, and the caller must be told why.
+func TestPublish_BrokenTemplateIsRefused(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{
+		"typst.toml": goodTOML,
+		"lib.typ":    "#let report(title: \"x\", body) = {\n  this is not typst (((\n}\n",
+	})
+
+	res := f.publish(t, "tpl", f.nsName, "1.0.0")
+	if !res.IsError {
+		t.Fatal("a template that does not compile was published")
+	}
+	got := resultText(res)
+	if !strings.Contains(got, "did not compile") {
+		t.Errorf("error does not say what happened: %s", got)
+	}
+	// And nothing was installed.
+	dest := filepath.Join(f.data, "typst", "packages")
+	if entries, _ := os.ReadDir(dest); len(entries) != 0 {
+		t.Errorf("a refused publish left files behind: %v", entries)
+	}
+}
+
+// A template referencing an asset it does not ship compiles fine for
+// its author and fails for everyone else. The check must catch that,
+// which is only true because it compiles against the STAGED package
+// rather than the workspace the files came from.
+func TestPublish_MissingAssetIsCaught(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{
+		"typst.toml": goodTOML,
+		"lib.typ":    "#let report(body) = {\n  image(\"assets/logo.svg\", width: 10mm)\n  body\n}\n",
+	})
+
+	res := f.publish(t, "tpl", f.nsName, "1.0.0")
+	if !res.IsError {
+		t.Fatal("a template referencing a file it does not ship was published")
+	}
+}
+
+// A template that ships its asset passes, and the asset travels with it.
+func TestPublish_WithAssetSucceeds(t *testing.T) {
+	f := newPublishFixture(t)
+	svg := `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">` +
+		`<rect width="10" height="10" fill="#006566"/></svg>`
+	f.stage(t, "tpl", map[string]string{
+		"typst.toml":      goodTOML,
+		"assets/logo.svg": svg,
+		"lib.typ":         "#let report(body) = {\n  image(\"assets/logo.svg\", width: 10mm)\n  body\n}\n",
+	})
+
+	if res := f.publish(t, "tpl", f.nsName, "1.0.0"); res.IsError {
+		t.Fatalf("publish failed: %s", resultText(res))
+	}
+	nsID, err := f.store.ResolveName(t.Context(), f.nsName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	asset := filepath.Join(f.data, "typst", "packages", nsID, "templates", "1.0.0", "assets", "logo.svg")
+	if _, err := os.Stat(asset); err != nil {
+		t.Errorf("the asset did not travel with the package: %v", err)
+	}
+}
+
+// Immutability. Documents pin what they import, so replacing a version
+// would change how already-written documents render.
+func TestPublish_VersionIsImmutable(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{"typst.toml": goodTOML, "lib.typ": goodLib})
+
+	if res := f.publish(t, "tpl", f.nsName, "1.0.0"); res.IsError {
+		t.Fatalf("first publish: %s", resultText(res))
+	}
+	res := f.publish(t, "tpl", f.nsName, "1.0.0")
+	if !res.IsError {
+		t.Fatal("a published version was overwritten")
+	}
+	if got := resultText(res); !strings.Contains(got, "immutable") {
+		t.Errorf("error does not explain why: %s", got)
+	}
+
+	// A new version is the way forward, and both then exist.
+	bumped := strings.Replace(goodTOML, "1.0.0", "1.0.1", 1)
+	f.stage(t, "tpl2", map[string]string{"typst.toml": bumped, "lib.typ": goodLib})
+	if res := f.publish(t, "tpl2", f.nsName, "1.0.1"); res.IsError {
+		t.Fatalf("publishing a new version: %s", resultText(res))
+	}
+	nsID, _ := f.store.ResolveName(t.Context(), f.nsName)
+	for _, v := range []string{"1.0.0", "1.0.1"} {
+		if _, err := os.Stat(filepath.Join(f.data, "typst", "packages", nsID, "templates", v)); err != nil {
+			t.Errorf("version %s missing: %v", v, err)
+		}
+	}
+}
+
+// You may publish only where you are an owner.
+func TestPublish_RequiresOwnership(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{"typst.toml": goodTOML, "lib.typ": goodLib})
+
+	// A namespace the caller is merely a member of.
+	if err := f.store.CreateOrg(t.Context(), "admin", "acme", "Acme"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.store.AddOrgMember(t.Context(), "admin", "acme", "author"); err != nil {
+		t.Fatal(err)
+	}
+	res := f.publish(t, "tpl", "acme", "1.0.0")
+	if !res.IsError {
+		t.Fatal("a member published to a namespace they do not own")
+	}
+	if got := resultText(res); !strings.Contains(got, "not an owner") {
+		t.Errorf("error does not explain: %s", got)
+	}
+
+	// A namespace they cannot see at all.
+	if err := f.store.CreateOrg(t.Context(), "admin", "globex", "Globex"); err != nil {
+		t.Fatal(err)
+	}
+	if res := f.publish(t, "tpl", "globex", "1.0.0"); !res.IsError {
+		t.Fatal("published into a namespace the caller cannot even see")
+	}
+}
+
+// The built-in is the server's, not a tenant's.
+func TestPublish_BuiltinIsNotWritable(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{"typst.toml": goodTOML, "lib.typ": goodLib})
+	if res := f.publish(t, "tpl", builtinNamespace, "9.9.9"); !res.IsError {
+		t.Fatal("published into the built-in namespace")
+	}
+}
+
+// Shapes typst rejects must be rejected here, not at every later import.
+func TestPublish_RejectsBadVersions(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{"typst.toml": goodTOML, "lib.typ": goodLib})
+	for _, v := range []string{"1", "1.0", "v1.0.0", "1.0.0-beta", "latest"} {
+		if res := f.publish(t, "tpl", f.nsName, v); !res.IsError {
+			t.Errorf("version %q was accepted", v)
+		}
+	}
+}
+
+func TestPublish_RequiresTypstToml(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{"lib.typ": goodLib})
+	res := f.publish(t, "tpl", f.nsName, "1.0.0")
+	if !res.IsError {
+		t.Fatal("published a directory with no typst.toml")
+	}
+	if got := resultText(res); !strings.Contains(got, "typst.toml") {
+		t.Errorf("error does not name what is missing: %s", got)
+	}
+}
+
+// An export that cannot be applied with default arguments is reported
+// but does not block: not every export is a document template.
+func TestPublish_ShowRuleFailureIsAWarningNotAGate(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{
+		"typst.toml": goodTOML,
+		// A plain helper, not a show-rule template.
+		"lib.typ": "#let accent = rgb(\"#006566\")\n#let swatch(colour) = rect(fill: colour, width: 5mm, height: 5mm)\n",
+	})
+
+	res := f.publish(t, "tpl", f.nsName, "1.0.0")
+	if res.IsError {
+		t.Fatalf("a package of plain helpers was refused: %s", resultText(res))
+	}
+	if got := resultText(res); !strings.Contains(got, "show rule") {
+		t.Logf("no show-rule note (acceptable): %s", got)
+	}
+}
+
+// A staged compile artefact in the source directory must not be
+// published along with the template.
+func TestPublish_SkipsStagedArtefacts(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{
+		"typst.toml":                           goodTOML,
+		"lib.typ":                              goodLib,
+		workspace.StagePrefix + "leftover.typ": "= not part of the package\n",
+	})
+
+	if res := f.publish(t, "tpl", f.nsName, "1.0.0"); res.IsError {
+		t.Fatalf("publish failed: %s", resultText(res))
+	}
+	nsID, _ := f.store.ResolveName(t.Context(), f.nsName)
+	dest := filepath.Join(f.data, "typst", "packages", nsID, "templates", "1.0.0")
+	entries, err := os.ReadDir(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), workspace.StagePrefix) {
+			t.Errorf("a staged artefact was published: %s", e.Name())
+		}
+	}
+}
+
+// Published templates show up in list_templates, which is how a caller
+// finds what they just made.
+func TestPublish_AppearsInListTemplates(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{"typst.toml": goodTOML, "lib.typ": goodLib})
+	if res := f.publish(t, "tpl", f.nsName, "1.0.0"); res.IsError {
+		t.Fatalf("publish failed: %s", resultText(res))
+	}
+
+	got := listTemplates(t, f.ctx, f.store)
+	var found bool
+	for _, e := range got.Templates {
+		if e.Import == "@"+f.nsName+"/templates:1.0.0" {
+			found = true
+			if !containsString(e.Exports, "report") {
+				t.Errorf("exports = %v, want report", e.Exports)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("the published template is not listed: %+v", got.Templates)
+	}
+}
+
+// Base64 assets survive the round trip through put_file and publish.
+func TestPublish_BinaryAssetRoundTrips(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{"typst.toml": goodTOML, "lib.typ": goodLib})
+
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "put_file"
+	req.Params.Arguments = map[string]any{
+		"path":     "tpl/assets/dot.png",
+		"content":  base64.StdEncoding.EncodeToString([]byte(testPNG)),
+		"encoding": "base64",
+	}
+	if res, err := handlePutFile(f.factory, f.store)(f.ctx, req); err != nil || res.IsError {
+		t.Fatalf("put_file png: %v %v", err, res)
+	}
+
+	if res := f.publish(t, "tpl", f.nsName, "1.0.0"); res.IsError {
+		t.Fatalf("publish failed: %s", resultText(res))
+	}
+	nsID, _ := f.store.ResolveName(t.Context(), f.nsName)
+	dst := filepath.Join(f.data, "typst", "packages", nsID, "templates", "1.0.0", "assets", "dot.png")
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != testPNG {
+		t.Error("the binary asset did not survive publishing byte-for-byte")
+	}
+}
+
+// The rule that decides whether an export gets applied to a document.
+// Getting this wrong in one direction refuses legitimate packages; in
+// the other it lets a broken template through — so it is worth pinning
+// against the shapes that actually occur.
+func TestIsDocumentTemplate(t *testing.T) {
+	cases := []struct {
+		name   string
+		params string
+		want   bool
+	}{
+		{"house report", `title: "Untitled", subtitle: none, author: none, date: datetime.today().display("[year]"), body`, true},
+		{"body only", "body", true},
+		{"named then body", `title: "x", body`, true},
+		{"a helper taking one positional", "colour", false},
+		{"a helper taking several", "colour, width", false},
+		{"no parameters", "", false},
+		{"all named", `title: "x", subtitle: none`, false},
+		{"body not last", `body, extra`, false},
+		{"a default containing a comma", `date: datetime.today().display("[year]-[month]"), body`, true},
+		{"a default containing brackets", `caption: [a, b], body`, true},
+		{"named body is not positional", `body: []`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDocumentTemplate(tc.params); got != tc.want {
+				t.Errorf("isDocumentTemplate(%q) = %v, want %v", tc.params, got, tc.want)
+			}
+		})
+	}
+}
+
+// The real house template is the fixture that matters: report and adr
+// must both be recognised, and the underscore-prefixed internals must
+// not be — they are not exported and applying them would be nonsense.
+func TestDocumentTemplateExports_HouseTemplate(t *testing.T) {
+	lib := filepath.Join(repoTemplates(t), templateNamespace, templateName, templateVersion, "lib.typ")
+	got := documentTemplateExports(lib)
+	if want := []string{"adr", "report"}; !equalStrings(got, want) {
+		t.Errorf("documentTemplateExports = %v, want %v", got, want)
+	}
+}
+
+// Parameter lists span lines and contain nested calls; the parser has
+// to survive both or it silently classifies a real template as a helper.
+func TestLetDeclarations_MultilineAndNested(t *testing.T) {
+	src := `// #let decoy(body) = none   <- a comment, not a declaration
+#let _private(body) = body
+#let report(
+  title: "Untitled",
+  date: datetime.today().display("[year]-[month]-[day]"),
+  body,
+) = {
+  body
+}
+#let accent = rgb("#006566")
+`
+	decls := letDeclarations(src)
+	var names []string
+	for _, d := range decls {
+		names = append(names, d.name)
+	}
+	if !containsString(names, "report") {
+		t.Fatalf("multiline declaration not found: %v", names)
+	}
+	if containsString(names, "_private") {
+		t.Errorf("an underscore-prefixed internal was treated as an export: %v", names)
+	}
+	if containsString(names, "accent") {
+		t.Errorf("a value binding was treated as a function: %v", names)
+	}
+	for _, d := range decls {
+		if d.name == "report" && !isDocumentTemplate(d.params) {
+			t.Errorf("multiline report not recognised as a template; params = %q", d.params)
+		}
+	}
+}

--- a/templates/README.md
+++ b/templates/README.md
@@ -60,6 +60,25 @@ Export a function from `lib.typ`. This is the path for a type that
 should exist for everyone, on every deployment: it ships in the binary,
 is covered by the tests below, and seeds onto every volume.
 
+### By publishing (anyone, into a namespace they own)
+
+`publish_template` takes a workspace directory holding `typst.toml` and
+the entrypoint and installs it as `@<namespace>/<name>:<version>`.
+Everyone has their own namespace, so this needs nothing granted.
+
+Two rules do the work:
+
+- **It must compile before it is accepted.** The package is staged and a
+  document is compiled against it, and every export whose last parameter
+  is a positional `body` — the shape `#show:` supplies — is also applied
+  with default arguments. That second part is not optional: typst
+  evaluates lazily, so a template referencing a logo it forgot to ship
+  imports cleanly and only fails when somebody calls it. Which is to
+  say, it fails for everyone except the person who published it.
+- **A published version is immutable.** Documents pin what they import,
+  so replacing `1.0.0` would change how already-written documents
+  render. Publish `1.0.1`; the old version keeps working.
+
 ### On the data volume (operator, immediate)
 
 Because seeding never overwrites, anything already at


### PR DESCRIPTION
Everything so far could *read* templates; the only way to write one was an operator editing the volume by hand. `publish_template` takes a package staged in the caller's workspace and installs it as `@<namespace>/<name>:<version>`.

Everyone owns a namespace, so a first template needs nobody to grant anything. Ownership settles who may publish — and for a personal namespace it's true by construction, which is why this rung didn't have to wait on a multi-party permission model.

## The compile check

**Importing the package is not a sufficient gate**, and finding that out was the interesting part. typst evaluates lazily, so a template referencing a logo it forgot to ship imports perfectly cleanly and only fails when somebody *calls* it — which is to say, for everyone except its author. `TestPublish_MissingAssetIsCaught` was passing for the wrong reason until I fixed an unrelated bug and it turned red.

So every document template is also **applied**, as `#show: report.with()` with arguments omitted — because that's what a model will do, and it's the case most likely to be broken.

**One heuristic had to be thrown away.** My first attempt classified failures by reading typst's error text to tell "broken" from "not that kind of thing". That isn't decidable: `swatch(colour)` and `report(…, body)` have identical shapes, and a helper misapplied as a show rule fails with a type error indistinguishable from a real defect. The rule is structural instead — a document template's final parameter is the positional `body` that `#show:` supplies. A convention, but one the house templates and the wider ecosystem follow, and it never refuses a package for exporting a helper. Pinned by a table test and against the real `lib.typ`.

## Immutability

A published version can't be replaced. Less a policy than a consequence of documents pinning what they import: if `1.0.0` could be overwritten, a bad publish would retroactively change documents that compiled yesterday. The error says to publish `1.0.1` instead, and a test asserts both versions then coexist.

## Coverage

13 publish tests: happy path through to importing what was just published; broken template refused with the typst error and nothing left on disk; missing asset caught; asset and binary asset round-tripping byte-for-byte; ownership required; built-in not writable; version shapes typst rejects rejected here; staged compile artefacts not published; appears in `list_templates`.

## Unrelated fix included

The devcontainer rebuild exposed a latent test bug: `findSystemFont` took the first font it saw, which on a machine with real fonts is a 6MB face that doesn't fit through `put_file`. `filepath.Walk` reports symlinks with `Lstat`, so the size looked fine until the upload failed. Now picks the smallest regular file under the limit.

## Ladder

- [x] 1–4 (#78, #79, #99)
- [x] **5. Organisation-scoped template management** ← publishing lands here; promoting a member to owner in the admin UI is the remaining piece, needed before a *shared* namespace can be published to by anyone but an admin.

Refers #63