### PR TITLE
fix(templates): a bounded numbering argument, so cross-references work (#112)

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -428,9 +428,19 @@ func templateInstructions() string {
   Note "background", not "context": context is a reserved word in Typst.
   The rendered heading still reads "Context".
 
+  To cross-reference a heading with @label, pass numbering: "1." —
+  typst cannot reference an unnumbered heading, and its own suggested
+  fix (#set heading(numbering: ...)) is the restyling you must not do.
+
+    #show: report.with(title: "...", numbering: "1.")
+    = Overview <intro>
+    See @intro.
+
   Do not override the template's fonts, colours or page setup. A
   document that restyles itself has opted out of the house style, which
-  is the one thing these templates exist to prevent.
+  is the one thing these templates exist to prevent. numbering: is the
+  single exception, and it is bounded: it decides whether headings are
+  numbered and nothing else.
 
 `,
 		templateNamespace, templateName, templateVersion)

--- a/cmd/typst-d2-mcp/templates_test.go
+++ b/cmd/typst-d2-mcp/templates_test.go
@@ -91,6 +91,28 @@ Trailing content.
 #show: report.with(title: "Minimal")
 = Only a title
 `,
+		// #112: @ref to a heading is impossible in typst without
+		// numbering, and the compiler's own hint is the restyling these
+		// templates forbid. The argument exists so a caller need not
+		// choose between a broken reference and opting out.
+		"report with heading cross-references": `#import "@house/templates:0.1.0": report
+#show: report.with(title: "Cross-referenced", numbering: "1.")
+= Overview <intro>
+== Detail
+See @intro and @intro again.
+`,
+		"adr with heading cross-references": `#import "@house/templates:0.1.0": adr
+#show: adr.with(
+  title: "A decision",
+  number: 2,
+  background: [Why.],
+  decision: [What.],
+  consequences: [So what.],
+  numbering: "1.",
+)
+== Appendix <extra>
+See @extra.
+`,
 	}
 
 	for name, src := range cases {
@@ -216,4 +238,66 @@ func TestSeedBundledTemplates_Compiles(t *testing.T) {
 	if info, err := os.Stat(out); err != nil || info.Size() == 0 {
 		t.Errorf("no PDF produced from seeded package: %v", err)
 	}
+}
+
+// The argument is bounded: it decides whether headings are numbered and
+// nothing else. A default-argument document must look exactly as it did
+// before the argument existed — otherwise this would have been the
+// "enable numbering outright" option wearing a parameter.
+func TestHouseTemplates_NumberingDefaultsToUnchanged(t *testing.T) {
+	if _, err := exec.LookPath("typst"); err != nil {
+		t.Skip("typst not installed")
+	}
+	staged := stageHousePackage(t)
+
+	render := func(src string) string {
+		dir := t.TempDir()
+		in := filepath.Join(dir, "doc.typ")
+		out := filepath.Join(dir, "doc.txt")
+		if err := os.WriteFile(in, []byte(src), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.Command("typst", "compile", "--format", "html", "--features", "html", in, out)
+		cmd.Env = append(os.Environ(), "XDG_DATA_HOME="+staged)
+		if b, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("html export unavailable: %s", b)
+		}
+		raw, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(raw)
+	}
+
+	plain := render(`#import "@house/templates:0.1.0": report
+#show: report.with(title: "T")
+= Overview
+`)
+	if strings.Contains(plain, "1. Overview") || strings.Contains(plain, "1.Overview") {
+		t.Errorf("the default gained heading numbers:\n%s", plain)
+	}
+
+	numbered := render(`#import "@house/templates:0.1.0": report
+#show: report.with(title: "T", numbering: "1.")
+= Overview
+`)
+	if !strings.Contains(numbered, "Overview") {
+		t.Errorf("numbered render lost the heading:\n%s", numbered)
+	}
+}
+
+// stageHousePackage puts the repo's template tree where typst looks for
+// a local package, and returns the XDG_DATA_HOME to use.
+func stageHousePackage(t *testing.T) string {
+	t.Helper()
+	staged := t.TempDir()
+	pkgRoot := filepath.Join(staged, "typst", "packages")
+	if err := os.MkdirAll(pkgRoot, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(repoTemplates(t), templateNamespace),
+		filepath.Join(pkgRoot, templateNamespace)); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	return staged
 }

--- a/templates/README.md
+++ b/templates/README.md
@@ -132,6 +132,21 @@ that `_`- and `.`-prefixed entries are not silently dropped; a bare
 `//go:embed` skips them, which would build cleanly and fail at a user's
 compile.
 
+### The one styling argument
+
+`report` and `adr` both take `numbering:`, defaulting to `none`. It
+exists because typst forces the choice: `@label` cannot reference an
+unnumbered heading, and the compiler's suggested fix —
+`#set heading(numbering: "1.")` — is exactly the restyling these
+templates forbid. Refusing the argument would not have kept documents
+consistent; it would have sent authors to `#set` in their own documents,
+which is worse.
+
+It is bounded on purpose. It decides whether headings are numbered and
+nothing else; fonts, colours, geometry and the type scale still come
+from the template and only from the template. Treat it as the exception
+that proves the rule rather than the first of a series.
+
 ### Either way
 
 Two shapes exist deliberately:

--- a/templates/house/templates/0.1.0/lib.typ
+++ b/templates/house/templates/0.1.0/lib.typ
@@ -18,6 +18,13 @@
 //
 // Styling only ever comes from here. A document that overrides fonts or
 // colours has opted out of the house style, which defeats the point.
+//
+// One exception, and it is deliberate: `numbering:`. Cross-referencing a
+// heading with `@label` is impossible in typst without it, so refusing
+// the argument would not have kept documents consistent — it would have
+// sent authors to `#set heading(...)` in their own documents, which is
+// worse. The argument is bounded: it decides whether headings are
+// numbered and nothing else.
 
 #let _accent = rgb("#1f5673")
 #let _muted = rgb("#5b6b73")
@@ -25,7 +32,20 @@
 // Page geometry suits A4 portrait with diagrams: generous margins so a
 // wide `#d2` block has somewhere to breathe rather than touching the
 // edge of the page.
-#let _page-setup(body) = {
+#let _page-setup(numbering: none, body) = {
+  // Heading numbering is the ONE thing a document may ask this template
+  // to change, and it is here because typst forces the choice: `@ref`
+  // to a heading hard-errors without numbering, and the compiler's own
+  // hint is `#set heading(numbering: "1.")` — precisely the restyling
+  // these templates forbid. A caller following the compiler silently
+  // opted out of the house style; one following the instructions lost
+  // cross-references. Neither is a good outcome, so numbering became an
+  // argument rather than a rule to break.
+  //
+  // It is not a precedent for styling knobs generally. Everything else
+  // — fonts, colours, page geometry, the type scale — still comes from
+  // here and only from here.
+  set heading(numbering: numbering)
   set page(
     paper: "a4",
     margin: (top: 2.5cm, bottom: 2.5cm, x: 2.2cm),
@@ -83,9 +103,10 @@
   subtitle: none,
   author: none,
   date: datetime.today().display("[year]-[month]-[day]"),
+  numbering: none,
   body,
 ) = {
-  show: _page-setup
+  show: _page-setup.with(numbering: numbering)
   _title-block(title, subtitle, author, date)
   body
 }
@@ -113,9 +134,10 @@
   decision: [],
   consequences: [],
   alternatives: none,
+  numbering: none,
   body,
 ) = {
-  show: _page-setup
+  show: _page-setup.with(numbering: numbering)
 
   let heading-text = if number != none [ADR #number: #title] else [#title]
   _title-block(heading-text, none, none, date)


### PR DESCRIPTION
Fixes the contradiction an agent found: typst cannot reference an unnumbered heading, and the compiler's own hint is the restyling the templates forbid.

Verified against the real thing rather than from memory:

```
= Overview <intro>
See @intro.                    → error: cannot reference heading without numbering
#set heading(numbering: "1.")  → compiles   ← what typst tells you to do
#link(<intro>)[the overview]   → compiles   ← what the agent worked out
#figure(...) <fig> / @fig      → compiles   ← figures are fine, headings aren't
```

So it is narrow: `@ref` to a **heading**. Figures, tables and equations already carry numbering and reference fine.

## The change

`report` and `adr` take `numbering:`, defaulting to `none`.

**Every existing document renders exactly as before**, and that is asserted rather than assumed — `TestHouseTemplates_NumberingDefaultsToUnchanged` checks a default-argument document gains no numbers. Without that this would have been "enable numbering outright" wearing a parameter.

`adr` gets it too: its sections are generated, but an appendix cross-reference hits the identical wall.

## Why an argument rather than a rule

Refusing it would not have kept documents consistent. It would have sent authors to `#set heading(...)` in their own documents — worse, because that is unbounded and invisible. The argument is the smaller concession: it decides whether headings are numbered and nothing else, and fonts, colours, geometry and the type scale still come from the template and only from there.

Documented as the exception that proves the rule, in both `lib.typ` and the server instructions, so the next person asking for a styling knob has something to argue against.

Refers #112
