### PR TITLE
fix(publish): let the compile check see the templates a caller can import (#115)

### DIFF
--- a/cmd/typst-d2-mcp/publish.go
+++ b/cmd/typst-d2-mcp/publish.go
@@ -131,7 +131,8 @@ func handlePublishTemplate(factory workspace.Factory, store *authdb.Store) serve
 				namespace, pkgName, version)), nil
 		}
 
-		if err := compileCheck(ctx, srcDir, files, nsID, pkgName, version); err != nil {
+		if err := compileCheck(ctx, store, id, srcDir, files,
+			namespace, nsID, pkgName, version); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf(
 				"the template did not compile, so it was not published:\n\n%s", err.Error())), nil
 		}
@@ -224,15 +225,63 @@ func containsFile(files []string, want string) bool {
 // The check runs in the same shape as a real compile — the package
 // reached only through XDG_DATA_HOME — so a template that resolves here
 // resolves for everyone importing it later.
-func compileCheck(ctx context.Context, srcDir string, files []string, nsID, pkgName, version string) error {
+func compileCheck(
+	ctx context.Context,
+	store *authdb.Store,
+	id identity.Identity,
+	srcDir string,
+	files []string,
+	nsName, nsID, pkgName, version string,
+) error {
 	stage, err := os.MkdirTemp("", "typst-d2-publish-*")
 	if err != nil {
 		return fmt.Errorf("stage package: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(stage) }()
 
-	pkgRoot := filepath.Join(stage, "data", "typst", "packages", nsID, pkgName, version)
-	if err := installPackage(srcDir, files, pkgRoot); err != nil {
+	// The check compiles against everything this caller could import,
+	// not against the candidate alone.
+	//
+	// Staging the candidate by itself rejected templates that build on
+	// another one — including the house style, which the instructions
+	// tell people to prefer — with "package not found". A gate that
+	// refuses correct work is worse than no gate: the caller is told
+	// their template is broken and the obvious remedy does not help
+	// (#115). Reusing the same view a real compile gets also removes a
+	// discrepancy nobody had declared, between what the check sees and
+	// what the document will see.
+	allowed, err := allowedNamespaces(ctx, store, id)
+	if err != nil {
+		return fmt.Errorf("resolve namespaces for the check: %w", err)
+	}
+	view, cleanupView, err := packageView(typstDataDir(), allowed)
+	if err != nil {
+		return fmt.Errorf("stage package: %w", err)
+	}
+	defer cleanupView()
+
+	// The candidate has to be a real directory under its own namespace
+	// name, replacing the symlink to the published store — otherwise
+	// installing it would write into the live store before it has
+	// passed.
+	pkgsDir := filepath.Join(view, "typst", "packages")
+	nsDir := filepath.Join(pkgsDir, nsName)
+	published := filepath.Join(typstDataDir(), "typst", "packages", nsID)
+	_ = os.Remove(nsDir) // drop the symlink, if the namespace has one
+	if err := os.MkdirAll(nsDir, 0o755); err != nil {
+		return fmt.Errorf("stage package: %w", err)
+	}
+	// Keep the namespace's already-published packages reachable, so a
+	// new version can build on an older one.
+	if entries, readErr := os.ReadDir(published); readErr == nil {
+		for _, e := range entries {
+			if e.Name() == pkgName {
+				continue // the candidate supersedes it for this check
+			}
+			_ = os.Symlink(filepath.Join(published, e.Name()), filepath.Join(nsDir, e.Name()))
+		}
+	}
+	if err := installPackage(srcDir, files, filepath.Join(nsDir, pkgName, version)); err != nil {
 		return fmt.Errorf("stage package: %w", err)
 	}
 
@@ -241,15 +290,14 @@ func compileCheck(ctx context.Context, srcDir string, files []string, nsID, pkgN
 		return fmt.Errorf("stage package: %w", err)
 	}
 
-	importPath := fmt.Sprintf("@%s/%s:%s", nsID, pkgName, version)
-	dataHome := filepath.Join(stage, "data")
+	importPath := fmt.Sprintf("@%s/%s:%s", nsName, pkgName, version)
 
 	// The gate: the package imports and a document using it compiles.
 	// This is what catches the failures that actually reach users — a
 	// syntax error, a missing asset, a typst.toml that does not match
 	// the directory it sits in.
 	doc := fmt.Sprintf("#import %q: *\n= Compile check\nBody text.\n", importPath)
-	if out, err := runTypst(ctx, work, dataHome, "check.typ", doc); err != nil {
+	if out, err := runTypst(ctx, work, view, "check.typ", doc); err != nil {
 		return errors.New(out)
 	}
 
@@ -269,7 +317,7 @@ func compileCheck(ctx context.Context, srcDir string, files []string, nsID, pkgN
 	for _, name := range documentTemplateExports(filepath.Join(srcDir, "lib.typ")) {
 		showDoc := fmt.Sprintf("#import %q: %s\n#show: %s.with()\n= Heading\nBody.\n",
 			importPath, name, name)
-		if out, err := runTypst(ctx, work, dataHome, "show-"+name+".typ", showDoc); err != nil {
+		if out, err := runTypst(ctx, work, view, "show-"+name+".typ", showDoc); err != nil {
 			return fmt.Errorf(
 				"%s is a document template but fails when applied to a document with its "+
 					"default arguments:\n\n%s", name, out)
@@ -436,7 +484,12 @@ func runTypst(ctx context.Context, workDir, dataHome, file, content string) (str
 		return "", err
 	}
 	out := strings.TrimSuffix(in, ".typ") + ".pdf"
-	cmd := exec.CommandContext(ctx, "typst", "compile", in, out)
+	// The check must see fonts the way a real compile does: a template
+	// may ship the typeface it is designed in, and validating it
+	// without that would reject it for a font it actually carries.
+	// Same discrepancy as #115, one axis over.
+	cmd := exec.CommandContext(ctx, "typst", "compile",
+		"--font-path", dataHome, in, out)
 	cmd.Env = compileEnv(dataHome)
 	combined, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(combined)), err

--- a/cmd/typst-d2-mcp/publish.go
+++ b/cmd/typst-d2-mcp/publish.go
@@ -131,7 +131,7 @@ func handlePublishTemplate(factory workspace.Factory, store *authdb.Store) serve
 				namespace, pkgName, version)), nil
 		}
 
-		if err := compileCheck(ctx, store, id, srcDir, files,
+		if err := compileCheck(ctx, store, id, resolver, srcDir, files,
 			namespace, nsID, pkgName, version); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf(
 				"the template did not compile, so it was not published:\n\n%s", err.Error())), nil
@@ -254,6 +254,7 @@ func compileCheck(
 	ctx context.Context,
 	store *authdb.Store,
 	id identity.Identity,
+	resolver workspace.Resolver,
 	srcDir string,
 	files []string,
 	nsName, nsID, pkgName, version string,
@@ -279,7 +280,7 @@ func compileCheck(
 	if err != nil {
 		return fmt.Errorf("resolve namespaces for the check: %w", err)
 	}
-	view, cleanupView, err := packageView(typstDataDir(), allowed)
+	view, cleanupView, err := packageView(typstDataDir(), allowed, workspaceFontPath(resolver))
 	if err != nil {
 		return fmt.Errorf("stage package: %w", err)
 	}

--- a/cmd/typst-d2-mcp/publish_test.go
+++ b/cmd/typst-d2-mcp/publish_test.go
@@ -442,3 +442,83 @@ func TestLetDeclarations_MultilineAndNested(t *testing.T) {
 		}
 	}
 }
+
+// #115: the check compiles against everything the caller could import,
+// not the candidate alone. Building on the house style is the
+// encouraged thing to do, and staging the candidate by itself rejected
+// exactly those templates with "package not found".
+func TestPublish_TemplateBuiltOnTheHouseStyle(t *testing.T) {
+	f := newPublishFixture(t)
+	seedBundledTemplates() // the house package, as a real server has it
+
+	lib := "#import \"@house/templates:0.1.0\": report\n" +
+		"#let incident(title: \"Untitled\", body) = {\n" +
+		"  show: report.with(title: title)\n  body\n}\n"
+	f.stage(t, "tpl", map[string]string{
+		"typst.toml": "[package]\nname = \"templates\"\nversion = \"1.0.0\"\nentrypoint = \"lib.typ\"\n",
+		"lib.typ":    lib,
+	})
+
+	res := f.publish(t, "tpl", f.nsName, "1.0.0")
+	if res.IsError {
+		t.Fatalf("a template built on the house style was refused:\n%s", resultText(res))
+	}
+}
+
+// A namespace the publisher cannot see must still be unreachable from
+// inside the check — widening what it resolves must not widen that.
+func TestPublish_CheckCannotReachAnotherTenantsNamespace(t *testing.T) {
+	f := newPublishFixture(t)
+
+	// Another tenant publishes something.
+	other := seedUser(t, f.store, "stranger", 77)
+	otherNS, err := f.store.EnsurePersonalNamespace(t.Context(), other.UserID, 77)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePackage(t, f.data, otherNS, "1.0.0")
+	strangerName := authdb.DerivedName(77)
+
+	f.stage(t, "tpl", map[string]string{
+		"typst.toml": goodTOML,
+		"lib.typ": "#import \"@" + strangerName + "/templates:1.0.0\": mark\n" +
+			"#let report(body) = { mark(); body }\n",
+	})
+
+	res := f.publish(t, "tpl", f.nsName, "1.0.0")
+	if !res.IsError {
+		t.Fatal("the check resolved a namespace the publisher cannot see")
+	}
+}
+
+// A new version may build on an older one in the same namespace.
+func TestPublish_NewVersionCanBuildOnAnOlderOne(t *testing.T) {
+	f := newPublishFixture(t)
+
+	f.stage(t, "base", map[string]string{
+		"typst.toml": "[package]\nname = \"base\"\nversion = \"1.0.0\"\nentrypoint = \"lib.typ\"\n",
+		"lib.typ":    "#let accent = rgb(\"#006566\")\n",
+	})
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "publish_template"
+	req.Params.Arguments = map[string]any{
+		"source": "base", "namespace": f.nsName, "version": "1.0.0", "name": "base",
+	}
+	res, err := handlePublishTemplate(f.factory, f.store)(f.ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("publishing the base package: %s", resultText(res))
+	}
+
+	f.stage(t, "tpl", map[string]string{
+		"typst.toml": goodTOML,
+		"lib.typ": "#import \"@" + f.nsName + "/base:1.0.0\": accent\n" +
+			"#let report(body) = { text(fill: accent, body) }\n",
+	})
+	if res := f.publish(t, "tpl", f.nsName, "1.0.0"); res.IsError {
+		t.Fatalf("a template building on an earlier package in its own namespace was refused:\n%s",
+			resultText(res))
+	}
+}


### PR DESCRIPTION
Fixes #115, found by a naive agent during the UX research programme.

## The bug

`compileCheck` staged the candidate package **alone**, so a template importing another one was refused:

```
the template did not compile, so it was not published:
error: package not found (searched for @house/templates:0.1.0)
```

The import is correct and resolves fine at compile time. It failed only inside the check — and it rejected precisely the templates we most want people to write, since the instructions tell callers to prefer the house style over styling from scratch.

A gate that refuses correct work is worse than no gate: the caller is told their template is broken, and the obvious remedy doesn't help.

## The fix

The check now compiles against **the same package view a real compile gets**, with the candidate overlaid as a real directory under its own namespace name — so staging it cannot write into the live store before it has passed. Already-published packages in that namespace stay reachable, so a new version can build on an earlier one.

Widening what the check resolves must not widen what a publisher can *reach*: `TestPublish_CheckCannotReachAnotherTenantsNamespace` asserts a namespace the publisher cannot see is still unreachable from inside the check.

## A second discrepancy of the same kind

While in here: `runTypst` passed **no font path at all**, so a template shipping the typeface it's designed in would fail validation for a font it actually carries — which is the exact capability #98 and #107 exist to provide. Now fixed too.

Both were the same underlying mistake: the check ran in an environment nobody had declared equal to the real one, and quietly wasn't.

## The check still works

The same research run shows it correctly catching a genuine fault — `package manifest contains mismatched name` — so the mechanism was sound and only the isolation was wrong. All existing publish tests still pass, including the broken-template and missing-asset gates.

Refers #115