### PR TITLE
feat(resources): read artefacts as resources, and make them findable

### DIFF
--- a/cmd/typst-d2-mcp/files.go
+++ b/cmd/typst-d2-mcp/files.go
@@ -33,14 +33,33 @@ import (
 // answer to a question nobody asks, and the same reasoning applies here
 // as to fonts.
 
-// maxGetFileBytes bounds what get_file will return inline.
-//
-// Reading a PDF back through a tool call is the wrong move — base64
-// inflates it by a third and it lands in the caller's context as noise.
-// PDFs have a resource URI for exactly this, so a large or binary file
-// is refused with a pointer at the right mechanism rather than being
-// silently truncated.
+// maxGetFileBytes bounds what get_file will return inline. The cap is a
+// backstop; the real division is artefact vs source — see artefactURI.
 const maxGetFileBytes = 256 << 10
+
+// artefactURI reports whether a path names something the server
+// rendered rather than something a caller wrote, and where to read it.
+//
+// Rendered output belongs on the resource side whatever its size: the
+// client streams it to a file, so it costs the caller no context at
+// all. Refusing only when a file happens to be large would send a
+// small PDF through the worse mechanism for no reason.
+// Only output the SERVER produced counts. A .png the caller pushed is a
+// logo or a figure — their file, and refusing it would be telling them
+// their own asset is an artefact. Rendered pages are distinguished by
+// living under the preview directory, not by extension.
+func artefactURI(path string) (string, bool) {
+	clean := filepath.ToSlash(path)
+	if strings.EqualFold(filepath.Ext(clean), ".pdf") {
+		return pdfURIPrefix + clean, true
+	}
+	for _, seg := range strings.Split(clean, "/") {
+		if seg == previewDir {
+			return pageURIPrefix + clean, true
+		}
+	}
+	return "", false
+}
 
 func handleGetFile(factory workspace.Factory) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -61,15 +80,28 @@ func handleGetFile(factory workspace.Factory) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultErrorFromErr("read file", err), nil
 		}
-		if info.Size() > maxGetFileBytes {
-			hint := ""
+		// Artefacts go out as resources, not through here — and that is
+		// a judgement about PURPOSE, not size. A client reading a
+		// resource saves the bytes to a file and hands back a path, so
+		// a PDF never enters the caller's context; base64 through a
+		// tool result is strictly the worse mechanism for the same job.
+		// Source you are about to edit is the opposite case: you want
+		// the text in front of you, which is what this tool is for.
+		if uri, isArtefact := artefactURI(path); isArtefact {
+			msg := fmt.Sprintf(
+				"%s is a rendered artefact, not source. Read it with resources/read on %s — "+
+					"your client saves it to a file instead of filling your context.", path, uri)
 			if strings.EqualFold(filepath.Ext(path), ".pdf") {
-				hint = fmt.Sprintf(" Fetch the PDF with resources/read on %s%s instead.",
-					pdfURIPrefix, path)
+				msg += fmt.Sprintf(" To SEE a page rather than the file, read %s%s/<page number>.",
+					pageURIPrefix, strings.TrimSuffix(path, filepath.Ext(path))+".typ")
 			}
+			return mcp.NewToolResultError(msg), nil
+		}
+		if info.Size() > maxGetFileBytes {
 			return mcp.NewToolResultError(fmt.Sprintf(
-				"%s is %s; get_file returns at most %s.%s",
-				path, humanBytes(info.Size()), humanBytes(maxGetFileBytes), hint)), nil
+				"%s is %s; get_file returns at most %s. Read it as a resource instead: %s%s",
+				path, humanBytes(info.Size()), humanBytes(maxGetFileBytes),
+				sourceURIPrefix, path)), nil
 		}
 
 		data, err := os.ReadFile(resolved)

--- a/cmd/typst-d2-mcp/files_test.go
+++ b/cmd/typst-d2-mcp/files_test.go
@@ -79,20 +79,43 @@ func TestGetFile_BinaryNeedsBase64(t *testing.T) {
 	}
 }
 
