### PR TITLE
fix(fonts): route workspace fonts through the package view (#107)

### DIFF
--- a/cmd/typst-d2-mcp/capabilities_test.go
+++ b/cmd/typst-d2-mcp/capabilities_test.go
@@ -42,7 +42,7 @@ func TestWorkspaceInfo_ReportsCapabilities(t *testing.T) {
 
 	root := t.TempDir()
 	factory := workspace.TenantFactory{Root: root}
-	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "gh:4242"})
 
 	info := wsInfo(t, ctx, factory)
 
@@ -87,10 +87,15 @@ func TestRenderEnvironment_HasProportionalSans(t *testing.T) {
 
 // A tenant's own typefaces have to reach the compiler, or an
 // organisation template cannot use the organisation's typeface.
-func TestTypstArgs_IncludesWorkspaceFontPath(t *testing.T) {
+//
+// They reach it through the package view, NOT as the tenant's own path:
+// a tenant root is <root>/gh:<id> and typst splits --font-path on ":",
+// so naming that path directly was silently discarded (#107).
+func TestTypstArgs_WorkspaceFontsReachTypstViaTheView(t *testing.T) {
 	root := t.TempDir()
-	tenant := filepath.Join(root, "user123")
-	if err := os.MkdirAll(tenant, 0o755); err != nil {
+	tenant := filepath.Join(root, "gh:4242")
+	fonts := filepath.Join(tenant, FontsDir)
+	if err := os.MkdirAll(fonts, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	r, err := workspace.NewScopedFS(tenant)
@@ -98,18 +103,19 @@ func TestTypstArgs_IncludesWorkspaceFontPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Absent is the normal case: no flag, no error.
-	if got := strings.Join(typstArgs(r, "in.typ", "out.pdf"), " "); strings.Contains(got, "--font-path") {
-		t.Errorf("font path passed for a workspace with no fonts dir: %s", got)
-	}
-
-	if err := os.MkdirAll(filepath.Join(tenant, FontsDir), 0o755); err != nil {
+	data := t.TempDir()
+	view, cleanup, err := packageView(data, map[string]string{}, workspaceFontPath(r))
+	if err != nil {
 		t.Fatal(err)
 	}
-	got := strings.Join(typstArgs(r, "in.typ", "out.pdf"), " ")
-	want := "--font-path " + filepath.Join(tenant, FontsDir)
-	if !strings.Contains(got, want) {
-		t.Errorf("args = %s, want it to contain %s", got, want)
+	defer cleanup()
+
+	got := strings.Join(typstArgs(r, "in.typ", "out.pdf", packageFontPath(view)), " ")
+	if !strings.Contains(got, "--font-path "+view) {
+		t.Errorf("args = %s, want the view passed as a font path", got)
+	}
+	if strings.Contains(got, tenant+"/"+FontsDir) {
+		t.Errorf("the tenant path was passed directly; typst would split it: %s", got)
 	}
 }
 
@@ -158,7 +164,7 @@ func TestCompile_WorkspaceFontIsUsable(t *testing.T) {
 	src := findSystemFont(t)
 	root := t.TempDir()
 	factory := workspace.TenantFactory{Root: root}
-	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "gh:4242"})
 
 	raw, err := os.ReadFile(src)
 	if err != nil {
@@ -179,7 +185,7 @@ func TestCompile_WorkspaceFontIsUsable(t *testing.T) {
 		t.Fatalf("put_file font: %s", resultText(res))
 	}
 
-	resolver, err := factory.Resolver(identity.Identity{UserID: "user123"})
+	resolver, err := factory.Resolver(identity.Identity{UserID: "gh:4242"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,8 +230,30 @@ func TestCompile_WorkspaceFontIsUsable(t *testing.T) {
 // system and typst-embedded fonts excluded.
 func familiesFromPathOnly(t *testing.T, dir string) []string {
 	t.Helper()
+	// Copy to a colon-free directory first. This helper asks "what does
+	// this font file provide", and a tenant path contains a colon that
+	// typst would split — the very bug under test (#107). Probing
+	// through it would make this helper fail for reasons unrelated to
+	// what it is measuring.
+	clean := t.TempDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		raw, readErr := os.ReadFile(filepath.Join(dir, e.Name()))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if writeErr := os.WriteFile(filepath.Join(clean, e.Name()), raw, 0o644); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+	}
 	out, err := exec.Command("typst", "fonts",
-		"--font-path", dir,
+		"--font-path", clean,
 		"--ignore-system-fonts",
 		"--ignore-embedded-fonts",
 	).Output()
@@ -258,7 +286,7 @@ func TestCompile_UnknownFontStillWarns(t *testing.T) {
 
 	root := t.TempDir()
 	factory := workspace.TenantFactory{Root: root}
-	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "gh:4242"})
 
 	if res := putFile(t, ctx, factory, "doc.typ",
 		"#set text(font: \"No Such Family At All\")\n= Title\n"); res.IsError {

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -1295,7 +1295,7 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 			log.Error("namespace resolution failed", "err", err)
 			return mcp.NewToolResultErrorFromErr("resolve template namespaces", err), nil
 		}
-		view, cleanupView, err := packageView(typstDataDir(), allowed)
+		view, cleanupView, err := packageView(typstDataDir(), allowed, workspaceFontPath(resolver))
 		if err != nil {
 			metrics.CompileTotal.WithLabelValues(metrics.ResultFail).Inc()
 			log.Error("package view failed", "err", err)
@@ -1415,24 +1415,24 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 // "workspace" is the user's filesystem) gets no --root, leaving typst's
 // default of the input file's own directory.
 //
-// A workspace fonts/ directory, if present, is added as a font path so
-// a tenant can set documents in its own typefaces. The path is inside
-// the tenant's own root, so one workspace's fonts are not visible to
-// another.
-//
-// extraFontPaths carries font directories the caller has already
-// resolved — today the package view, so a template can ship the
-// typeface it is designed in. Empty strings are ignored.
+// Fonts reach typst through the package view, never as the tenant's own
+// path. A tenant root is <root>/gh:<id>, and typst splits --font-path on
+// ":" — so naming that path directly silently discarded it, which is
+// what #107 was. extraFontPaths therefore carries view paths, and a
+// path that cannot survive the command line is dropped with a warning
+// rather than passed and quietly ignored.
 func typstArgs(r workspace.Resolver, in, out string, extraFontPaths ...string) []string {
 	args := []string{"compile"}
 	if b, ok := r.(workspace.Bounded); ok {
 		args = append(args, "--root", b.WorkspaceRoot())
 	}
-	if fonts := workspaceFontPath(r); fonts != "" {
-		args = append(args, "--font-path", fonts)
-	}
 	for _, p := range extraFontPaths {
-		if p != "" {
+		switch {
+		case p == "":
+		case !safeFontPath(p):
+			slog.Error("refusing to pass a font path containing the list separator; "+
+				"fonts from it would be silently ignored", "path", p)
+		default:
 			args = append(args, "--font-path", p)
 		}
 	}

--- a/cmd/typst-d2-mcp/namespaces.go
+++ b/cmd/typst-d2-mcp/namespaces.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
 	"github.com/dlouwers/typst-d2-mcp/internal/identity"
@@ -87,7 +88,7 @@ func sortedNames(allowed map[string]string) []string {
 // A namespace with no directory in the store is skipped rather than
 // failing: an organisation exists in the schema before anyone publishes
 // a template to it (rung 5), and that is not an error.
-func packageView(dataDir string, allowed map[string]string) (string, func(), error) {
+func packageView(dataDir string, allowed map[string]string, workspaceFonts string) (string, func(), error) {
 	viewRoot, err := os.MkdirTemp("", "typst-d2-pkgview-*")
 	if err != nil {
 		return "", nil, fmt.Errorf("create package view: %w", err)
@@ -112,6 +113,26 @@ func packageView(dataDir string, allowed map[string]string) (string, func(), err
 		if linkErr := os.Symlink(src, filepath.Join(pkgDir, name)); linkErr != nil {
 			cleanup()
 			return "", nil, fmt.Errorf("link namespace %s: %w", name, linkErr)
+		}
+	}
+
+	// The tenant's own fonts are linked in HERE rather than passed to
+	// typst directly, and that is the whole fix for #107.
+	//
+	// typst splits --font-path on the OS path-list separator, which on
+	// Unix is ":". A tenant workspace is rooted at <root>/gh:<id>, so
+	// its font directory ALWAYS contains a colon, and the path was
+	// always silently split into two nonexistent directories. typst
+	// then substituted and exited 0 — a PDF that looks fine and is
+	// wrong, which is the exact failure #92 was filed about.
+	//
+	// The view root is a mkdtemp path with no colon in it, so a link
+	// from here is safe to name on a command line however the tenant
+	// directory is spelled.
+	if workspaceFonts != "" {
+		if linkErr := os.Symlink(workspaceFonts, filepath.Join(viewRoot, FontsDir)); linkErr != nil {
+			cleanup()
+			return "", nil, fmt.Errorf("link workspace fonts: %w", linkErr)
 		}
 	}
 	return viewRoot, cleanup, nil
@@ -147,5 +168,16 @@ func packageFontPath(view string) string {
 	if view == "" {
 		return ""
 	}
-	return filepath.Join(view, "typst", "packages")
+	// The view root, not the packages subdirectory: typst searches a
+	// font path recursively, so one colon-free path covers both the
+	// templates' own fonts and the tenant's linked fonts/ directory.
+	return view
+}
+
+// safeFontPath reports whether p can survive being named on a typst
+// command line. A path containing the OS list separator is split into
+// pieces that do not exist, and typst says nothing about it — so this
+// is checked rather than assumed. See #107.
+func safeFontPath(p string) bool {
+	return !strings.Contains(p, string(os.PathListSeparator))
 }

--- a/cmd/typst-d2-mcp/namespaces_test.go
+++ b/cmd/typst-d2-mcp/namespaces_test.go
@@ -131,7 +131,7 @@ func TestPackageView_ExposesOnlyAllowed(t *testing.T) {
 	writePackage(t, data, "acme", "1.0.0")
 	writePackage(t, data, "globex", "1.0.0")
 
-	view, cleanup, err := packageView(data, map[string]string{"house": "house", "acme": "acme"})
+	view, cleanup, err := packageView(data, map[string]string{"house": "house", "acme": "acme"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestPackageView_UnpublishedNamespaceIsSkipped(t *testing.T) {
 	data := t.TempDir()
 	writePackage(t, data, "house", "0.1.0")
 
-	view, cleanup, err := packageView(data, map[string]string{"house": "house", "brand-new-org": "ns-unpublished"})
+	view, cleanup, err := packageView(data, map[string]string{"house": "house", "brand-new-org": "ns-unpublished"}, "")
 	if err != nil {
 		t.Fatalf("an org with nothing published broke the view: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestPackageView_UnpublishedNamespaceIsSkipped(t *testing.T) {
 func TestPackageView_CleanupRemovesIt(t *testing.T) {
 	data := t.TempDir()
 	writePackage(t, data, "house", "0.1.0")
-	view, cleanup, err := packageView(data, map[string]string{"house": "house"})
+	view, cleanup, err := packageView(data, map[string]string{"house": "house"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,8 +386,8 @@ func TestTypstArgs_PackageViewIsAFontPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := strings.Join(typstArgs(r, "in.typ", "out.pdf", packageFontPath("/the/view")), " ")
-	if want := "--font-path " + filepath.Join("/the/view", "typst", "packages"); !strings.Contains(got, want) {
-		t.Errorf("args = %s, want it to contain %s", got, want)
+	if !strings.Contains(got, "--font-path /the/view") {
+		t.Errorf("args = %s, want the view as a font path", got)
 	}
 
 	// An empty extra path must not produce a bare --font-path.
@@ -570,5 +570,69 @@ func TestCompile_ANameOnlyReachesItsOwnNamespace(t *testing.T) {
 	}
 	if got := resultText(res); !strings.Contains(got, "package not found") {
 		t.Errorf("expected an unresolved package, got: %s", got)
+	}
+}
+
+// #107: typst splits --font-path on the OS list separator, and a tenant
+// root is <root>/gh:<id> — so naming that path directly was always
+// discarded, silently. Nothing may reach the command line with a colon
+// in it.
+func TestTypstArgs_NeverPassesAColonInAFontPath(t *testing.T) {
+	root := t.TempDir()
+	tenant := filepath.Join(root, "gh:4242")
+	if err := os.MkdirAll(filepath.Join(tenant, FontsDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r, err := workspace.NewScopedFS(tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	args := typstArgs(r, "in.typ", "out.pdf", packageFontPath("/tmp/view-abc"), workspaceFontPath(r))
+	for i, a := range args {
+		if a == "--font-path" && i+1 < len(args) {
+			if strings.Contains(args[i+1], string(os.PathListSeparator)) {
+				t.Errorf("font path %q contains the list separator; typst would split and ignore it", args[i+1])
+			}
+		}
+	}
+}
+
+func TestSafeFontPath(t *testing.T) {
+	if !safeFontPath("/tmp/typst-d2-pkgview-123") {
+		t.Error("a plain path was rejected")
+	}
+	if safeFontPath("/workspaces/gh:4242/fonts") {
+		t.Error("a path containing a colon was accepted; typst would split it")
+	}
+}
+
+// The fix itself: a tenant's fonts must reach typst through the view,
+// whose root has no colon, and the link must resolve to the real files.
+func TestPackageView_LinksWorkspaceFonts(t *testing.T) {
+	data := t.TempDir()
+	writePackage(t, data, "house", "0.1.0")
+
+	tenant := filepath.Join(t.TempDir(), "gh:4242")
+	fonts := filepath.Join(tenant, FontsDir)
+	if err := os.MkdirAll(fonts, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fonts, "marker.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	view, cleanup, err := packageView(data, map[string]string{"house": "house"}, fonts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if strings.Contains(view, string(os.PathListSeparator)) {
+		t.Fatalf("the view root itself contains a separator: %q", view)
+	}
+	linked := filepath.Join(view, FontsDir, "marker.txt")
+	if _, err := os.Stat(linked); err != nil {
+		t.Errorf("tenant fonts are not reachable through the view: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #107 — found by a naive agent during the UX research programme, then isolated and verified.

## The bug

typst splits `--font-path` on the OS list separator (`:` on Unix). A tenant workspace is rooted at `<root>/gh:<github_id>`, so its font directory **always** contains a colon and the path was always split into two nonexistent directories and discarded. typst then substituted and exited 0 — a PDF that looks fine and is wrong, which is precisely the failure #92 was filed about.

Isolated to one variable, identical font file:

```
$ typst fonts --font-path /tmp/fontA    --ignore-system-fonts --ignore-embedded-fonts
Geist
$ typst fonts --font-path '/tmp/font:B' --ignore-system-fonts --ignore-embedded-fonts
(nothing)
```

## The fix

The tenant's `fonts/` directory is symlinked into the per-compile package view, and typst is given the **view root** — a `mkdtemp` path with no colon. One colon-free argument now covers both the templates' own fonts and the tenant's, since typst searches a font path recursively. Nothing about where fonts live on disk changes, so there's no migration.

A font path that cannot survive the command line is now **dropped with an error** rather than passed and silently ignored. The whole failure class here is typst saying nothing when a path yields nothing; the server shouldn't compound that.

## Why the tests missed it

They used `identity.Identity{UserID: "user123"}` — no colon. Unrealistic in exactly the dimension that hides the bug. They now use `gh:4242`, and `TestTypstArgs_NeverPassesAColonInAFontPath` asserts directly that no `--font-path` argument ever contains the list separator, so this cannot regress quietly.

One test helper was itself tripping over the bug once the identity became realistic (`typst fonts --font-path .../gh:4242/fonts` read nothing) — it now probes through a clean copy, since its job is "what does this file provide", not "does the server pass paths correctly".

## Verified against the original failing case

Over HTTP, `AUTH=dev`, real Geist Regular pushed with `put_file` into a `gh:<id>` workspace:

```
before:  warning: unknown font family: geist   → Libertinus substituted
after:   (no warning)                          → Geist-Regular embedded
```

Refers #107
Refers #92