### PR TITLE
feat(workspace): add get_file, delete_file and search_file (#111)

### DIFF
--- a/cmd/typst-d2-mcp/files.go
+++ b/cmd/typst-d2-mcp/files.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// The rest of the workspace verbs. put_file was the only one, which
+// meant a caller could write a document and then neither read it back,
+// find it, nor remove it.
+//
+// The cost of that was not theoretical. An agent editing a 13KB document
+// re-uploaded the whole thing for a two-line change, because the
+// alternative was `find` on the server's filesystem — which worked only
+// because the server happened to be local. Probe files it wrote while
+// diagnosing were still sitting in the workspace at the end of the run,
+// counting against the byte budget, with no way to reclaim them.
+//
+// Search rather than list, deliberately. A workspace accumulates
+// documents, PDFs and now page previews; "show me everything" is the
+// answer to a question nobody asks, and the same reasoning applies here
+// as to fonts.
+
+// maxGetFileBytes bounds what get_file will return inline.
+//
+// Reading a PDF back through a tool call is the wrong move — base64
+// inflates it by a third and it lands in the caller's context as noise.
+// PDFs have a resource URI for exactly this, so a large or binary file
+// is refused with a pointer at the right mechanism rather than being
+// silently truncated.
+const maxGetFileBytes = 256 << 10
+
+func handleGetFile(factory workspace.Factory) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		path, err := request.RequireString("path")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		resolver, err := resolverFor(ctx, factory)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("workspace setup", err), nil
+		}
+		resolved, err := workspace.MustExist(resolver, path)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		info, err := os.Stat(resolved)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("read file", err), nil
+		}
+		if info.Size() > maxGetFileBytes {
+			hint := ""
+			if strings.EqualFold(filepath.Ext(path), ".pdf") {
+				hint = fmt.Sprintf(" Fetch the PDF with resources/read on %s%s instead.",
+					pdfURIPrefix, path)
+			}
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"%s is %s; get_file returns at most %s.%s",
+				path, humanBytes(info.Size()), humanBytes(maxGetFileBytes), hint)), nil
+		}
+
+		data, err := os.ReadFile(resolved)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("read file", err), nil
+		}
+		// Text comes back as text. Encoding binary as base64 by default
+		// would hand the caller something it cannot read and cannot act
+		// on, so that is opt-in.
+		if utf8.Valid(data) && !strings.EqualFold(request.GetString("encoding", ""), "base64") {
+			return mcp.NewToolResultText(string(data)), nil
+		}
+		if !strings.EqualFold(request.GetString("encoding", ""), "base64") {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"%s is not text. Pass encoding \"base64\" if you really want the bytes.", path)), nil
+		}
+		return mcp.NewToolResultText(base64.StdEncoding.EncodeToString(data)), nil
+	}
+}
+
+func handleDeleteFile(factory workspace.Factory) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		path, err := request.RequireString("path")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		resolver, err := resolverFor(ctx, factory)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("workspace setup", err), nil
+		}
+		resolved, err := resolver.Resolve(path)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		info, err := os.Stat(resolved)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return mcp.NewToolResultError("no such file: " + path), nil
+			}
+			return mcp.NewToolResultErrorFromErr("delete", err), nil
+		}
+		// One file at a time. A recursive delete is a different tool
+		// with a different risk profile, and nothing here needs it.
+		if info.IsDir() {
+			return mcp.NewToolResultError(path + " is a directory; delete_file removes one file"), nil
+		}
+		if err := os.Remove(resolved); err != nil {
+			return mcp.NewToolResultErrorFromErr("delete", err), nil
+		}
+		return mcp.NewToolResultText(fmt.Sprintf(
+			"Deleted %s (%s reclaimed).", path, humanBytes(info.Size()))), nil
+	}
+}
+
+// fileHit is one match.
+type fileHit struct {
+	Path  string `json:"path"`
+	Bytes int64  `json:"bytes"`
+	Human string `json:"size"`
+	Line  string `json:"line,omitempty"`
+}
+
+const maxSearchHits = 100
+
+func handleSearchFile(factory workspace.Factory) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		resolver, err := resolverFor(ctx, factory)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("workspace setup", err), nil
+		}
+		bounded, ok := resolver.(workspace.Bounded)
+		if !ok {
+			return mcp.NewToolResultError(
+				"search_file needs a bounded workspace; this server is running unscoped"), nil
+		}
+		root := bounded.WorkspaceRoot()
+		namePat := strings.ToLower(request.GetString("name", ""))
+		contains := request.GetString("contains", "")
+
+		var hits []fileHit
+		truncated := false
+		err = filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil || d.IsDir() {
+				return nil //nolint:nilerr // an unreadable entry is not a search failure
+			}
+			// Server scratch is not the caller's business.
+			if strings.HasPrefix(d.Name(), workspace.StagePrefix) {
+				return nil
+			}
+			rel, relErr := filepath.Rel(root, p)
+			if relErr != nil {
+				return nil
+			}
+			rel = filepath.ToSlash(rel)
+			if namePat != "" && !strings.Contains(strings.ToLower(rel), namePat) {
+				return nil
+			}
+			info, infoErr := d.Info()
+			if infoErr != nil || !info.Mode().IsRegular() {
+				return nil
+			}
+			hit := fileHit{Path: rel, Bytes: info.Size(), Human: humanBytes(info.Size())}
+			if contains != "" {
+				line, found := firstMatchingLine(p, contains)
+				if !found {
+					return nil
+				}
+				hit.Line = line
+			}
+			if len(hits) >= maxSearchHits {
+				truncated = true
+				return filepath.SkipAll
+			}
+			hits = append(hits, hit)
+			return nil
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("search", err), nil
+		}
+		sort.Slice(hits, func(i, j int) bool { return hits[i].Path < hits[j].Path })
+
+		out := map[string]any{"matches": hits, "count": len(hits)}
+		if truncated {
+			// Say so rather than silently returning a prefix — a
+			// truncated answer that looks complete is worse than none.
+			out["note"] = fmt.Sprintf(
+				"stopped at %d matches; narrow the search with name or contains", maxSearchHits)
+		}
+		if len(hits) == 0 {
+			out["note"] = "nothing matched. Omit both arguments to see everything in the workspace."
+		}
+		payload, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("encode results", err), nil
+		}
+		return mcp.NewToolResultText(string(payload)), nil
+	}
+}
+
+// firstMatchingLine returns the first line of a text file containing
+// needle. Binary files never match: searching them yields noise, and a
+// byte sequence found inside a PDF tells the caller nothing.
+func firstMatchingLine(path, needle string) (string, bool) {
+	info, err := os.Stat(path)
+	if err != nil || info.Size() > maxGetFileBytes {
+		return "", false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || !utf8.Valid(data) {
+		return "", false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, needle) {
+			line = strings.TrimSpace(line)
+			if len(line) > 160 {
+				line = line[:160] + "…"
+			}
+			return line, true
+		}
+	}
+	return "", false
+}

