### PR TITLE
fix(templates): let a caller find out which namespace is theirs (#108)

### DIFF
--- a/cmd/typst-d2-mcp/listtemplates.go
+++ b/cmd/typst-d2-mcp/listtemplates.go
@@ -40,9 +40,37 @@ type templateEntry struct {
 	Builtin   bool     `json:"builtin,omitempty"`
 }
 
+// namespaceEntry is a namespace the caller can reach, whether or not
+// anything has been published to it.
+//
+// Listing these is not a nicety. Templates alone answered "what can I
+// import", and left "where can I publish" unanswerable: a caller's own
+// namespace holds nothing until they publish, so it produced no
+// template rows and was invisible. Agents guessed names, were refused,
+// and concluded they had no namespace at all — while owning one (#108).
+type namespaceEntry struct {
+	Name      string `json:"name"`
+	Writable  bool   `json:"writable"`
+	Builtin   bool   `json:"builtin,omitempty"`
+	Templates int    `json:"templates"`
+}
+
 type listTemplatesResult struct {
-	Templates []templateEntry `json:"templates"`
-	Note      string          `json:"note,omitempty"`
+	Namespaces []namespaceEntry `json:"namespaces"`
+	Templates  []templateEntry  `json:"templates"`
+	Note       string           `json:"note,omitempty"`
+}
+
+// ownsNamespace reports whether the caller may publish to a namespace.
+func ownsNamespace(ctx context.Context, store *authdb.Store, id identity.Identity, nsID string) bool {
+	if store == nil || id.IsAnonymous() {
+		return false
+	}
+	role, err := store.RoleFor(ctx, nsID, id.UserID)
+	if err != nil {
+		return false // fail closed: never advertise a write you cannot do
+	}
+	return role == authdb.RoleOwner
 }
 
 func handleListTemplates(store *authdb.Store) server.ToolHandlerFunc {
@@ -53,16 +81,37 @@ func handleListTemplates(store *authdb.Store) server.ToolHandlerFunc {
 			return mcp.NewToolResultErrorFromErr("resolve template namespaces", err), nil
 		}
 
-		out := listTemplatesResult{Templates: []templateEntry{}}
+		out := listTemplatesResult{
+			Namespaces: []namespaceEntry{},
+			Templates:  []templateEntry{},
+		}
+		var writable []string
 		for _, name := range sortedNames(allowed) {
 			// Listed under the NAME, which is what goes in the import;
 			// read from the id, which is where the packages live.
-			out.Templates = append(out.Templates,
-				templatesInNamespace(typstDataDir(), name, allowed[name])...)
+			found := templatesInNamespace(typstDataDir(), name, allowed[name])
+			out.Templates = append(out.Templates, found...)
+
+			canPublish := name != builtinNamespace &&
+				ownsNamespace(ctx, store, id, allowed[name])
+			if canPublish {
+				writable = append(writable, name)
+			}
+			out.Namespaces = append(out.Namespaces, namespaceEntry{
+				Name:      name,
+				Writable:  canPublish,
+				Builtin:   name == builtinNamespace,
+				Templates: len(found),
+			})
 		}
-		if len(out.Templates) == 0 {
-			out.Note = "No templates are installed for you. Style the document yourself, " +
-				"or ask an administrator to publish one."
+		switch {
+		case len(writable) > 0 && len(out.Templates) == 0:
+			out.Note = fmt.Sprintf(
+				"No templates published yet. You can publish one to @%s with publish_template.",
+				writable[0])
+		case len(out.Templates) == 0:
+			out.Note = "No templates are available to you, and you own no namespace to " +
+				"publish one to. Style the document yourself, or ask an administrator."
 		}
 
 		payload, err := json.MarshalIndent(out, "", "  ")

--- a/cmd/typst-d2-mcp/listtemplates_test.go
+++ b/cmd/typst-d2-mcp/listtemplates_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
@@ -177,5 +178,99 @@ func TestListTemplates_RealHouseTemplateExports(t *testing.T) {
 	}
 	if want := []string{"adr", "report"}; !equalStrings(got.Templates[0].Exports, want) {
 		t.Errorf("exports = %v, want %v", got.Templates[0].Exports, want)
+	}
+}
+
+// #108: a caller who has published nothing must still be able to find
+// out which namespace is theirs. Two agents independently guessed
+// names, were refused, and concluded they owned nothing — while owning
+// a namespace the listing never mentioned.
+func TestListTemplates_NamesYourOwnEmptyNamespace(t *testing.T) {
+	// Nothing published anywhere: the case a new caller actually meets.
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+
+	store := newTestStore(t)
+	user := seedUser(t, store, "newcomer", 5)
+	ctx := identity.WithIdentity(context.Background(), user)
+
+	got := listTemplates(t, ctx, store)
+
+	var mine []string
+	for _, ns := range got.Namespaces {
+		if ns.Writable {
+			mine = append(mine, ns.Name)
+		}
+	}
+	if len(mine) != 1 {
+		t.Fatalf("writable namespaces = %v, want exactly the caller's own", mine)
+	}
+	if mine[0] != authdb.DerivedName(5) {
+		t.Errorf("writable namespace = %q, want %q", mine[0], authdb.DerivedName(5))
+	}
+
+	// The built-in is listed but not writable.
+	var sawBuiltin bool
+	for _, ns := range got.Namespaces {
+		if ns.Name == builtinNamespace {
+			sawBuiltin = true
+			if ns.Writable {
+				t.Error("the built-in namespace is advertised as writable")
+			}
+			if !ns.Builtin {
+				t.Error("the built-in is not flagged as such")
+			}
+		}
+	}
+	if !sawBuiltin {
+		t.Error("the built-in namespace is missing from the listing")
+	}
+
+	// With nothing published, the note points somewhere actionable
+	// rather than saying "no templates" and stopping.
+	if !strings.Contains(got.Note, authdb.DerivedName(5)) {
+		t.Errorf("note does not name a namespace to publish to: %q", got.Note)
+	}
+}
+
+// A namespace you are only a member of is visible but not writable —
+// otherwise the listing would advertise a publish that will be refused.
+func TestListTemplates_MembershipIsNotWritable(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+	writePackage(t, data, builtinNamespace, "0.1.0")
+
+	store := newTestStore(t)
+	if err := store.CreateOrg(context.Background(), "admin", "acme", "Acme"); err != nil {
+		t.Fatal(err)
+	}
+	user := seedUser(t, store, "member", 6)
+	if err := store.AddOrgMember(context.Background(), "admin", "acme", "member"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := listTemplates(t, identity.WithIdentity(context.Background(), user), store)
+	for _, ns := range got.Namespaces {
+		if ns.Name == "acme" && ns.Writable {
+			t.Error("a namespace the caller is only a member of is marked writable")
+		}
+	}
+}
+
+// A refusal must carry its own remedy rather than delegating to a tool.
+func TestPublish_RefusalNamesWhereYouCanPublish(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{"typst.toml": goodTOML, "lib.typ": goodLib})
+
+	res := f.publish(t, "tpl", "a-name-that-is-not-yours", "1.0.0")
+	if !res.IsError {
+		t.Fatal("published into a namespace the caller cannot see")
+	}
+	got := resultText(res)
+	if !strings.Contains(got, f.nsName) {
+		t.Errorf("refusal does not name the caller's own namespace:\n%s", got)
+	}
+	if strings.Contains(got, "call list_templates to see yours") {
+		t.Errorf("refusal still delegates instead of answering:\n%s", got)
 	}
 }

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -391,7 +391,9 @@ func templateInstructions() string {
 
   If the look someone wants does not exist yet, write it once and
   publish_template it into your own namespace rather than restyling
-  each document. Everyone has a namespace, so nothing needs granting.
+  each document. Everyone has a namespace, so nothing needs granting —
+  list_templates names it, under "namespaces", flagged writable. Do not
+  guess a namespace name; the one that is yours is listed there.
 
     #import "@%[1]s/%[2]s:%[3]s": report, adr
 
@@ -1101,6 +1103,10 @@ documents from different people, written at different times, come out
 looking the same. Call this before writing any #set or #show rules.
 
 No arguments; returns JSON:
+  - namespaces[]: every namespace you can reach, including ones with
+    nothing in them yet. "writable" marks the ones you may publish to
+    with publish_template — normally your own. This is where you find
+    your own namespace's name; do not guess it.
   - templates[]: namespace, name, version, and the exact "import" string
     to use, plus "exports" — the functions that package offers.
   - builtin: true for the server's house templates, available to

--- a/cmd/typst-d2-mcp/publish.go
+++ b/cmd/typst-d2-mcp/publish.go
@@ -160,16 +160,41 @@ func namespaceForPublish(ctx context.Context, store *authdb.Store, id identity.I
 	}
 	nsID, ok := allowed[name]
 	if !ok {
-		return "", fmt.Errorf("you cannot see a namespace called @%s — call list_templates to see yours", name)
+		// Name what they CAN publish to. Pointing at list_templates was
+		// worse than useless while it listed only packages: a caller
+		// with an empty namespace saw nothing of theirs and concluded
+		// they had none (#108).
+		return "", fmt.Errorf("you cannot see a namespace called @%s.%s",
+			name, ownedNamespacesHint(ctx, store, id))
 	}
 	role, err := store.RoleFor(ctx, nsID, id.UserID)
 	if err != nil {
 		return "", fmt.Errorf("check ownership: %w", err)
 	}
 	if role != authdb.RoleOwner {
-		return "", fmt.Errorf("you are a member of @%s but not an owner, so you cannot publish to it", name)
+		return "", fmt.Errorf("you are a member of @%s but not an owner, so you cannot publish to it.%s",
+			name, ownedNamespacesHint(ctx, store, id))
 	}
 	return nsID, nil
+}
+
+// ownedNamespacesHint names the namespaces the caller may publish to,
+// so a refusal carries its own remedy.
+func ownedNamespacesHint(ctx context.Context, store *authdb.Store, id identity.Identity) string {
+	allowed, err := allowedNamespaces(ctx, store, id)
+	if err != nil {
+		return ""
+	}
+	var owned []string
+	for _, name := range sortedNames(allowed) {
+		if name != builtinNamespace && ownsNamespace(ctx, store, id, allowed[name]) {
+			owned = append(owned, "@"+name)
+		}
+	}
+	if len(owned) == 0 {
+		return " You own no namespace to publish to."
+	}
+	return " You can publish to: " + strings.Join(owned, ", ") + "."
 }
 
 // collectPackage lists the package's files, relative to its root.


### PR DESCRIPTION
Fixes #108, found by two independent agents during the UX research programme.

## The closed loop

`list_templates` listed **packages, never namespaces**. A caller's own namespace holds nothing until they publish to it, so it produced no rows and was invisible. `publish_template` then refused a guessed name with *"call list_templates to see yours"* — pointing at the one tool that could not answer.

Both agents reasoned correctly from what they were shown, and both reached the wrong conclusion because what they were shown was incomplete:

- Pass 02 guessed `@stormlantern`, was refused, called `list_templates`, saw only `@house`, concluded *"this caller has no writable namespace"*, and hand-styled the document — the outcome #90 exists to prevent.
- Pass 04 probed `@house`, `@dirk`, `@local`, was refused three times, and fell back to a shared `.typ` in its own workspace — invisible to the colleagues the assignment explicitly mentioned.

Both owned a namespace the whole time.

## The fix

**`list_templates` reports namespaces**, empty ones included, with `writable` marking those the caller may publish to:

```json
"namespaces": [
  {"name": "house",   "writable": false, "builtin": true, "templates": 2},
  {"name": "gh-1234", "writable": true,  "templates": 0}
]
```

Membership without ownership is listed but **not** writable, so the listing never advertises a publish that would be refused. Ownership lookup fails closed.

**Refusals carry their own remedy** — `you cannot see a namespace called @x. You can publish to: @gh-1234.` — instead of delegating to a tool that omitted the answer.

**The instructions say the name is in the listing and must not be guessed**, since guessing is exactly what both agents did.

## Also worth knowing

Every `publish_template` attempt in pass 04 passed a local absolute path as `source`, which is workspace-relative and would also have failed. The namespace check runs first, so that never surfaced. Not changed here — noted on the issue, since it only becomes reachable once the namespace question is answerable.

Refers #108