-// A PDF pulled through a tool call is the wrong move; point at the
-// resource URI rather than filling the caller's context.
-func TestGetFile_LargeFileRefusedWithAPointer(t *testing.T) {
+// Artefacts belong on the resource side whatever their size — the
+// client streams them to a file, so they cost the caller no context.
+// Refusing only when a file happens to be large would send a small PDF
+// through the worse mechanism for no reason.
+func TestGetFile_ArtefactsGoToResourcesRegardlessOfSize(t *testing.T) {
 	f, ctx := fileFixture(t)
-	big := strings.Repeat("x", maxGetFileBytes+1)
-	if res := putFile(t, ctx, f, "big.pdf", big); res.IsError {
+	if res := putFile(t, ctx, f, "tiny.pdf", "not really a pdf"); res.IsError {
 		t.Fatalf("put_file: %s", resultText(res))
 	}
-	got := callTool(t, handleGetFile(f), ctx, map[string]any{"path": "big.pdf"})
+	got := callTool(t, handleGetFile(f), ctx, map[string]any{"path": "tiny.pdf"})
+	if !got.IsError {
+		t.Fatal("a small PDF was returned inline rather than pointed at a resource")
+	}
+	msg := resultText(got)
+	for _, want := range []string{"resources/read", pdfURIPrefix, pageURIPrefix} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal missing %q:\n%s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "at most") {
+		t.Errorf("refusal justified by size rather than purpose:\n%s", msg)
+	}
+}
+
+// Source over the cap is still a size refusal, and points at the
+// source resource rather than at a PDF.
+func TestGetFile_LargeSourcePointsAtTheSourceResource(t *testing.T) {
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "big.typ", strings.Repeat("x", maxGetFileBytes+1)); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	got := callTool(t, handleGetFile(f), ctx, map[string]any{"path": "big.typ"})
 	if !got.IsError {
 		t.Fatal("a file over the cap was returned inline")
 	}
-	if !strings.Contains(resultText(got), "resources/read") {
-		t.Errorf("refusal does not point at the right mechanism: %s", resultText(got))
+	if !strings.Contains(resultText(got), sourceURIPrefix) {
+		t.Errorf("refusal does not point at the source resource: %s", resultText(got))
 	}
 }
 
@@ -240,5 +263,20 @@ func TestFileVerbs_ArePerTenant(t *testing.T) {
 	got := decodeSearch(t, callTool(t, handleSearchFile(f), other, map[string]any{}))
 	if n := int(got["count"].(float64)); n != 0 {
 		t.Errorf("another tenant's search returned %d of my files", n)
+	}
+}
+
+// A PNG the caller pushed is their asset, not a rendered artefact.
+// Refusing it would be telling someone their own logo belongs on the
+// resource side.
+func TestGetFile_UploadedImagesAreNotArtefacts(t *testing.T) {
+	if uri, isArtefact := artefactURI("assets/logo.png"); isArtefact {
+		t.Errorf("an uploaded PNG was classed as an artefact (%s)", uri)
+	}
+	if _, isArtefact := artefactURI("docs/" + previewDir + "/report/page-1.png"); !isArtefact {
+		t.Error("a rendered page was not classed as an artefact")
+	}
+	if _, isArtefact := artefactURI("report.pdf"); !isArtefact {
+		t.Error("a PDF was not classed as an artefact")
 	}
 }

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/dlouwers/typst-d2-mcp/templates"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	"github.com/yosida95/uritemplate/v3"
 )
 
 // serverVersion is overridden at release time via