--- a/cmd/typst-d2-mcp/files_test.go
+++ b/cmd/typst-d2-mcp/files_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func fileFixture(t *testing.T) (workspace.Factory, context.Context) {
+	t.Helper()
+	return workspace.TenantFactory{Root: t.TempDir()},
+		identity.WithIdentity(context.Background(), identity.Identity{UserID: "gh:4242"})
+}
+
+func callTool(t *testing.T, h func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error),
+	ctx context.Context, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := h(ctx, req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	return res
+}
+
+// The point of get_file: edit what you wrote without re-uploading it.
+func TestGetFile_RoundTripsText(t *testing.T) {
+	f, ctx := fileFixture(t)
+	const body = "= Title\n\nBody text with a línea and an emoji 🌊.\n"
+	if res := putFile(t, ctx, f, "doc.typ", body); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	got := callTool(t, handleGetFile(f), ctx, map[string]any{"path": "doc.typ"})
+	if got.IsError {
+		t.Fatalf("get_file: %s", resultText(got))
+	}
+	if resultText(got) != body {
+		t.Errorf("round trip changed the content:\n%q", resultText(got))
+	}
+}
+
+// Bytes you cannot read are not an answer, so binary is opt-in.
+func TestGetFile_BinaryNeedsBase64(t *testing.T) {
+	f, ctx := fileFixture(t)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"path": "dot.png", "content": base64.StdEncoding.EncodeToString([]byte(testPNG)),
+		"encoding": "base64",
+	}
+	if res, err := handlePutFile(f, nil)(ctx, req); err != nil || res.IsError {
+		t.Fatalf("put_file: %v", err)
+	}
+
+	plain := callTool(t, handleGetFile(f), ctx, map[string]any{"path": "dot.png"})
+	if !plain.IsError {
+		t.Error("binary returned as text without being asked for")
+	}
+	if !strings.Contains(resultText(plain), "base64") {
+		t.Errorf("refusal does not say how to get the bytes: %s", resultText(plain))
+	}
+
+	b64 := callTool(t, handleGetFile(f), ctx, map[string]any{"path": "dot.png", "encoding": "base64"})
+	if b64.IsError {
+		t.Fatalf("get_file base64: %s", resultText(b64))
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(resultText(b64)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != testPNG {
+		t.Error("binary did not survive the round trip")
+	}
+}
+
+// A PDF pulled through a tool call is the wrong move; point at the
+// resource URI rather than filling the caller's context.
+func TestGetFile_LargeFileRefusedWithAPointer(t *testing.T) {
+	f, ctx := fileFixture(t)
+	big := strings.Repeat("x", maxGetFileBytes+1)
+	if res := putFile(t, ctx, f, "big.pdf", big); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	got := callTool(t, handleGetFile(f), ctx, map[string]any{"path": "big.pdf"})
+	if !got.IsError {
+		t.Fatal("a file over the cap was returned inline")
+	}
+	if !strings.Contains(resultText(got), "resources/read") {
+		t.Errorf("refusal does not point at the right mechanism: %s", resultText(got))
+	}
+}
+
+// Reclaiming space is the whole point — an agent's probe files sat in a
+// workspace for a whole session with no way to remove them.
+func TestDeleteFile_ReclaimsBytes(t *testing.T) {
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "scratch/t1.typ", strings.Repeat("x", 500)); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	resolver, err := f.Resolver(identity.Identity{UserID: "gh:4242"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, _, _ := workspace.Usage(resolver)
+
+	got := callTool(t, handleDeleteFile(f), ctx, map[string]any{"path": "scratch/t1.typ"})
+	if got.IsError {
+		t.Fatalf("delete_file: %s", resultText(got))
+	}
+	after, _, _ := workspace.Usage(resolver)
+	if after >= before {
+		t.Errorf("usage did not drop: %d then %d", before, after)
+	}
+
+	if again := callTool(t, handleDeleteFile(f), ctx, map[string]any{"path": "scratch/t1.typ"}); !again.IsError {
+		t.Error("deleting a missing file succeeded")
+	}
+}
+
+// Deletion must not become a way out of the workspace, nor a way to
+// remove a directory by accident.
+func TestDeleteFile_Bounded(t *testing.T) {
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "docs/a.typ", "x"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	for _, p := range []string{"../escape.txt", "../../etc/passwd", "/etc/passwd"} {
+		if res := callTool(t, handleDeleteFile(f), ctx, map[string]any{"path": p}); !res.IsError {
+			t.Errorf("delete escaped the workspace: %q", p)
+		}
+	}
+	if res := callTool(t, handleDeleteFile(f), ctx, map[string]any{"path": "docs"}); !res.IsError {
+		t.Error("deleted a directory")
+	}
+}
+
+func decodeSearch(t *testing.T, res *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("search_file: %s", resultText(res))
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("decode: %v\n%s", err, resultText(res))
+	}
+	return out
+}
+
+func TestSearchFile_ByNameAndContent(t *testing.T) {
+	f, ctx := fileFixture(t)
+	for path, body := range map[string]string{
+		"reports/q3-review.typ": "= Q3 Review\nStormlantern engagement.\n",
+		"reports/q4-plan.typ":   "= Q4 Plan\nNothing notable.\n",
+		"notes/scratch.md":      "Stormlantern colours\n",
+	} {
+		if res := putFile(t, ctx, f, path, body); res.IsError {
+			t.Fatalf("put_file %s: %s", path, resultText(res))
+		}
+	}
+
+	all := decodeSearch(t, callTool(t, handleSearchFile(f), ctx, map[string]any{}))
+	if n := int(all["count"].(float64)); n != 3 {
+		t.Errorf("bare search found %d, want 3", n)
+	}
+
+	byName := decodeSearch(t, callTool(t, handleSearchFile(f), ctx, map[string]any{"name": "reports/"}))
+	if n := int(byName["count"].(float64)); n != 2 {
+		t.Errorf("name search found %d, want 2", n)
+	}
+
+	byContent := decodeSearch(t, callTool(t, handleSearchFile(f), ctx, map[string]any{"contains": "Stormlantern"}))
+	if n := int(byContent["count"].(float64)); n != 2 {
+		t.Errorf("content search found %d, want 2", n)
+	}
+	m := byContent["matches"].([]any)[0].(map[string]any)
+	if line, _ := m["line"].(string); line == "" {
+		t.Error("content match does not show the matching line")
+	}
+
+	both := decodeSearch(t, callTool(t, handleSearchFile(f), ctx,
+		map[string]any{"name": ".typ", "contains": "Stormlantern"}))
+	if n := int(both["count"].(float64)); n != 1 {
+		t.Errorf("combined search found %d, want 1", n)
+	}
+
+	none := decodeSearch(t, callTool(t, handleSearchFile(f), ctx, map[string]any{"name": "nothing-like-this"}))
+	if none["note"] == nil {
+		t.Error("an empty result says nothing about why")
+	}
+}
+
+// Server scratch is not the caller's business, and a byte sequence
+// inside a PDF is not a content match.
+func TestSearchFile_SkipsScratchAndBinary(t *testing.T) {
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, workspace.StagePrefix+"leftover.typ", "Stormlantern"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"path": "img.png", "content": base64.StdEncoding.EncodeToString([]byte(testPNG)),
+		"encoding": "base64",
+	}
+	if _, err := handlePutFile(f, nil)(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+
+	got := decodeSearch(t, callTool(t, handleSearchFile(f), ctx, map[string]any{}))
+	for _, m := range got["matches"].([]any) {
+		if p := m.(map[string]any)["path"].(string); strings.HasPrefix(p, workspace.StagePrefix) {
+			t.Errorf("server scratch surfaced in a search: %s", p)
+		}
+	}
+	binary := decodeSearch(t, callTool(t, handleSearchFile(f), ctx, map[string]any{"contains": "PNG"}))
+	if n := int(binary["count"].(float64)); n != 0 {
+		t.Errorf("content search matched inside a binary file (%d hits)", n)
+	}
+}
+
+// One tenant's workspace is not another's.
+func TestFileVerbs_ArePerTenant(t *testing.T) {
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "mine.typ", "secret"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	other := identity.WithIdentity(context.Background(), identity.Identity{UserID: "gh:9999"})
+
+	if res := callTool(t, handleGetFile(f), other, map[string]any{"path": "mine.typ"}); !res.IsError {
+		t.Error("another tenant read the file")
+	}
+	if res := callTool(t, handleDeleteFile(f), other, map[string]any{"path": "mine.typ"}); !res.IsError {
+		t.Error("another tenant deleted the file")
+	}
+	got := decodeSearch(t, callTool(t, handleSearchFile(f), other, map[string]any{}))
+	if n := int(got["count"].(float64)); n != 0 {
+		t.Errorf("another tenant's search returned %d of my files", n)
+	}
+}

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -261,6 +261,12 @@ WORKSPACE, FILES & LIMITS (put_file / workspace_info):
   put_file BEFORE you compile. Do that rather than giving up or falling
   back to a local toolchain, which a hosted deployment may not have.
 
+  put_file is not the only file verb: get_file reads one back, so a
+  small edit does not mean re-uploading a whole document; search_file
+  finds what you wrote earlier; delete_file reclaims the bytes of
+  scratch you are done with, which nothing else frees before the
+  sweeper's TTL.
+
   put_file's size limit is on the DECODED bytes, roughly 3/4 of the
   base64 string you pass — NOT the string's length. An asset that fits
   under the limit (see workspace_info.per_call_limit_bytes) goes in one
@@ -1160,6 +1166,60 @@ Publish 1.0.1 instead; the old version keeps working.`),
 		),
 	)
 	s.AddTool(publishTemplateTool, handlePublishTemplate(factory, store))
+
+	// The rest of the workspace verbs. put_file alone meant a caller
+	// could write a document and then neither read it back, find it,
+	// nor remove it — so edits meant re-uploading whole files and
+	// scratch accumulated with no way to reclaim the space.
+	getFileTool := mcp.NewTool("get_file",
+		mcp.WithDescription(fmt.Sprintf(`Read a file back out of the workspace.
+
+Use this before editing something you wrote earlier, rather than
+re-uploading a whole document to change a line.
+
+Returns text as text. A file that is not valid UTF-8 is refused unless
+you pass encoding "base64", because bytes you cannot read are not an
+answer. Files over %s are refused outright — for a PDF, fetch it with
+resources/read on %s<path> instead, which streams rather than filling
+your context.`, humanBytes(maxGetFileBytes), pdfURIPrefix)),
+		mcp.WithString("path", mcp.Required(),
+			mcp.Description("Workspace-relative path in scoped/hosted mode; any path in local mode.")),
+		mcp.WithString("encoding",
+			mcp.Description(`Omit for text. "base64" to get the raw bytes of a non-text file.`)),
+	)
+	s.AddTool(getFileTool, handleGetFile(factory))
+
+	deleteFileTool := mcp.NewTool("delete_file",
+		mcp.WithDescription(`Delete one file from the workspace and reclaim its bytes.
+
+Use it for scratch you no longer need — probe documents, superseded
+drafts, page previews. A workspace may have a cumulative byte budget,
+and nothing else frees space before the sweeper's file TTL expires.
+
+Removes a single file. Directories are refused.`),
+		mcp.WithString("path", mcp.Required(),
+			mcp.Description("Workspace-relative path in scoped/hosted mode; any path in local mode.")),
+	)
+	s.AddTool(deleteFileTool, handleDeleteFile(factory))
+
+	searchFileTool := mcp.NewTool("search_file",
+		mcp.WithDescription(`Find files in your workspace by name, by content, or both.
+
+  name      substring of the path, case-insensitive  ("report", ".typ")
+  contains  text that must appear inside the file    ("Stormlantern")
+
+Both are optional; with neither, you get everything. Returns each
+match's path and size, plus the first matching line when searching by
+content. Binary files never match a content search.
+
+Use it to find what you wrote earlier in a long session, or to see what
+is taking up your byte budget before deleting anything.`),
+		mcp.WithString("name",
+			mcp.Description("Case-insensitive substring of the path.")),
+		mcp.WithString("contains",
+			mcp.Description("Text that must appear inside the file. Text files only.")),
+	)
+	s.AddTool(searchFileTool, handleSearchFile(factory))
 }
 
 func registerResources(s *server.MCPServer, factory workspace.Factory) {


### PR DESCRIPTION
Closes the gap an agent hit during the research programme, in its own words:

> *"`put_file` is the only file tool: no `get_file`, no patch, no list, no delete. For a two-line fix I either re-upload 13KB or go find the workspace on disk — I did the latter with `find`, which only worked because the server happens to be local. On a genuinely remote workspace my `t1.typ`/`t2.typ` scratch files would still be sitting there."*

Both halves were true. The scratch files *were* still sitting there at the end of the run, counting against the byte budget, with nothing able to reclaim them before the sweeper's TTL.

## `get_file`

Text comes back as text. Two refusals rather than surprises:

- **not valid UTF-8** → refused unless `encoding: "base64"` is asked for explicitly. Bytes a caller cannot read are not an answer.
- **over 256KB** → refused with a pointer at `resources/read`. Pulling a PDF through a tool call inflates it by a third and lands it in the caller's context as noise; the resource URI exists for exactly this.

## `delete_file`

Removes one file, reports the bytes reclaimed. Directories are refused — a recursive delete is a different tool with a different risk profile, and nothing here needs one.

This also matters for the page previews we discussed: they'll live in the workspace and count against the budget, so there has to be a way to clear them.

## `search_file`

Search rather than list, deliberately — same reasoning as the font decision on #120. A workspace accumulates documents, PDFs and previews; "show me everything" answers a question nobody asks.

Matches on `name` (path substring), `contains` (text inside the file), or both. Content search skips binaries, because a byte sequence found inside a PDF tells the caller nothing. Server scratch never surfaces. A result that hits the 100-match cap says so, rather than returning a prefix that looks complete.

## Boundaries

All three go through the same resolver `put_file` uses, so traversal is rejected and one tenant cannot read, search or delete another's files — `TestFileVerbs_ArePerTenant` and `TestDeleteFile_Bounded` assert it rather than assuming it.

Refers #111
