### PR TITLE
ci: pin d2 and stop the sqlite lock flake (#103, #105)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,22 @@ jobs:
           go-version: '1.25'
           cache: true
 
+      # Pinned, and fetched straight from the release tarball. The
+      # install script resolves "latest" through the unauthenticated
+      # GitHub API, which is rate-limited on shared runners — it failed
+      # three times and gave up on a PR run. It also meant CI tested a
+      # d2 the image does not ship, silently, the moment the two drift.
+      # Keep this version in step with Dockerfile's D2_VERSION and
+      # .devcontainer/post-create.sh.
       - name: Install D2
         timeout-minutes: 3
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
+        env:
+          D2_VERSION: v0.7.1
+        run: |
+          curl -fsSL "https://github.com/terrastruct/d2/releases/download/${D2_VERSION}/d2-${D2_VERSION}-linux-amd64.tar.gz" \
+            | tar -xz -C /tmp --strip-components=2 "d2-${D2_VERSION}/bin/d2"
+          sudo install -m 0755 /tmp/d2 /usr/local/bin/d2
+          d2 --version
 
       - name: Install Typst
         timeout-minutes: 3

--- a/playwright/helpers/db.ts
+++ b/playwright/helpers/db.ts
@@ -14,7 +14,15 @@ const STATE_DIR = process.env.E2E_STATE_DIR ?? "/tmp/typst-d2-mcp-e2e";
 const DB = `${STATE_DIR}/auth.sqlite`;
 
 function sql(statement: string): string {
-  return execFileSync("sqlite3", [DB, statement], { encoding: "utf8" });
+  // `.timeout` matters. The server under test writes to this same file
+  // while the suite reads it, and the sqlite3 CLI defaults to a zero
+  // busy timeout — so a plain SELECT fails outright with
+  // "database is locked (5)" the moment a write is in flight. That is
+  // not contention worth failing a test over; it is contention worth
+  // waiting out.
+  return execFileSync("sqlite3", ["-cmd", ".timeout 5000", DB, statement], {
+    encoding: "utf8",
+  });
 }
 
 /** Insert a user who has "signed in", returning their identity key. */


### PR DESCRIPTION
Two unrelated flakes, each of which cost a red build on an unrelated PR during this week's work.

## #103 — d2 unpinned, via a rate-limited API

CI installed d2 with `curl … d2lang.com/install.sh`, which resolves "latest" through the **unauthenticated GitHub API** — rate-limited per IP on shared runners. It returned 403 three times and gave up.

The second problem is worse because it is currently invisible: CI was testing an **unpinned** d2 while the image ships `v0.7.1`. Today they agree, so nothing looks wrong. The moment terrastruct releases v0.8.0, CI silently tests a d2 the image does not ship.

`Dockerfile` and `.devcontainer/post-create.sh` both already fetch the pinned release tarball directly. CI now does the same — no API call, no drift.

## #105 — sqlite CLI gives up instantly on a busy database

`playwright/helpers/db.ts` ran `sqlite3` with its default **zero** busy timeout, so a plain `SELECT` failed with `database is locked (5)` whenever the server under test held a write. Reproduced locally, not only in CI.

With `.timeout 5000`, the suite passed **27/27 on five consecutive local runs**.

## Left deliberately undone

WAL journal mode is the deeper fix — a reader would not wait at all rather than waiting briefly. But it changes the on-disk shape of a production database (adds `-wal`/`-shm`, affects backup assumptions), and that is not a decision to slip into a test-flake commit. Noted on #105 for a deliberate call.

Refers #103
Refers #105