@@ -1222,16 +1221,6 @@ is taking up your byte budget before deleting anything.`),
 	s.AddTool(searchFileTool, handleSearchFile(factory))
 }
 
-func registerResources(s *server.MCPServer, factory workspace.Factory) {
-	tmpl := mcp.ResourceTemplate{
-		URITemplate: &mcp.URITemplate{Template: uritemplate.MustNew(pdfURIPrefix + "{+path}")},
-		Name:        "pdf",
-		Description: "Compiled Typst PDF produced by compile_typst_with_d2.",
-		MIMEType:    "application/pdf",
-	}
-	s.AddResourceTemplate(tmpl, handleReadPDF(factory))
-}
-
 func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		filePath, err := request.RequireString("file_path")
@@ -1410,7 +1399,11 @@ func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.T
 		}
 		successMsg += fmt.Sprintf(
 			"Fetch it with resources/read on %s%s — that works whether or not you "+
-				"share a filesystem with this server.\n\n", pdfURIPrefix, toolVisibleOut)
+				"share a filesystem with this server.\n"+
+				"To SEE a page rather than the file, read %s%s/1 (and /2, /3 …). "+
+				"Pages render on first read; that is the way to check a layout you "+
+				"cannot otherwise look at.\n\n",
+			pdfURIPrefix, toolVisibleOut, pageURIPrefix, filePath)
 
 		// Diagram advice only where there are diagrams. Appending it
 		// unconditionally meant telling callers to add 'direction: down'

--- a/cmd/typst-d2-mcp/resources.go
+++ b/cmd/typst-d2-mcp/resources.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/preprocessor"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/yosida95/uritemplate/v3"
+)
+
+// Resources are how artefacts leave this server; tools are how source
+// does.
+//
+// The division is by purpose, not by size. A client reading a resource
+// saves the bytes to a file and hands back a path, so a PDF or a page
+// image never enters the caller's context at all — which is strictly
+// better than a tool returning base64. But re-reading your own .typ to
+// change two lines is not fetching an artefact; you want the text in
+// front of you, which is what get_file is for.
+//
+// The catch found in testing: only PDFs were exposed, as a resource
+// TEMPLATE, and templates are not what resources/list returns. An agent
+// asking what it could read was told "No resources found" while holding
+// a working typst-d2:// URI. Hence the index below — one concrete
+// resource whose job is to answer that question honestly.
+
+const (
+	sourceURIPrefix = "typst-d2://source/"
+	pageURIPrefix   = "typst-d2://page/"
+	indexURI        = "typst-d2://index"
+	previewDir      = ".previews"
+)
+
+func registerResources(s *server.MCPServer, factory workspace.Factory) {
+	s.AddResourceTemplate(mcp.ResourceTemplate{
+		URITemplate: templateFor(pdfURIPrefix + "{+path}"),
+		Name:        "pdf",
+		Description: "Compiled Typst PDF produced by compile_typst_with_d2.",
+		MIMEType:    "application/pdf",
+	}, handleReadPDF(factory))
+
+	s.AddResourceTemplate(mcp.ResourceTemplate{
+		URITemplate: templateFor(sourceURIPrefix + "{+path}"),
+		Name:        "source",
+		Description: "A text file in the workspace, read as text.",
+		MIMEType:    "text/plain",
+	}, handleReadSource(factory))
+
+	s.AddResourceTemplate(mcp.ResourceTemplate{
+		URITemplate: templateFor(pageURIPrefix + "{+path}"),
+		Name:        "page",
+		Description: "One rendered page of a document, as PNG. " +
+			"Address as typst-d2://page/<document.typ>/<page number>. " +
+			"Pages are rendered on first read, not at compile time.",
+		MIMEType: "image/png",
+	}, handleReadPage(factory))
+
+	// A concrete resource, so resources/list has something to return.
+	// Without it a caller asking what is readable is told nothing is,
+	// which is the same discoverability failure as a namespace that
+	// exists but is never named.
+	s.AddResource(mcp.Resource{
+		URI:         indexURI,
+		Name:        "workspace",
+		Description: "What this caller can read: every document, its pages, and its compiled PDF.",
+		MIMEType:    "application/json",
+	}, handleReadIndex(factory))
+}
+
+// handleReadSource returns a workspace text file as text.
+func handleReadSource(factory workspace.Factory) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		rel, err := uriPath(req.Params.URI, sourceURIPrefix)
+		if err != nil {
+			return nil, err
+		}
+		resolver, err := resolverFor(ctx, factory)
+		if err != nil {
+			return nil, fmt.Errorf("workspace setup: %w", err)
+		}
+		resolved, err := workspace.MustExist(resolver, rel)
+		if err != nil {
+			return nil, err
+		}
+		data, err := os.ReadFile(resolved)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", rel, err)
+		}
+		return []mcp.ResourceContents{mcp.TextResourceContents{
+			URI: req.Params.URI, MIMEType: "text/plain", Text: string(data),
+		}}, nil
+	}
+}
+
+// handleReadPage renders one page of a document and returns it as PNG.
+//
+// Rendering is lazy: nothing is produced at compile time, because
+// agents compile repeatedly while iterating and mostly never look. The
+// first read of any page renders the whole document once and caches the
+// pages in the workspace, so the second read is free. Cached pages
+// older than the source are re-rendered, so a stale preview cannot be
+// served as if it were current.
+func handleReadPage(factory workspace.Factory) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		spec, err := uriPath(req.Params.URI, pageURIPrefix)
+		if err != nil {
+			return nil, err
+		}
+		slash := strings.LastIndex(spec, "/")
+		if slash < 0 {
+			return nil, fmt.Errorf("address a page as %s<document.typ>/<page number>", pageURIPrefix)
+		}
+		docRel, pageStr := spec[:slash], spec[slash+1:]
+		page, convErr := strconv.Atoi(pageStr)
+		if convErr != nil || page < 1 {
+			return nil, fmt.Errorf("page number must be 1 or greater, got %q", pageStr)
+		}
+		resolver, err := resolverFor(ctx, factory)
+		if err != nil {
+			return nil, err
+		}
+		srcPath, err := workspace.MustExist(resolver, docRel)
+		if err != nil {
+			return nil, err
+		}
+
+		pageFile, err := renderPages(ctx, resolver, docRel, srcPath, page)
+		if err != nil {
+			return nil, err
+		}
+		data, err := os.ReadFile(pageFile)
+		if err != nil {
+			return nil, fmt.Errorf("page %d of %s was not produced — does it have that many pages?", page, docRel)
+		}
+		return []mcp.ResourceContents{mcp.BlobResourceContents{
+			URI: req.Params.URI, MIMEType: "image/png", Blob: base64.StdEncoding.EncodeToString(data),
+		}}, nil
+	}
+}
+
+// renderPages rasterises a document into the workspace preview
+// directory if the cache is missing or stale, and returns the path of
+// the requested page.
+//
+// The previews live in the workspace and count against the tenant's
+// byte budget, which is deliberate: the caller asked for them, and
+// hiding storage a caller caused is how quotas stop meaning anything.
+// delete_file reclaims them.
+func renderPages(ctx context.Context, r workspace.Resolver, docRel, srcPath string, page int) (string, error) {
+	outDir, err := r.Resolve(filepath.Join(filepath.Dir(docRel), previewDir,
+		strings.TrimSuffix(filepath.Base(docRel), filepath.Ext(docRel))))
+	if err != nil {
+		return "", err
+	}
+	want := filepath.Join(outDir, fmt.Sprintf("page-%d.png", page))
+
+	srcInfo, err := os.Stat(srcPath)
+	if err != nil {
+		return "", err
+	}
+	if info, statErr := os.Stat(want); statErr == nil && info.ModTime().After(srcInfo.ModTime()) {
+		return want, nil // cached and newer than the source
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return "", fmt.Errorf("prepare previews: %w", err)
+	}
+
+	processed, err := preprocessor.Preprocess(ctx, r, docRel)
+	if err != nil {
+		return "", fmt.Errorf("preprocess %s: %w", docRel, err)
+	}
+	staged, err := os.CreateTemp(filepath.Dir(srcPath), workspace.StagePrefix+"*.typ")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = os.Remove(staged.Name()) }()
+	if _, err := staged.WriteString(processed); err != nil {
+		_ = staged.Close()
+		return "", err
+	}
+	if err := staged.Close(); err != nil {
+		return "", err
+	}
+
+	args := typstArgs(r, staged.Name(), filepath.Join(outDir, "page-{n}.png"))
+	args = append([]string{args[0], "--format", "png", "--ppi", "96"}, args[1:]...)
+	cmd := exec.CommandContext(ctx, "typst", args...)
+	if out, runErr := cmd.CombinedOutput(); runErr != nil {
+		return "", fmt.Errorf("render pages of %s: %s", docRel, strings.TrimSpace(string(out)))
+	}
+	return want, nil
+}
+
+// handleReadIndex answers "what can I read here" for this caller.
+func handleReadIndex(factory workspace.Factory) server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		resolver, err := resolverFor(ctx, factory)
+		if err != nil {
+			return nil, err
+		}
+		bounded, ok := resolver.(workspace.Bounded)
+		if !ok {
+			return nil, fmt.Errorf("no bounded workspace on this server")
+		}
+		root := bounded.WorkspaceRoot()
+
+		type entry struct {
+			Document string `json:"document"`
+			Source   string `json:"source"`
+			PDF      string `json:"pdf,omitempty"`
+			Pages    string `json:"pages,omitempty"`
+		}
+		var out []entry
+		_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil || d.IsDir() || !strings.EqualFold(filepath.Ext(d.Name()), ".typ") {
+				return nil //nolint:nilerr // an unreadable entry is not a listing failure
+			}
+			if strings.HasPrefix(d.Name(), workspace.StagePrefix) {
+				return nil
+			}
+			rel, relErr := filepath.Rel(root, p)
+			if relErr != nil {
+				return nil
+			}
+			rel = filepath.ToSlash(rel)
+			e := entry{
+				Document: rel,
+				Source:   sourceURIPrefix + rel,
+				Pages:    pageURIPrefix + rel + "/1",
+			}
+			if pdf := strings.TrimSuffix(rel, filepath.Ext(rel)) + ".pdf"; fileExists(filepath.Join(root, pdf)) {
+				e.PDF = pdfURIPrefix + pdf
+			}
+			out = append(out, e)
+			return nil
+		})
+		sort.Slice(out, func(i, j int) bool { return out[i].Document < out[j].Document })
+
+		payload, err := json.MarshalIndent(map[string]any{
+			"documents": out,
+			"note": "Read a PDF or a page rather than pulling it through a tool — the client " +
+				"saves it to a file instead of filling your context. Pages render on first read.",
+		}, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return []mcp.ResourceContents{mcp.TextResourceContents{
+			URI: indexURI, MIMEType: "application/json", Text: string(payload),
+		}}, nil
+	}
+}
+
+func fileExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// templateFor builds a URI template, panicking on a malformed one —
+// these are constants, so a bad one is a programming error caught at
+// startup rather than a runtime failure per request.
+func templateFor(t string) *mcp.URITemplate {
+	return &mcp.URITemplate{Template: uritemplate.MustNew(t)}
+}
+
+// uriPath extracts and unescapes the path portion of a typst-d2 URI.
+func uriPath(uri, prefix string) (string, error) {
+	if !strings.HasPrefix(uri, prefix) {
+		return "", fmt.Errorf("not a %s URI: %s", strings.TrimSuffix(prefix, "/"), uri)
+	}
+	p, err := url.PathUnescape(strings.TrimPrefix(uri, prefix))
+	if err != nil {
+		return "", fmt.Errorf("decode URI path: %w", err)
+	}
+	return p, nil
+}

--- a/cmd/typst-d2-mcp/resources_test.go
+++ b/cmd/typst-d2-mcp/resources_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func readResource(t *testing.T, h server.ResourceTemplateHandlerFunc, ctx context.Context, uri string) []mcp.ResourceContents {
+	t.Helper()
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = uri
+	got, err := h(ctx, req)
+	if err != nil {
+		t.Fatalf("read %s: %v", uri, err)
+	}
+	return got
+}
+
+// An agent asking what it could read was told "No resources found"
+// while holding a working typst-d2:// URI, because only templates were
+// registered and templates are not what resources/list returns.
+func TestIndexResource_NamesWhatIsReadable(t *testing.T) {
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "docs/report.typ", "= Report\nBody.\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	if res := putFile(t, ctx, f, "docs/report.pdf", "fake pdf"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = indexURI
+	got, err := handleReadIndex(f)(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := got[0].(mcp.TextResourceContents).Text
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("index is not JSON: %v", err)
+	}
+	docs := out["documents"].([]any)
+	if len(docs) != 1 {
+		t.Fatalf("index listed %d documents, want 1", len(docs))
+	}
+	d := docs[0].(map[string]any)
+	for k, want := range map[string]string{
+		"source": sourceURIPrefix + "docs/report.typ",
+		"pdf":    pdfURIPrefix + "docs/report.pdf",
+		"pages":  pageURIPrefix + "docs/report.typ/1",
+	} {
+		if got, _ := d[k].(string); got != want {
+			t.Errorf("index %s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestSourceResource_ReturnsText(t *testing.T) {
+	f, ctx := fileFixture(t)
+	const body = "= Title\nBody with an accent: café.\n"
+	if res := putFile(t, ctx, f, "doc.typ", body); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	got := readResource(t, handleReadSource(f), ctx, sourceURIPrefix+"doc.typ")
+	if text := got[0].(mcp.TextResourceContents).Text; text != body {
+		t.Errorf("source resource returned %q", text)
+	}
+}
+
+// Pages render on first read, are cached, and are re-rendered when the
+// source changes — a stale preview must never be served as current.
+func TestPageResource_RendersLazilyAndStaysCurrent(t *testing.T) {
+	if _, err := exec.LookPath("typst"); err != nil {
+		t.Skip("typst not installed")
+	}
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "doc.typ", "= One\n#pagebreak()\n= Two\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+
+	resolver, err := f.Resolver(identity.Identity{UserID: "gh:4242"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, _, _ := workspace.Usage(resolver)
+
+	got := readResource(t, handleReadPage(f), ctx, pageURIPrefix+"doc.typ/2")
+	blob := got[0].(mcp.BlobResourceContents)
+	if blob.MIMEType != "image/png" {
+		t.Errorf("mime = %q, want image/png", blob.MIMEType)
+	}
+	raw, err := base64.StdEncoding.DecodeString(blob.Blob)
+	if err != nil || len(raw) < 100 || string(raw[1:4]) != "PNG" {
+		t.Fatalf("page 2 is not a PNG (%d bytes)", len(raw))
+	}
+
+	// Previews live in the workspace and count against the budget —
+	// deliberately, since the caller asked for them.
+	after, _, _ := workspace.Usage(resolver)
+	if after <= before {
+		t.Errorf("previews did not appear in workspace usage: %d then %d", before, after)
+	}
+
+	// A changed source must not serve the cached page.
+	if res := putFile(t, ctx, f, "doc.typ", "= Different\n#pagebreak()\n= Pages\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	again := readResource(t, handleReadPage(f), ctx, pageURIPrefix+"doc.typ/2")
+	if again[0].(mcp.BlobResourceContents).Blob == blob.Blob {
+		t.Error("a stale page was served after the source changed")
+	}
+}
+
+func TestPageResource_RejectsBadAddresses(t *testing.T) {
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "doc.typ", "= One\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	for _, uri := range []string{
+		pageURIPrefix + "doc.typ",
+		pageURIPrefix + "doc.typ/0",
+		pageURIPrefix + "doc.typ/notanumber",
+	} {
+		req := mcp.ReadResourceRequest{}
+		req.Params.URI = uri
+		if _, err := handleReadPage(f)(ctx, req); err == nil {
+			t.Errorf("accepted a malformed page address: %s", uri)
+		}
+	}
+}
+
+// Resources are bounded by the same resolver as everything else.
+func TestResources_ArePerTenant(t *testing.T) {
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "mine.typ", "secret"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	other := identity.WithIdentity(context.Background(), identity.Identity{UserID: "gh:9999"})
+
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = sourceURIPrefix + "mine.typ"
+	if _, err := handleReadSource(f)(other, req); err == nil {
+		t.Error("another tenant read the source")
+	}
+	req.Params.URI = indexURI
+	got, err := handleReadIndex(f)(other, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got[0].(mcp.TextResourceContents).Text, "mine.typ") {
+		t.Error("another tenant's index listed my document")
+	}
+}


### PR DESCRIPTION
Your question — *"is `resources/read` an alternative to `get_file`, but better?"* — turned out to be answerable from the research transcripts, and the answer corrected something I'd asserted a message earlier.

I said no agent used resources. **Wrong: `ReadMcpResourceTool` was called 12 times**, and it works better than `get_file` does — the client saves the blob to a file and returns a path, so a 200KB PDF never enters context. Base64 through a tool result is strictly worse at the same job.

Two things stopped that being the whole answer, and both are fixed here.

## Only PDFs were exposed, and only as a template

`resources/list` returns concrete resources, not templates — so an agent asking what it could read got **"No resources found"** while holding a working `typst-d2://` URI (pass 08, verbatim). Same discoverability failure as a namespace that exists but is never named.

