### PR TITLE
fix(compile): say where the output is, name the right diagram, drop advice that does not apply

### DIFF
--- a/cmd/typst-d2-mcp/capabilities.go
+++ b/cmd/typst-d2-mcp/capabilities.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -74,20 +75,30 @@ var (
 
 // toolVersions reports the typst and d2 versions this image actually
 // runs. They cannot change while the process does, so probe once.
+// missingBinary is what a version field reads when the binary is not
+// there. It is a value rather than an omission on purpose: an omitted
+// field is indistinguishable from one the server does not implement, so
+// a server that cannot render a single diagram looked healthy. An agent
+// wrote a whole document with diagrams before finding out (#110).
+const missingBinary = "NOT INSTALLED"
+
 func toolVersions() (typstVersion, d2Version string) {
 	versionOnce.Do(func() {
-		typstVer = firstLine(mustProbe("typst", "--version"))
-		d2Ver = firstLine(mustProbe("d2", "--version"))
+		typstVer = probeVersion("typst")
+		d2Ver = probeVersion("d2")
 	})
 	return typstVer, d2Ver
 }
 
-func mustProbe(name string, args ...string) string {
-	out, err := runProbe(name, args...)
+func probeVersion(name string) string {
+	out, err := runProbe(name, "--version")
 	if err != nil {
-		return ""
+		return missingBinary
 	}
-	return out
+	if v := firstLine(out); v != "" {
+		return v
+	}
+	return missingBinary
 }
 
 func runProbe(name string, args ...string) (string, error) {
@@ -116,4 +127,44 @@ func firstLine(s string) string {
 		s = s[:i]
 	}
 	return strings.TrimSpace(s)
+}
+
+// pdfPageCount reads the page count straight out of the PDF, so a
+// caller learns how long its document is without needing to open it.
+//
+// Counting "/Type /Page" objects is crude but has no dependency and
+// cannot fail the compile: a zero return simply omits the figure. The
+// alternative — shelling out to a PDF tool — would add a binary the
+// image does not ship, which is the shape of problem #110 is about.
+func pdfPageCount(path string) int {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	// "/Type/Page" with optional whitespace, not followed by "s"
+	// (which would be /Pages, the tree node rather than a leaf).
+	n := 0
+	for i := 0; i+9 < len(raw); i++ {
+		if raw[i] != '/' || !bytes.HasPrefix(raw[i:], []byte("/Type")) {
+			continue
+		}
+		j := i + 5
+		for j < len(raw) && (raw[j] == ' ' || raw[j] == '\n' || raw[j] == '\r') {
+			j++
+		}
+		if !bytes.HasPrefix(raw[j:], []byte("/Page")) {
+			continue
+		}
+		k := j + 5
+		if k < len(raw) && (raw[k] == 's' || isPDFNameByte(raw[k])) {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+func isPDFNameByte(c byte) bool {
+	return c == '-' || c == '_' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }

--- a/cmd/typst-d2-mcp/capabilities_test.go
+++ b/cmd/typst-d2-mcp/capabilities_test.go
@@ -345,3 +345,75 @@ func findSystemFont(t *testing.T) string {
 	}
 	return best
 }
+
+// #110: an absent binary must be reported as absent. Omitting the field
+// made a server that could not render a single diagram look healthy —
+// an agent wrote a whole document with diagrams before finding out.
+func TestToolVersions_ReportsAMissingBinary(t *testing.T) {
+	if got := probeVersion("a-binary-that-does-not-exist"); got != missingBinary {
+		t.Errorf("probeVersion(missing) = %q, want %q", got, missingBinary)
+	}
+	if _, err := exec.LookPath("typst"); err == nil {
+		if got := probeVersion("typst"); got == missingBinary || got == "" {
+			t.Errorf("probeVersion(typst) = %q, want a version", got)
+		}
+	}
+}
+
+// The page count answers the question every agent asked next.
+func TestPDFPageCount(t *testing.T) {
+	requireTypst(t)
+	dir := t.TempDir()
+
+	for _, tc := range []struct {
+		name string
+		src  string
+		want int
+	}{
+		{"one page", "= One\nBody.\n", 1},
+		{"three pages", "= One\n#pagebreak()\n= Two\n#pagebreak()\n= Three\n", 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := filepath.Join(dir, tc.name+".typ")
+			out := filepath.Join(dir, tc.name+".pdf")
+			if err := os.WriteFile(in, []byte(tc.src), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if outBytes, err := exec.Command("typst", "compile", in, out).CombinedOutput(); err != nil {
+				t.Fatalf("compile: %v\n%s", err, outBytes)
+			}
+			if got := pdfPageCount(out); got != tc.want {
+				t.Errorf("pdfPageCount = %d, want %d", got, tc.want)
+			}
+		})
+	}
+
+	// A missing or unreadable file must not fail a compile.
+	if got := pdfPageCount(filepath.Join(dir, "nope.pdf")); got != 0 {
+		t.Errorf("pdfPageCount(missing) = %d, want 0", got)
+	}
+}
+
+// #109 and #110: the result tells you where the output is and how long
+// it is, and only mentions diagrams when there are diagrams.
+func TestCompileResult_LocatesOutputAndOmitsIrrelevantAdvice(t *testing.T) {
+	requireTypst(t)
+	root := t.TempDir()
+	factory := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "gh:4242"})
+
+	if res := putFile(t, ctx, factory, "plain.typ", "= Title\n#pagebreak()\n= Second\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	got := resultText(compile(t, ctx, factory, "plain.typ"))
+
+	if !strings.Contains(got, "2 page(s)") {
+		t.Errorf("result does not report the page count:\n%s", got)
+	}
+	if !strings.Contains(got, "resources/read") {
+		t.Errorf("result does not say how to fetch the PDF:\n%s", got)
+	}
+	if strings.Contains(got, "direction: down") {
+		t.Errorf("diagram advice on a document with no diagrams:\n%s", got)
+	}
+}

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -1336,15 +1336,37 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		toolVisibleOut := strings.TrimSuffix(filePath, ".typ") + ".pdf"
 
 		successMsg := fmt.Sprintf("Successfully compiled to %s\n\n", toolVisibleOut)
-		successMsg += "NEXT STEPS:\n"
-		successMsg += "1. Open the PDF to verify diagram layout and readability\n"
-		successMsg += "2. Check that diagrams fit within page margins (not cramped)\n"
-		successMsg += "3. Verify text labels are readable (not too small)\n"
-		successMsg += "4. If diagrams are cramped or text is tiny:\n"
-		successMsg += "   - Add 'direction: down' at top of D2 block (for A4 portrait)\n"
-		successMsg += "   - Split large diagrams into multiple focused diagrams\n"
-		successMsg += "   - Reduce number of nodes or simplify structure\n"
-		successMsg += "\nIf you cannot view the PDF yourself, inform the user to check the layout."
+
+		// #109: the tool's whole output is a file, and the result named
+		// neither where it is nor how big it is. Every agent tested ran
+		// `find /` immediately after a successful compile — which only
+		// worked because the server happened to be local.
+		if info, statErr := os.Stat(resolvedOut); statErr == nil {
+			successMsg += fmt.Sprintf("The PDF is %s", humanBytes(info.Size()))
+			if pages := pdfPageCount(resolvedOut); pages > 0 {
+				successMsg += fmt.Sprintf(", %d page(s)", pages)
+			}
+			successMsg += ".\n"
+		}
+		successMsg += fmt.Sprintf(
+			"Fetch it with resources/read on %s%s — that works whether or not you "+
+				"share a filesystem with this server.\n\n", pdfURIPrefix, toolVisibleOut)
+
+		// Diagram advice only where there are diagrams. Appending it
+		// unconditionally meant telling callers to add 'direction: down'
+		// to documents containing no D2 blocks — two agents said
+		// independently that it trained them to skim the block, which
+		// also carries the real warnings (#110).
+		if strings.Contains(processed, "decode64(") {
+			successMsg += "NEXT STEPS:\n"
+			successMsg += "1. Open the PDF to verify diagram layout and readability\n"
+			successMsg += "2. Check that diagrams fit within page margins (not cramped)\n"
+			successMsg += "3. Verify text labels are readable (not too small)\n"
+			successMsg += "4. If diagrams are cramped or text is tiny:\n"
+			successMsg += "   - Add 'direction: down' at top of D2 block (for A4 portrait)\n"
+			successMsg += "   - Split large diagrams into multiple focused diagrams\n"
+			successMsg += "   - Reduce number of nodes or simplify structure\n"
+		}
 
 		// Instructions are advisory and get truncated; a warning on a
 		// successful compile is neither. If the document styled itself

--- a/internal/preprocessor/preprocessor.go
+++ b/internal/preprocessor/preprocessor.go
@@ -82,21 +82,27 @@ func Preprocess(ctx context.Context, r workspace.Resolver, inputPath string) (st
 
 	slog.DebugContext(ctx, "rendering d2 blocks", "count", len(d2Blocks))
 
-	// Replace in reverse order to preserve positions
-	for i := len(d2Blocks) - 1; i >= 0; i-- {
-		block := d2Blocks[i]
-
-		// Render D2 to SVG
+	// Render forward, replace backward.
+	//
+	// Replacement must run in reverse so earlier offsets stay valid,
+	// but rendering in that order meant the first failure REACHED was
+	// the last diagram in the document — so a broken first diagram was
+	// reported as "failed to render diagram 3". An agent went hunting
+	// through its third diagram for a fault that was not there (#110).
+	// Rendering first, in document order, makes the diagram named the
+	// diagram to look at.
+	rendered := make([]string, len(d2Blocks))
+	for i, block := range d2Blocks {
 		svg, err := d2.Render(ctx, block.Code, block.Options)
 		if err != nil {
-			return "", fmt.Errorf("failed to render diagram %d: %w", i+1, err)
+			return "", fmt.Errorf("failed to render diagram %d of %d: %w",
+				i+1, len(d2Blocks), err)
 		}
-
-		// Convert to Typst image
-		typstImg := svgToTypstImage(svg, block.Options, block.CodeContext)
-
-		// Replace in content
-		content = content[:block.Start] + typstImg + content[block.End:]
+		rendered[i] = svgToTypstImage(svg, block.Options, block.CodeContext)
+	}
+	for i := len(d2Blocks) - 1; i >= 0; i-- {
+		block := d2Blocks[i]
+		content = content[:block.Start] + rendered[i] + content[block.End:]
 	}
 
 	// Add based package import

--- a/internal/preprocessor/preprocessor_test.go
+++ b/internal/preprocessor/preprocessor_test.go
@@ -3,6 +3,7 @@ package preprocessor
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -343,5 +344,31 @@ func TestLineCol(t *testing.T) {
 		if line != tc.line || col != tc.col {
 			t.Errorf("lineCol(%d) = %d:%d, want %d:%d", tc.offset, line, col, tc.line, tc.col)
 		}
+	}
+}
+
+// #110: a failing diagram must be named by its position in the
+// document, not by where a reverse loop happened to reach it. An agent
+// was told "failed to render diagram 3" when its FIRST diagram was the
+// fault, and went hunting through the third.
+func TestPreprocess_NamesTheDiagramThatFailed(t *testing.T) {
+	if _, err := exec.LookPath("d2"); err != nil {
+		t.Skip("d2 not installed")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.typ")
+
+	// The first diagram is broken; the other two are fine.
+	content := "#d2[\n  a -> ->\n]\n\n#d2[\n  b -> c\n]\n\n#d2[\n  d -> e\n]\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Preprocess(context.Background(), workspace.LocalFS{}, path)
+	if err == nil {
+		t.Fatal("expected the broken diagram to fail")
+	}
+	if !strings.Contains(err.Error(), "diagram 1 of 3") {
+		t.Errorf("error names the wrong diagram: %v", err)
 	}
 }


### PR DESCRIPTION
Three findings from the agent research, all in what a compile tells the caller.

## The result never said where the output was (#109)

**Every** agent tested ran `find /` immediately after a successful compile — which only worked because the server happened to be local. Against a hosted deployment it does not work at all. One agent caught two half-empty pages solely because `pdftoppm` happened to be installed; no error would have reported it.

The result now gives the size, the page count, and how to fetch the file via `resources/read` — which works without sharing a filesystem. Page count is parsed from the PDF directly rather than by shelling out to a PDF tool, since adding a binary the image does not ship is the shape of the *next* problem.

This is the cheap half of #109. **Page images — the top request from every agent — are deliberately not here**, since payload size and whether it belongs behind a parameter are your calls. #109 stays open for that.

## A missing binary was invisible (#110)

The version probe returned an empty string on failure and the field was `omitempty`, so a server that could not render a single diagram reported typst and 285 font families and said nothing about d2. An agent wrote a full architecture document with diagrams before discovering it, then rewrote every one in CeTZ.

Absent now reads `NOT INSTALLED` — an omitted field is indistinguishable from one the server does not implement.

## The wrong diagram was named (#110)

Blocks are replaced in reverse so earlier offsets stay valid, which meant the first failure *reached* was the last diagram: a broken **first** diagram was reported as the third, and the agent went hunting through its third.

Rendering now runs forward and replacement still runs backward, so the diagram named is the diagram to look at. A test asserts `diagram 1 of 3` for a broken first diagram.

## Advice that could not tell what you compiled (#110)

Diagram guidance is now appended only when the document contains diagrams. Two agents said independently that unconditional boilerplate trained them to skim the block — which also carries the genuine typst warnings.

## Left for you

The font-list flood (also #110) — bounded, summarised, or opt-in are three defensible shapes with different ergonomics, so I have not picked one.

Refers #109
Refers #110
