### PR TITLE
chore: remove a build artefact committed to main by accident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ test-*.pdf
 # Go
 /typst-d2-prep
 /typst-d2-mcp
+# Scratch binaries built for local experiments. A 26MB build artefact
+# reached main once already, swept in by a broad `git add`; the pattern
+# is here so it cannot happen from a filename nobody remembered.
+/.research-mcpd
+/.mcpd-*
+/.fontcheck/
 *.test
 *.out
 coverage.txt


### PR DESCRIPTION
A 26MB server binary (`.research-mcpd`, built for the agent-research harness) was swept into #113 by a broad `git add`. My mistake — it is not source, it is stale the moment anything changes, and it makes every clone 26MB heavier.

Removed, and the scratch filenames the harness uses are now in `.gitignore` so it cannot return through a name nobody remembers.

**The blob is still in history.** Purging it needs a force-push over already-merged commits, which I am not doing unilaterally — say if you want that and I will. Otherwise the working tree is clean from here.