There's now a concrete `typst-d2://index` resource that answers it: every document, its source URI, its PDF if compiled, and where its pages are.

## Source is not an artefact

Re-reading your own `.typ` to change two lines isn't fetching a file — you want the text in front of you. `get_file` keeps that case; its refusal is now framed by **purpose, not size**. A rendered artefact goes to resources whatever it weighs, because a small PDF through the worse mechanism is still the worse mechanism.

**A test caught me classifying by extension**: any `.png` was treated as rendered output, so a logo the caller pushed was refused and pointed at a nonexistent page URI. Only what the server produced counts — a PDF, or a PNG under the preview directory.

## Page images, lazily (#109)

Nothing renders at compile time, because agents compile repeatedly and mostly never look — one pass compiled nine times. The first read of `typst-d2://page/doc.typ/2` renders the document once and caches the pages; a cached page older than its source is re-rendered, so a stale preview can't be served as current.

Previews live in the workspace and **count against the byte budget**, per your call — the caller asked for them, and hiding storage a caller caused is how a quota stops meaning anything. `delete_file` from #121 reclaims them, which is why those two decisions fit together.

This is the half of #109 that agents actually asked for: *"compile should return page images, since I only found the layout problems because `pdftoppm` happened to be on this machine."* Now they can look, without a rasteriser in the image — typst renders PNG natively.

Refers #109
Refers #111
