### PR TITLE
feat(auth): dev backend that selects a real identity without credentials

### DIFF
--- a/cmd/typst-d2-mcp/devauth_test.go
+++ b/cmd/typst-d2-mcp/devauth_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/auth"
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+)
+
+// The whole reason dev auth exists: a caller who never authenticates
+// still gets a REAL identity, which means a real personal namespace to
+// publish into. An identity that skipped that would exercise a code
+// path nothing in production uses.
+func TestDevAuth_GivesARealIdentityWithANamespace(t *testing.T) {
+	store, err := authdb.Open(filepath.Join(t.TempDir(), "auth.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	dev := &auth.Dev{Store: store}
+	r := httptest.NewRequest("POST", "/mcp", nil)
+	r.Header.Set(auth.DevUserHeader, "octocat")
+
+	id, err := dev.IdentifyFromRequest(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id.IsAnonymous() {
+		t.Fatal("dev auth produced an anonymous identity")
+	}
+
+	ns, err := store.NamespacesForUser(context.Background(), id.UserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ns) == 0 {
+		t.Fatal("no personal namespace for a dev identity — publishing would be impossible")
+	}
+
+	// And they own it, so they can publish without anything granted.
+	for _, nsID := range ns {
+		role, err := store.RoleFor(context.Background(), nsID, id.UserID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if role != authdb.RoleOwner {
+			t.Errorf("role = %q, want %q", role, authdb.RoleOwner)
+		}
+	}
+}
+
+// Two dev users are two tenants — separate namespaces, separate
+// workspaces. Without this, every multi-user scenario would be
+// untestable.
+func TestDevAuth_UsersAreDistinctTenants(t *testing.T) {
+	store, err := authdb.Open(filepath.Join(t.TempDir(), "auth.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	dev := &auth.Dev{Store: store}
+
+	ids := map[string]string{}
+	for _, login := range []string{"alice", "bob"} {
+		r := httptest.NewRequest("POST", "/mcp", nil)
+		r.Header.Set(auth.DevUserHeader, login)
+		id, err := dev.IdentifyFromRequest(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids[login] = id.UserID
+	}
+	if ids["alice"] == ids["bob"] {
+		t.Fatal("two dev users share one identity")
+	}
+
+	alice, _ := store.NamespacesForUser(context.Background(), ids["alice"])
+	bob, _ := store.NamespacesForUser(context.Background(), ids["bob"])
+	for name := range alice {
+		if _, shared := bob[name]; shared {
+			t.Errorf("namespace %q is visible to both tenants", name)
+		}
+	}
+}
+
+// selectAuth must not produce a dev backend by accident — it is opt-in
+// by an exact value, never a fallback.
+func TestSelectAuth_DevIsOptIn(t *testing.T) {
+	for _, mode := range []string{"", "none"} {
+		t.Setenv(envAuth, mode)
+		backend, _, _, closer, err := selectAuth()
+		if err != nil {
+			t.Fatalf("selectAuth(%q): %v", mode, err)
+		}
+		if closer != nil {
+			closer()
+		}
+		if _, isDev := backend.(*auth.Dev); isDev {
+			t.Errorf("AUTH=%q produced the dev backend", mode)
+		}
+	}
+
+	t.Setenv(envAuth, "dev")
+	t.Setenv(envDB, filepath.Join(t.TempDir(), "auth.sqlite"))
+	backend, _, store, closer, err := selectAuth()
+	if err != nil {
+		t.Fatalf("AUTH=dev: %v", err)
+	}
+	if closer != nil {
+		defer closer()
+	}
+	if _, isDev := backend.(*auth.Dev); !isDev {
+		t.Errorf("AUTH=dev produced %T", backend)
+	}
+	if store == nil {
+		t.Error("dev auth without a store cannot provision namespaces")
+	}
+}
+
+// Without a database there are no real identities to select, so this
+// must fail at startup rather than degrade to anonymous.
+func TestSelectAuth_DevRequiresADatabase(t *testing.T) {
+	t.Setenv(envAuth, "dev")
+	t.Setenv(envDB, "")
+	if _, _, _, closer, err := selectAuth(); err == nil {
+		if closer != nil {
+			closer()
+		}
+		t.Error("AUTH=dev started without a database")
+	}
+}

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -57,6 +57,7 @@ const (
 	envWorkspaceBudget = "TYPST_D2_MCP_WORKSPACE_BUDGET_BYTES"
 
 	envAuth            = "TYPST_D2_MCP_AUTH"
+	envDevUser         = "TYPST_D2_MCP_DEV_USER"
 	envDB              = "TYPST_D2_MCP_DB"
 	envPublicURL       = "TYPST_D2_MCP_PUBLIC_URL"
 	envGitHubID        = "TYPST_D2_MCP_GITHUB_CLIENT_ID"
@@ -661,8 +662,26 @@ func selectAuth() (auth.Backend, *gitHubHandlers, *authdb.Store, func(), error) 
 			authorize:           gh.ServeAuthorize,
 			token:               gh.ServeToken,
 		}, store, closer, nil
+	case "dev":
+		// Real identities, no credentials. Selected explicitly and
+		// never as a fallback, and refused on a non-loopback bind (see
+		// auth.RequireLoopback, enforced in serve).
+		dbPath := os.Getenv(envDB)
+		if dbPath == "" {
+			return nil, nil, nil, nil, fmt.Errorf("%s=dev requires %s to be set", envAuth, envDB)
+		}
+		store, err := authdb.Open(dbPath)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("open auth db: %w", err)
+		}
+		dev := &auth.Dev{
+			Store:        store,
+			DefaultLogin: os.Getenv(envDevUser),
+			AdminLogins:  parseAllowlist(os.Getenv(envAdmins)),
+		}
+		return dev, nil, store, func() { _ = store.Close() }, nil
 	default:
-		return nil, nil, nil, nil, fmt.Errorf("unknown %s=%q (expected none or github)", envAuth, mode)
+		return nil, nil, nil, nil, fmt.Errorf("unknown %s=%q (expected none, github or dev)", envAuth, mode)
 	}
 }
 
@@ -698,6 +717,18 @@ func serve(s *server.MCPServer, backend auth.Backend, gh *gitHubHandlers, factor
 		addr := os.Getenv(envAddr)
 		if addr == "" {
 			addr = defaultAddr
+		}
+		// Dev auth grants any identity to anyone who can reach the
+		// port, so a non-loopback bind is not something to warn about.
+		// Refusing to start is the only guard that survives somebody
+		// leaving AUTH=dev set in an environment where it stops being
+		// harmless.
+		if _, isDev := backend.(*auth.Dev); isDev {
+			if err := auth.RequireLoopback(addr); err != nil {
+				return err
+			}
+			slog.Warn("DEV AUTH ENABLED — every request is whoever it says it is",
+				"header", auth.DevUserHeader, "addr", addr)
 		}
 		path := os.Getenv(envPath)
 		if path == "" {

--- a/internal/auth/dev.go
+++ b/internal/auth/dev.go
@@ -1,0 +1,162 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+)
+
+// Dev identifies a request by a header naming a user, with no
+// credentials at all. It exists so a developer — or an agent under
+// test — can BE a particular person without a browser OAuth round trip,
+// which is otherwise impossible to automate.
+//
+// The identities are real. Dev upserts the named login into the users
+// table, so the caller gets a genuine user row, a personal namespace,
+// their own workspace and their own quota. That is the point: an auth
+// mode that hands out a fake identity would exercise a code path
+// nothing in production uses, and would prove nothing about the paths
+// that matter — membership, ownership, publishing.
+//
+// It is not a "bypass" in the sense of weakening the GitHub backend.
+// It is a separate backend selected by configuration, which is what the
+// Backend interface is for; nothing about GitHub sign-in changes.
+//
+// Two guards keep it where it belongs. Selecting it is explicit
+// (TYPST_D2_MCP_AUTH=dev — never a fallback, never a default), and
+// RequireLoopback refuses a non-loopback bind, so leaving it on cannot
+// quietly expose a server to a network.
+type Dev struct {
+	// Store upserts and looks up the named user. Required.
+	Store DevStore
+
+	// DefaultLogin is used when a request names nobody. Empty means an
+	// unnamed request is anonymous, which keeps the "no header" case
+	// honest rather than silently privileged.
+	DefaultLogin string
+
+	// AdminLogins may reach the admin UI, mirroring the GitHub backend's
+	// allowlist so the same deployment config works in both modes.
+	AdminLogins map[string]bool
+}
+
+// DevStore is the slice of authdb.Store that Dev needs.
+type DevStore interface {
+	UpsertGitHubUser(ctx context.Context, githubID int64, login, email string) (int64, error)
+}
+
+// DevUserHeader names the identity a request should be treated as.
+const DevUserHeader = "X-Dev-User"
+
+// IdentifyFromRequest resolves the header (or the default) to a real
+// user row.
+//
+// A login maps to a stable synthetic GitHub id, so "octocat" is the
+// same person across restarts and across passes — workspaces, quota and
+// namespaces all persist for them the way they would for a real
+// account. Without that stability every run would be a new tenant and
+// nothing about returning users could be tested.
+func (d *Dev) IdentifyFromRequest(r *http.Request) (identity.Identity, error) {
+	login := strings.ToLower(strings.TrimSpace(r.Header.Get(DevUserHeader)))
+	if login == "" {
+		login = strings.ToLower(strings.TrimSpace(d.DefaultLogin))
+	}
+	if login == "" {
+		return identity.Anonymous(), nil
+	}
+	if !validDevLogin(login) {
+		return identity.Identity{}, fmt.Errorf("invalid %s header %q", DevUserHeader, login)
+	}
+	if d.Store == nil {
+		return identity.Identity{}, fmt.Errorf("dev auth requires a store")
+	}
+
+	id := devGitHubID(login)
+	if _, err := d.Store.UpsertGitHubUser(r.Context(), id, login, login+"@dev.invalid"); err != nil {
+		return identity.Identity{}, fmt.Errorf("upsert dev user %q: %w", login, err)
+	}
+	return identity.Identity{
+		UserID:      "gh:" + strconv.FormatInt(id, 10),
+		GitHubLogin: login,
+		Email:       login + "@dev.invalid",
+	}, nil
+}
+
+// Name returns the backend's startup label. It says "dev" loudly on
+// purpose: this string ends up in the startup log an operator reads.
+func (d *Dev) Name() string { return "dev (NO AUTHENTICATION — identity from " + DevUserHeader + ")" }
+
+// IsAdmin reports whether a login administers this server.
+func (d *Dev) IsAdmin(login string) bool {
+	return d.AdminLogins[strings.ToLower(strings.TrimSpace(login))]
+}
+
+// devGitHubID maps a login to a stable id in a range real GitHub
+// accounts do not occupy, so a dev user can never collide with a real
+// one in a database that has seen both.
+func devGitHubID(login string) int64 {
+	const devIDBase = 1 << 40
+	var h int64 = 1469598103934665603 // FNV-1a offset basis, 64-bit
+	for i := 0; i < len(login); i++ {
+		h ^= int64(login[i])
+		h *= 1099511628211
+	}
+	if h < 0 {
+		h = -h
+	}
+	return devIDBase + h%(1<<30)
+}
+
+// validDevLogin keeps the header to GitHub's own login grammar, so a
+// dev identity cannot be something a real one could never be.
+func validDevLogin(s string) bool {
+	if len(s) == 0 || len(s) > 39 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '-' && i != 0 && i != len(s)-1:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// RequireLoopback reports an error unless addr binds only the loopback
+// interface.
+//
+// Dev auth grants any identity to anyone who can reach the port, so a
+// non-loopback bind is not a configuration to warn about — it is one to
+// refuse. The check is on the address rather than on a promise in the
+// documentation, because the failure mode is somebody leaving
+// AUTH=dev set in an environment where it stops being harmless.
+func RequireLoopback(addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// No port separator: treat the whole thing as a host.
+		host = addr
+	}
+	host = strings.TrimSpace(host)
+	switch host {
+	case "localhost":
+		return nil
+	case "", "0.0.0.0", "[::]", "::":
+		return fmt.Errorf("refusing to serve dev auth on %q: it accepts connections from "+
+			"any interface, and dev auth grants any identity without credentials. "+
+			"Bind 127.0.0.1 instead", addr)
+	}
+	ip := net.ParseIP(strings.Trim(host, "[]"))
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf("refusing to serve dev auth on %q: dev auth grants any identity "+
+			"without credentials, so it may only bind the loopback interface", addr)
+	}
+	return nil
+}

--- a/internal/auth/dev_test.go
+++ b/internal/auth/dev_test.go
@@ -1,0 +1,150 @@
+package auth
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type fakeDevStore struct {
+	upserts []string
+}
+
+func (f *fakeDevStore) UpsertGitHubUser(_ context.Context, _ int64, login, _ string) (int64, error) {
+	f.upserts = append(f.upserts, login)
+	return 1, nil
+}
+
+func identifyAs(t *testing.T, d *Dev, login string) (string, error) {
+	t.Helper()
+	r := httptest.NewRequest("POST", "/mcp", nil)
+	if login != "" {
+		r.Header.Set(DevUserHeader, login)
+	}
+	id, err := d.IdentifyFromRequest(r)
+	return id.UserID, err
+}
+
+// The header names who you are, and the answer is stable — a dev user's
+// workspace, quota and namespace have to persist across restarts or
+// nothing about a returning user can be tested.
+func TestDev_HeaderSelectsAStableIdentity(t *testing.T) {
+	d := &Dev{Store: &fakeDevStore{}}
+
+	first, err := identifyAs(t, d, "octocat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == "" {
+		t.Fatal("no identity returned")
+	}
+	again, err := identifyAs(t, d, "OCTOCAT") // case-insensitive, like GitHub
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != first {
+		t.Errorf("identity is not stable: %q then %q", first, again)
+	}
+
+	other, err := identifyAs(t, d, "hubot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other == first {
+		t.Errorf("two logins collapsed to one identity: %q", other)
+	}
+}
+
+// An unnamed request must not silently become somebody. Anonymous is
+// the honest answer.
+func TestDev_NoHeaderIsAnonymous(t *testing.T) {
+	d := &Dev{Store: &fakeDevStore{}}
+	got, err := identifyAs(t, d, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "anonymous" {
+		t.Errorf("unnamed request = %q, want anonymous", got)
+	}
+}
+
+func TestDev_DefaultLoginApplies(t *testing.T) {
+	d := &Dev{Store: &fakeDevStore{}, DefaultLogin: "octocat"}
+	got, err := identifyAs(t, d, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "anonymous" || got == "" {
+		t.Errorf("default login not applied: %q", got)
+	}
+}
+
+// The header must not be a way to invent an identity shaped like
+// something a real login could never be.
+func TestDev_RejectsMalformedLogins(t *testing.T) {
+	d := &Dev{Store: &fakeDevStore{}}
+	for _, login := range []string{
+		"has space", "under_score", "-leading", "trailing-",
+		"sym$bol", strings.Repeat("a", 40), "../etc/passwd", "a/b",
+	} {
+		if _, err := identifyAs(t, d, login); err == nil {
+			t.Errorf("login %q was accepted", login)
+		}
+	}
+}
+
+// A dev identity must never collide with a real GitHub account in a
+// database that has seen both.
+func TestDev_IDsCannotCollideWithRealAccounts(t *testing.T) {
+	const highestPlausibleRealID = 1 << 39 // GitHub ids are far below this
+	for _, login := range []string{"a", "octocat", "hubot", "some-long-login-name"} {
+		if got := devGitHubID(login); got <= highestPlausibleRealID {
+			t.Errorf("devGitHubID(%q) = %d, inside the real GitHub id range", login, got)
+		}
+	}
+}
+
+// The store is what makes the identity real; without one, fail rather
+// than hand back something that looks authenticated.
+func TestDev_WithoutAStoreItFails(t *testing.T) {
+	d := &Dev{}
+	if _, err := identifyAs(t, d, "octocat"); err == nil {
+		t.Error("identified a user with no store")
+	}
+}
+
+// The guard that matters. Dev auth grants any identity to anyone who
+// can reach the port, so exposure is refused rather than warned about.
+func TestRequireLoopback(t *testing.T) {
+	ok := []string{"127.0.0.1:8080", "localhost:8080", "[::1]:8080", "127.0.0.1", "::1"}
+	for _, addr := range ok {
+		if err := RequireLoopback(addr); err != nil {
+			t.Errorf("RequireLoopback(%q) = %v, want nil", addr, err)
+		}
+	}
+	bad := []string{":8080", "0.0.0.0:8080", "[::]:8080", "192.168.1.5:8080", "10.0.0.1:80", "example.com:8080"}
+	for _, addr := range bad {
+		if err := RequireLoopback(addr); err == nil {
+			t.Errorf("RequireLoopback(%q) = nil, want an error — this would expose dev auth", addr)
+		}
+	}
+}
+
+// The startup label has to be unmissable in a log.
+func TestDev_NameIsLoud(t *testing.T) {
+	name := (&Dev{}).Name()
+	if !strings.Contains(name, "NO AUTHENTICATION") {
+		t.Errorf("Name() = %q — an operator scanning logs must see what this is", name)
+	}
+}
+
+func TestDev_AdminAllowlist(t *testing.T) {
+	d := &Dev{AdminLogins: map[string]bool{"dlouwers": true}}
+	if !d.IsAdmin("DLouwers") {
+		t.Error("admin check should be case-insensitive")
+	}
+	if d.IsAdmin("octocat") {
+		t.Error("non-admin treated as admin")
+	}
+}


### PR DESCRIPTION
Automating anything that touches a namespace was impossible, which blocks testing roughly half of what #63 built.

- `AUTH=none` leaves the store nil (`main.go:622`), so a caller is anonymous: no user row, no personal namespace, no publishing, `list_templates` showing only the house package.
- `AUTH=github` needs a browser OAuth round trip, which no automated caller can complete.

`AUTH=dev` names the caller in a header (`X-Dev-User: octocat`) and gives them a **real** identity — the login is upserted, so there's a genuine user row, a personal namespace, a workspace and a quota.

That distinction is the design, not an implementation detail: a mode that handed out a *synthetic* identity would exercise a code path nothing in production uses, and would prove nothing about the paths that matter — membership, ownership, publishing. `auth.Backend` is a two-method interface whose doc comment says the split exists so the rest of the server stays oblivious to the mechanism; this is that, not a bypass bolted onto GitHub sign-in, which is untouched.

## Stability

Logins map to stable ids in a range real GitHub accounts don't occupy. Stable because otherwise every run is a fresh tenant and nothing about a *returning* user can be tested; out-of-range because a dev identity must never collide with a real account in a database that has seen both.

## Two guards

**Selection is explicit.** `dev` exactly — never a fallback, never reached from an empty or unknown value. A test asserts `AUTH=""` and `AUTH=none` cannot produce it.

**Non-loopback binds are refused, not warned about.** Dev auth grants any identity to anyone who can reach the port, so `0.0.0.0`, a bare `:8080`, or a LAN address makes the server exit with an explanation. That's the guard that survives someone leaving `AUTH=dev` set in an environment where it stops being harmless — a doc note wouldn't. The startup label reads `NO AUTHENTICATION` in capitals because it lands in the log an operator scans.

## Verified over HTTP, not just in unit tests

Booted the server with `AUTH=dev` and drove it with raw JSON-RPC. A request carrying nothing but the header provisions both rows:

```
users:            1099912786523 | alice
namespace_names:  gh-1099912786523 → ns-89d601d8fd07f6d3
```

`initialize` also confirms the #95 instruction reordering lands in a real client — the payload starts with `TEMPLATES — READ THIS FIRST`. Two logins resolve to two tenants with disjoint namespaces.

## Known limitation

The admin UI is still gated on `*auth.GitHub`, so `/admin` isn't reachable under dev auth. Org setup for testing has to go through the store directly. Worth wiring later if it gets in the way.

Refers #63