### PR TITLE
feat(fonts): ship a curated collection, and make fonts searchable (#120)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ARG TYPST_VERSION=v0.14.2
 # workspace fonts/ directory, where the licensing stays with the tenant.
 RUN apt-get update \
  && apt-get install --no-install-recommends -y \
-      ca-certificates curl tini xz-utils \
+      ca-certificates curl tini xz-utils unzip \
       fonts-dejavu-core fonts-liberation2 \
  && rm -rf /var/lib/apt/lists/*
 
@@ -85,6 +85,21 @@ RUN curl -fsSL "https://github.com/terrastruct/d2/releases/download/${D2_VERSION
 RUN curl -fsSL "https://github.com/typst/typst/releases/download/${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz" \
       | tar -xJ -C /usr/local/bin --strip-components=1 \
  && typst --version
+
+# A curated set of open-licensed typefaces, so a document has something
+# to be set in beyond the four faces typst embeds. See the script for
+# why these families and why statics over variable builds; the short
+# version is that a family must be callable by the name people write.
+#
+# Versions are pinned and archives fetched directly — not an install
+# script resolving "latest", which is the mistake #103 was about.
+ARG FONT_INTER=4.1
+ARG FONT_SOURCE_SERIF=4.005R
+ARG FONT_SOURCE_SANS=3.052R
+ARG FONT_JETBRAINS_MONO=2.304
+COPY fonts/manifest.json /usr/local/share/typst-d2/fonts/manifest.json
+COPY scripts/install-fonts.sh /tmp/install-fonts.sh
+RUN sh /tmp/install-fonts.sh && rm /tmp/install-fonts.sh
 
 # House document templates, resolved by typst as `@house/templates:0.1.0`.
 #

--- a/cmd/typst-d2-mcp/capabilities.go
+++ b/cmd/typst-d2-mcp/capabilities.go
@@ -168,3 +168,71 @@ func isPDFNameByte(c byte) bool {
 	return c == '-' || c == '_' ||
 		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
+
+// familiesUnder lists the font families a directory provides, ignoring
+// system and typst-embedded fonts so the answer is attributable to that
+// directory alone. An unreadable or absent path yields nothing, which
+// is the normal case for a tenant with no fonts of their own.
+func familiesUnder(dir string) []string {
+	if dir == "" {
+		return nil
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return nil
+	}
+	// #107, again. typst splits --font-path on the list separator, and a
+	// tenant directory is gh:<id> — so probing it directly reads
+	// nothing and reports the tenant has no fonts. The compile path
+	// solves this by routing through the package view; a probe has no
+	// view, so it borrows a colon-free name for the duration.
+	if !safeFontPath(dir) {
+		linked, cleanup, err := linkColonFree(dir)
+		if err != nil {
+			return nil
+		}
+		defer cleanup()
+		dir = linked
+	}
+	out, err := runProbe("typst", "fonts", "--font-path", dir,
+		"--ignore-system-fonts", "--ignore-embedded-fonts")
+	if err != nil {
+		return nil
+	}
+	return nonEmptyLines(out)
+}
+
+// embeddedFamilies lists what typst carries itself.
+func embeddedFamilies() []string {
+	out, err := runProbe("typst", "fonts", "--ignore-system-fonts")
+	if err != nil {
+		return nil
+	}
+	return nonEmptyLines(out)
+}
+
+func nonEmptyLines(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// linkColonFree gives a directory a name typst can be told about,
+// returning the safe path and a cleanup. The link target may contain
+// anything; only the argument on the command line has to be clean.
+func linkColonFree(dir string) (string, func(), error) {
+	tmp, err := os.MkdirTemp("", "typst-d2-fontprobe-*")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { _ = os.RemoveAll(tmp) }
+	link := filepath.Join(tmp, "fonts")
+	if err := os.Symlink(dir, link); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return link, cleanup, nil
+}

--- a/cmd/typst-d2-mcp/capabilities_test.go
+++ b/cmd/typst-d2-mcp/capabilities_test.go
@@ -52,8 +52,8 @@ func TestWorkspaceInfo_ReportsCapabilities(t *testing.T) {
 	if _, err := exec.LookPath("d2"); err == nil && info.D2Version == "" {
 		t.Error("d2_version not reported")
 	}
-	if len(info.FontFamilies) == 0 {
-		t.Fatal("font_families not reported")
+	if info.FontCount == 0 {
+		t.Fatal("no fonts reported as available")
 	}
 	if info.FontsDir != FontsDir {
 		t.Errorf("fonts_dir = %q, want %q", info.FontsDir, FontsDir)

--- a/cmd/typst-d2-mcp/files.go
+++ b/cmd/typst-d2-mcp/files.go
@@ -183,6 +183,7 @@ func handleSearchFile(factory workspace.Factory) server.ToolHandlerFunc {
 		contains := request.GetString("contains", "")
 
 		var hits []fileHit
+		var skipped []string
 		truncated := false
 		err = filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
 			if walkErr != nil || d.IsDir() {
@@ -206,8 +207,12 @@ func handleSearchFile(factory workspace.Factory) server.ToolHandlerFunc {
 			}
 			hit := fileHit{Path: rel, Bytes: info.Size(), Human: humanBytes(info.Size())}
 			if contains != "" {
-				line, found := firstMatchingLine(p, contains)
-				if !found {
+				line, result := firstMatchingLine(p, contains)
+				switch result {
+				case searchNoMatch:
+					return nil
+				case searchSkipped:
+					skipped = append(skipped, rel)
 					return nil
 				}
 				hit.Line = line
@@ -225,6 +230,13 @@ func handleSearchFile(factory workspace.Factory) server.ToolHandlerFunc {
 		sort.Slice(hits, func(i, j int) bool { return hits[i].Path < hits[j].Path })
 
 		out := map[string]any{"matches": hits, "count": len(hits)}
+		if len(skipped) > 0 {
+			// Say which files were not searched. Treating them as
+			// non-matches would hand back an answer that looks complete.
+			out["not_searched"] = skipped
+			out["not_searched_reason"] = fmt.Sprintf(
+				"larger than %s; search their contents another way", humanBytes(maxSearchBytes))
+		}
 		if truncated {
 			// Say so rather than silently returning a prefix — a
 			// truncated answer that looks complete is worse than none.
@@ -242,26 +254,53 @@ func handleSearchFile(factory workspace.Factory) server.ToolHandlerFunc {
 	}
 }
 
+// searchResult is what scanning one file for a needle produced.
+type searchResult int
+
+const (
+	searchNoMatch searchResult = iota
+	searchMatched
+	searchSkipped // too large, or not text
+)
+
+// maxSearchBytes bounds how much of one file a content search reads.
+// Generous, because silently not searching a document is worse than
+// spending a moment on a big one — and a file past it is REPORTED as
+// unsearched rather than quietly treated as a non-match.
+const maxSearchBytes = 4 << 20
+
 // firstMatchingLine returns the first line of a text file containing
-// needle. Binary files never match: searching them yields noise, and a
-// byte sequence found inside a PDF tells the caller nothing.
-func firstMatchingLine(path, needle string) (string, bool) {
+// needle, case-insensitively — matching how `name` behaves, because one
+// tool with two matching rules is a trap.
+//
+// Binary files never match: a byte sequence found inside a PDF tells
+// the caller nothing. A file too large to scan is reported as skipped,
+// not as a non-match: an answer that looks complete and is not is the
+// failure this whole tool exists to avoid.
+func firstMatchingLine(path, needle string) (string, searchResult) {
 	info, err := os.Stat(path)
-	if err != nil || info.Size() > maxGetFileBytes {
-		return "", false
+	if err != nil {
+		return "", searchSkipped
+	}
+	if info.Size() > maxSearchBytes {
+		return "", searchSkipped
 	}
 	data, err := os.ReadFile(path)
-	if err != nil || !utf8.Valid(data) {
-		return "", false
+	if err != nil {
+		return "", searchSkipped
 	}
+	if !utf8.Valid(data) {
+		return "", searchNoMatch // binary: a genuine non-match, not a skip
+	}
+	lowerNeedle := strings.ToLower(needle)
 	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, needle) {
+		if strings.Contains(strings.ToLower(line), lowerNeedle) {
 			line = strings.TrimSpace(line)
 			if len(line) > 160 {
 				line = line[:160] + "…"
 			}
-			return line, true
+			return line, searchMatched
 		}
 	}
-	return "", false
+	return "", searchNoMatch
 }

--- a/cmd/typst-d2-mcp/files_test.go
+++ b/cmd/typst-d2-mcp/files_test.go
@@ -280,3 +280,69 @@ func TestGetFile_UploadedImagesAreNotArtefacts(t *testing.T) {
 		t.Error("a PDF was not classed as an artefact")
 	}
 }
+
+// One tool, one matching rule. `name` was case-insensitive and
+// `contains` was not, so the same search behaved differently depending
+// which half you used.
+func TestSearchFile_ContentMatchIsCaseInsensitive(t *testing.T) {
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "doc.typ", "The Stormlantern engagement\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	for _, q := range []string{"stormlantern", "STORMLANTERN", "StOrMlAnTeRn"} {
+		got := decodeSearch(t, callTool(t, handleSearchFile(f), ctx, map[string]any{"contains": q}))
+		if n := int(got["count"].(float64)); n != 1 {
+			t.Errorf("contains %q found %d, want 1", q, n)
+		}
+	}
+}
+
+// A file too large to scan must be reported as unsearched, not quietly
+// treated as a non-match — an answer that looks complete and is not is
+// the failure this tool exists to avoid.
+func TestSearchFile_ReportsWhatItCouldNotSearch(t *testing.T) {
+	f, ctx := fileFixture(t)
+	// A file this large can only be built by chunked append in normal
+	// use; raise the per-call cap so the fixture is one write.
+	t.Setenv(envMaxInputBytes, "8388608")
+	big := strings.Repeat("padding line\n", (maxSearchBytes/13)+64)
+	if res := putFile(t, ctx, f, "huge.typ", big); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	if res := putFile(t, ctx, f, "small.typ", "findme\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+
+	got := decodeSearch(t, callTool(t, handleSearchFile(f), ctx, map[string]any{"contains": "findme"}))
+	skipped, ok := got["not_searched"].([]any)
+	if !ok || len(skipped) != 1 {
+		t.Fatalf("a file too large to scan was not reported: %v", got)
+	}
+	if skipped[0].(string) != "huge.typ" {
+		t.Errorf("reported %v as unsearched, want huge.typ", skipped[0])
+	}
+	if int(got["count"].(float64)) != 1 {
+		t.Errorf("the searchable file was not matched: %v", got)
+	}
+}
+
+// A binary file is a genuine non-match, not something we failed to
+// search — it must not appear in not_searched.
+func TestSearchFile_BinaryIsANonMatchNotASkip(t *testing.T) {
+	f, ctx := fileFixture(t)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"path": "img.png", "content": base64.StdEncoding.EncodeToString([]byte(testPNG)),
+		"encoding": "base64",
+	}
+	if _, err := handlePutFile(f, nil)(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+	got := decodeSearch(t, callTool(t, handleSearchFile(f), ctx, map[string]any{"contains": "PNG"}))
+	if got["not_searched"] != nil {
+		t.Errorf("a binary file was reported as unsearched: %v", got["not_searched"])
+	}
+	if int(got["count"].(float64)) != 0 {
+		t.Errorf("a binary file matched a content search")
+	}
+}

--- a/cmd/typst-d2-mcp/fonts.go
+++ b/cmd/typst-d2-mcp/fonts.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Fonts arrive from four places and none of them was discoverable
+// together: typst's embedded faces, the collection this image ships, a
+// tenant's own fonts/ directory, and the fonts inside a template they
+// can import. A caller choosing a typeface had to reason across four
+// mechanisms, three of them invisible — so two research agents went and
+// fetched fonts from the internet rather than ask what was already
+// there.
+//
+// Search rather than a list, for the same reason as files: nobody wants
+// to read family names, they want to know whether a humanist sans is
+// available or whether a particular family is here.
+//
+// The answer is derived from the SAME paths a compile resolves, and
+// attributed by asking typst about each source separately. That is not
+// tidiness: this area's recurring failure is the server saying one
+// thing and typst doing another (#107), so agreement is built in rather
+// than maintained.
+
+// fontsDirName is where the image keeps the collection it ships.
+const bundledFontsPath = "/usr/local/share/typst-d2/fonts"
+
+// fontFace is one family, and where it comes from.
+type fontFace struct {
+	Family  string `json:"family"`
+	Source  string `json:"source"`
+	Origin  string `json:"origin,omitempty"`
+	License string `json:"license,omitempty"`
+	Note    string `json:"note,omitempty"`
+}
+
+// manifestEntry describes a bundled family. Recorded rather than
+// inferred, so "may we redistribute this?" is answerable later without
+// archaeology.
+type manifestEntry struct {
+	Family  string `json:"family"`
+	License string `json:"license"`
+	Origin  string `json:"origin"`
+	Note    string `json:"note,omitempty"`
+}
+
+func loadFontManifest() map[string]manifestEntry {
+	out := map[string]manifestEntry{}
+	raw, err := os.ReadFile(filepath.Join(bundledFontsPath, "manifest.json"))
+	if err != nil {
+		return out
+	}
+	var entries []manifestEntry
+	if json.Unmarshal(raw, &entries) != nil {
+		return out
+	}
+	for _, e := range entries {
+		out[strings.ToLower(e.Family)] = e
+	}
+	return out
+}
+
+func handleSearchFonts(factory workspace.Factory, store *authdb.Store) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		query := strings.ToLower(strings.TrimSpace(request.GetString("query", "")))
+		resolver, err := resolverFor(ctx, factory)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("workspace setup", err), nil
+		}
+		id, _ := identity.FromContext(ctx)
+
+		faces := collectFonts(ctx, store, id, resolver)
+
+		var hits []fontFace
+		for _, f := range faces {
+			if query != "" && !strings.Contains(strings.ToLower(f.Family), query) {
+				continue
+			}
+			hits = append(hits, f)
+		}
+		sort.Slice(hits, func(i, j int) bool { return hits[i].Family < hits[j].Family })
+
+		out := map[string]any{"fonts": hits, "count": len(hits)}
+		if len(hits) == 0 {
+			out["note"] = "Nothing matched. Omit query to see everything available to you, " +
+				"or push a .ttf/.otf to your workspace fonts/ directory to use your own."
+		} else {
+			out["note"] = "Every family listed here resolves in a compile by you. " +
+				"A family NOT listed will be silently substituted by typst, producing a " +
+				"document that looks fine and is wrong."
+		}
+		payload, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("encode fonts", err), nil
+		}
+		return mcp.NewToolResultText(string(payload)), nil
+	}
+}
+
+// collectFonts asks typst what each source provides, so the answer
+// cannot drift from what a compile resolves.
+func collectFonts(ctx context.Context, store *authdb.Store, id identity.Identity, r workspace.Resolver) []fontFace {
+	manifest := loadFontManifest()
+	seen := map[string]bool{}
+	var out []fontFace
+
+	add := func(family, source, origin string) {
+		key := strings.ToLower(family)
+		if family == "" || seen[key] {
+			return
+		}
+		seen[key] = true
+		f := fontFace{Family: family, Source: source, Origin: origin}
+		if m, ok := manifest[key]; ok {
+			f.License, f.Origin, f.Note = m.License, m.Origin, m.Note
+		}
+		out = append(out, f)
+	}
+
+	// A tenant's own fonts win the attribution: if they shipped a family
+	// that shadows a bundled one, theirs is the one in force.
+	if ws := workspaceFontPath(r); ws != "" {
+		for _, fam := range familiesUnder(ws) {
+			add(fam, "workspace", "your fonts/ directory")
+		}
+	}
+	// Then anything inside a template they can import.
+	if allowed, err := allowedNamespaces(ctx, store, id); err == nil {
+		for _, name := range sortedNames(allowed) {
+			nsRoot := filepath.Join(typstDataDir(), "typst", "packages", allowed[name])
+			for _, fam := range familiesUnder(nsRoot) {
+				add(fam, "template", "@"+name)
+			}
+		}
+	}
+	for _, fam := range familiesUnder(bundledFontsPath) {
+		add(fam, "bundled", "shipped with this server")
+	}
+	for _, fam := range embeddedFamilies() {
+		add(fam, "built-in", "built into typst")
+	}
+	return out
+}

--- a/cmd/typst-d2-mcp/fonts_test.go
+++ b/cmd/typst-d2-mcp/fonts_test.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func searchFonts(t *testing.T, ctx context.Context, f workspace.Factory, store *authdb.Store, query string) map[string]any {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	args := map[string]any{}
+	if query != "" {
+		args["query"] = query
+	}
+	req.Params.Arguments = args
+	res, err := handleSearchFonts(f, store)(ctx, req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("search_fonts: %s", resultText(res))
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("decode: %v\n%s", err, resultText(res))
+	}
+	return out
+}
+
+func familyNames(out map[string]any) []string {
+	var names []string
+	for _, f := range out["fonts"].([]any) {
+		names = append(names, f.(map[string]any)["family"].(string))
+	}
+	return names
+}
+
+// typst's own faces must always be findable — they are what a document
+// gets when nothing else is available.
+func TestSearchFonts_FindsBuiltins(t *testing.T) {
+	requireTypst(t)
+	f, ctx := fileFixture(t)
+
+	got := searchFonts(t, ctx, f, nil, "libertinus")
+	names := familyNames(got)
+	if len(names) == 0 {
+		t.Fatalf("built-in family not found: %v", got)
+	}
+	for _, entry := range got["fonts"].([]any) {
+		if src := entry.(map[string]any)["source"].(string); src != "built-in" {
+			t.Errorf("Libertinus attributed to %q, want built-in", src)
+		}
+	}
+}
+
+// A font the caller pushed must be findable, and attributed to them —
+// this is the discovery half of what #107 fixed the rendering half of.
+func TestSearchFonts_FindsWorkspaceFontsAndAttributesThem(t *testing.T) {
+	requireTypst(t)
+	src := findSystemFont(t)
+	f, ctx := fileFixture(t)
+
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"path":    FontsDir + "/" + filepath.Base(src),
+		"content": base64.StdEncoding.EncodeToString(raw), "encoding": "base64",
+	}
+	if res, err := handlePutFile(f, nil)(ctx, req); err != nil || res.IsError {
+		t.Fatalf("put_file: %v", err)
+	}
+
+	resolver, err := f.Resolver(identity.Identity{UserID: "gh:4242"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pushed := familiesUnder(workspaceFontPath(resolver))
+	if len(pushed) == 0 {
+		t.Skip("could not determine the pushed family")
+	}
+
+	got := searchFonts(t, ctx, f, nil, strings.ToLower(pushed[0]))
+	var found bool
+	for _, entry := range got["fonts"].([]any) {
+		m := entry.(map[string]any)
+		if m["family"].(string) == pushed[0] {
+			found = true
+			if src := m["source"].(string); src != "workspace" {
+				t.Errorf("a pushed font is attributed to %q, want workspace", src)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("a font pushed to fonts/ is not findable: %v", familyNames(got))
+	}
+}
+
+// The promise the tool makes: everything it lists actually resolves.
+// The recurring failure in this area is the server saying one thing and
+// typst doing another, so check the claim against a real compile.
+func TestSearchFonts_EverythingListedActuallyResolves(t *testing.T) {
+	requireTypst(t)
+	f, ctx := fileFixture(t)
+
+	got := searchFonts(t, ctx, f, nil, "")
+	names := familyNames(got)
+	if len(names) == 0 {
+		t.Fatal("nothing reported at all")
+	}
+
+	dir := t.TempDir()
+	for _, family := range names {
+		in := filepath.Join(dir, "probe.typ")
+		out := filepath.Join(dir, "probe.pdf")
+		src := "#set text(font: \"" + family + "\")\nProbe.\n"
+		if err := os.WriteFile(in, []byte(src), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.Command("typst", "compile", in, out)
+		combined, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Errorf("%s: reported but does not compile: %s", family, combined)
+			continue
+		}
+		if strings.Contains(strings.ToLower(string(combined)), "unknown font family") {
+			t.Errorf("%s: reported available but typst substituted it", family)
+		}
+	}
+}
+
+// Nothing matching says so, and says what to do about it.
+func TestSearchFonts_EmptyResultIsActionable(t *testing.T) {
+	requireTypst(t)
+	f, ctx := fileFixture(t)
+	got := searchFonts(t, ctx, f, nil, "a-family-that-does-not-exist")
+	if got["count"].(float64) != 0 {
+		t.Fatalf("unexpected matches: %v", familyNames(got))
+	}
+	note, _ := got["note"].(string)
+	if !strings.Contains(note, "fonts/") {
+		t.Errorf("empty result does not say how to add one: %q", note)
+	}
+}
+
+// #107 came back in new code, and this is the guard. A tenant path
+// contains a colon; typst splits --font-path on it and reads nothing,
+// so probing a tenant's font directory directly reported that they had
+// no fonts. Caught by a skipping test, which is exactly how the
+// original hid for a day.
+func TestFamiliesUnder_SurvivesAColonInThePath(t *testing.T) {
+	requireTypst(t)
+	src := findSystemFont(t)
+
+	root := t.TempDir()
+	colon := filepath.Join(root, "gh:4242", "fonts")
+	if err := os.MkdirAll(colon, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(colon, filepath.Base(src)), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := familiesUnder(colon); len(got) == 0 {
+		t.Error("a font directory whose path contains a colon reported no families")
+	}
+
+	plain := filepath.Join(root, "plain")
+	if err := os.MkdirAll(plain, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(plain, filepath.Base(src)), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if a, b := familiesUnder(colon), familiesUnder(plain); len(a) != len(b) {
+		t.Errorf("colon path found %d families, colon-free found %d — must agree", len(a), len(b))
+	}
+}
+
+// The manifest is a promise about what this image ships. A family it
+// names that typst cannot resolve is the same species of lie as #107 —
+// the server saying one thing and typst doing another — so the two are
+// checked against each other rather than trusted.
+func TestFontManifest_MatchesWhatIsInstalled(t *testing.T) {
+	requireTypst(t)
+	entries := loadFontManifest()
+	if len(entries) == 0 {
+		t.Skip("no bundled collection on this machine (manifest is installed by the image)")
+	}
+	resolved := map[string]bool{}
+	for _, fam := range familiesUnder(bundledFontsPath) {
+		resolved[strings.ToLower(fam)] = true
+	}
+	for key, e := range entries {
+		if !resolved[key] {
+			t.Errorf("manifest promises %q but typst does not resolve it", e.Family)
+		}
+		if e.License == "" {
+			t.Errorf("%s has no recorded licence — the image is redistributed", e.Family)
+		}
+		if e.Origin == "" {
+			t.Errorf("%s has no recorded origin", e.Family)
+		}
+	}
+}
+
+// The repo's manifest must be well-formed and licensed, whether or not
+// the collection is installed on this machine.
+func TestFontManifest_InRepoIsComplete(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "fonts", "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var entries []manifestEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("manifest is empty")
+	}
+	for _, e := range entries {
+		if e.Family == "" || e.License == "" || e.Origin == "" {
+			t.Errorf("incomplete entry: %+v", e)
+		}
+		// Redistribution is the constraint; record it per family so the
+		// question stays answerable without archaeology.
+		if !strings.Contains(e.License, "OFL") && !strings.Contains(e.License, "Apache") {
+			t.Errorf("%s is licensed %q — check redistribution before shipping it",
+				e.Family, e.License)
+		}
+	}
+}

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -1094,10 +1094,10 @@ No arguments; returns JSON:
     remaining space, present only when a budget is configured (absent =
     no cap). A put_file over available_bytes is rejected.
   - typst_version / d2_version: the binaries this server actually runs.
-  - font_families: every font family a compile can resolve, including
-    any you have pushed. Typst SUBSTITUTES an unknown family silently
-    and still exits 0, so a document naming one produces a PDF that
-    looks fine and is wrong — check this list before setting a font.
+  - font_families_available: how many families you can use. Call
+    search_fonts to find one by name — typst SUBSTITUTES an unknown
+    family silently and still exits 0, so a document naming one
+    produces a PDF that looks fine and is wrong.
   - fonts_dir: push .ttf/.otf files here (via put_file) to use your own
     typefaces; they are visible only to your workspace. Present only
     where the workspace is bounded.
@@ -1229,6 +1229,26 @@ is taking up your byte budget before deleting anything.`),
 			mcp.Description("Text that must appear inside the file. Text files only.")),
 	)
 	s.AddTool(searchFileTool, handleSearchFile(factory))
+
+	searchFontsTool := mcp.NewTool("search_fonts",
+		mcp.WithDescription(`Find a typeface you can actually use.
+
+CHECK HERE BEFORE SETTING A FONT. typst substitutes an unknown family
+silently and still exits 0, so a document naming one renders fine and is
+wrong — and nothing downstream tells you.
+
+  query   part of a family name ("garamond", "mono"); omit for everything
+
+Every family returned resolves in a compile by you. Fonts come from four
+places and this searches all of them: the collection shipped with this
+server, your workspace fonts/ directory, the fonts inside any template
+you can import, and the faces built into typst.
+
+To use your own: put_file the .ttf/.otf into fonts/ and it appears here.`),
+		mcp.WithString("query",
+			mcp.Description("Part of a family name, case-insensitive. Omit to list everything.")),
+	)
+	s.AddTool(searchFontsTool, handleSearchFonts(factory, store))
 }
 
 func handleCompileTypst(factory workspace.Factory, store *authdb.Store) server.ToolHandlerFunc {
@@ -1735,10 +1755,10 @@ type workspaceInfo struct {
 	// spending a compile on a probe document — and typst substitutes a
 	// missing font silently, so the probe was the only way to find out
 	// at all.
-	TypstVersion string   `json:"typst_version,omitempty"`
-	D2Version    string   `json:"d2_version,omitempty"`
-	FontFamilies []string `json:"font_families,omitempty"`
-	FontsDir     string   `json:"fonts_dir,omitempty"`
+	TypstVersion string `json:"typst_version,omitempty"`
+	D2Version    string `json:"d2_version,omitempty"`
+	FontCount    int    `json:"font_families_available,omitempty"`
+	FontsDir     string `json:"fonts_dir,omitempty"`
 }
 
 func handleWorkspaceInfo(factory workspace.Factory, store *authdb.Store) server.ToolHandlerFunc {
@@ -1747,6 +1767,7 @@ func handleWorkspaceInfo(factory workspace.Factory, store *authdb.Store) server.
 		if err != nil {
 			return mcp.NewToolResultErrorFromErr("workspace setup", err), nil
 		}
+		callerID, _ := identity.FromContext(ctx)
 		limit := maxInputBytes()
 		used, tracked, err := workspace.Usage(resolver)
 		if err != nil {
@@ -1759,7 +1780,11 @@ func handleWorkspaceInfo(factory workspace.Factory, store *authdb.Store) server.
 			UsageTracked:      tracked,
 			TypstVersion:      typstVersion,
 			D2Version:         d2Version,
-			FontFamilies:      fontFamilies(workspaceFontPath(resolver)),
+			// A count, not the list. Enumerating every family cost more
+			// than the whole instruction block on a font-rich host, and
+			// answered a question nobody asks — "which fonts exist" is
+			// search_fonts' job, and it can attribute each one.
+			FontCount: len(collectFonts(ctx, store, callerID, resolver)),
 		}
 		if _, ok := resolver.(workspace.Bounded); ok {
 			info.FontsDir = FontsDir
@@ -1771,8 +1796,7 @@ func handleWorkspaceInfo(factory workspace.Factory, store *authdb.Store) server.
 			// Budget/available only when a budget applies (per-workspace
 			// override, else the env default). Unconfigured means unlimited,
 			// so the fields stay absent.
-			id, _ := identity.FromContext(ctx)
-			if budget := effectiveWorkspaceBudget(ctx, store, id); budget > 0 {
+			if budget := effectiveWorkspaceBudget(ctx, store, callerID); budget > 0 {
 				b := budget
 				info.BudgetBytes = &b
 				info.BudgetHuman = humanBytes(budget)

--- a/fonts/manifest.json
+++ b/fonts/manifest.json
@@ -1,0 +1,26 @@
+[
+  {
+    "family": "Inter",
+    "license": "SIL OFL 1.1",
+    "origin": "rsms/inter",
+    "note": "Neutral grotesque. Dense documents, tables, UI-like material."
+  },
+  {
+    "family": "Source Serif 4",
+    "license": "SIL OFL 1.1",
+    "origin": "adobe-fonts/source-serif",
+    "note": "Transitional serif. A workhorse for running text."
+  },
+  {
+    "family": "Source Sans 3",
+    "license": "SIL OFL 1.1",
+    "origin": "adobe-fonts/source-sans",
+    "note": "Humanist sans. Warmer than Inter; good for body text."
+  },
+  {
+    "family": "JetBrains Mono",
+    "license": "SIL OFL 1.1",
+    "origin": "JetBrains/JetBrainsMono",
+    "note": "Monospace. Code, data, anything that must align."
+  }
+]

--- a/scripts/install-fonts.sh
+++ b/scripts/install-fonts.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Install the curated typeface collection into the runtime image.
+#
+# Variable fonts throughout: typst honours the axes, so one ~1MB file
+# covers a whole weight range that would take several megabytes as
+# statics — smaller and more capable at once.
+#
+# Pinned release archives, fetched directly. NOT an install script and
+# not "latest": #103 was exactly that mistake, where CI resolved a
+# version through a rate-limited API and then silently drifted from the
+# image. Bump the versions below deliberately.
+#
+# Every face is SIL OFL 1.1, which permits redistribution here. The
+# licence text ships beside the fonts and fonts/manifest.json records
+# the licence per family, so "may we ship this?" stays answerable
+# without archaeology.
+set -eu
+
+INTER=${FONT_INTER:-4.1}
+SOURCE_SERIF=${FONT_SOURCE_SERIF:-4.005R}
+SOURCE_SANS=${FONT_SOURCE_SANS:-3.052R}
+JETBRAINS_MONO=${FONT_JETBRAINS_MONO:-2.304}
+
+DEST=${FONT_DEST:-/usr/local/share/typst-d2/fonts}
+mkdir -p "$DEST"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fetch() { curl -fsSL --retry 3 --retry-delay 2 -o "$2" "$1"; }
+
+echo "==> Inter $INTER"
+# Statics. The variable pair reports itself as "Inter Variable", so
+# `#set text(font: "Inter")` — the name anyone would actually write —
+# would silently substitute. That is the failure this collection exists
+# to prevent, so the family has to be callable by its own name.
+fetch "https://github.com/rsms/inter/releases/download/v${INTER}/Inter-${INTER}.zip" "$tmp/inter.zip"
+unzip -q -j "$tmp/inter.zip" \
+  "extras/ttf/Inter-Regular.ttf" "extras/ttf/Inter-Italic.ttf" \
+  "extras/ttf/Inter-SemiBold.ttf" "extras/ttf/Inter-Bold.ttf" \
+  "LICENSE.txt" -d "$tmp/inter"
+cp "$tmp/inter"/Inter-*.ttf "$DEST/"
+cp "$tmp/inter/LICENSE.txt" "$DEST/Inter-LICENSE.txt"
+
+echo "==> Source Serif $SOURCE_SERIF"
+# Statics, not the variable file. Adobe's variable builds report
+# themselves as "Source Serif 4 Variable" and "SourceSans3VF", which
+# nobody searching for "source serif" will find — and a family a caller
+# cannot name is a family they cannot use. The statics carry the plain
+# names. Four weights rather than a continuous axis is the price.
+# The asset name drops the R suffix the tag carries.
+fetch "https://github.com/adobe-fonts/source-serif/releases/download/${SOURCE_SERIF}/source-serif-${SOURCE_SERIF%R}_Desktop.zip" "$tmp/ss.zip"
+unzip -q -j "$tmp/ss.zip" \
+  "*/TTF/SourceSerif4-Regular.ttf" "*/TTF/SourceSerif4-It.ttf" \
+  "*/TTF/SourceSerif4-Semibold.ttf" "*/TTF/SourceSerif4-Bold.ttf" -d "$tmp/ss"
+cp "$tmp/ss"/*.ttf "$DEST/"
+
+echo "==> Source Sans $SOURCE_SANS"
+fetch "https://github.com/adobe-fonts/source-sans/releases/download/${SOURCE_SANS}/TTF-source-sans-${SOURCE_SANS}.zip" "$tmp/sa.zip"
+unzip -q -j "$tmp/sa.zip" \
+  "TTF/SourceSans3-Regular.ttf" "TTF/SourceSans3-It.ttf" \
+  "TTF/SourceSans3-Semibold.ttf" "TTF/SourceSans3-Bold.ttf" -d "$tmp/sa"
+cp "$tmp/sa"/*.ttf "$DEST/"
+
+echo "==> Adobe OFL texts"
+fetch "https://raw.githubusercontent.com/adobe-fonts/source-serif/release/LICENSE.md" "$DEST/SourceSerif-LICENSE.md"
+fetch "https://raw.githubusercontent.com/adobe-fonts/source-sans/release/LICENSE.md" "$DEST/SourceSans-LICENSE.md"
+
+echo "==> JetBrains Mono $JETBRAINS_MONO"
+fetch "https://github.com/JetBrains/JetBrainsMono/releases/download/v${JETBRAINS_MONO}/JetBrainsMono-${JETBRAINS_MONO}.zip" "$tmp/jb.zip"
+unzip -q -j "$tmp/jb.zip" "fonts/variable/*.ttf" "OFL.txt" -d "$tmp/jb"
+cp "$tmp/jb"/*.ttf "$DEST/"
+cp "$tmp/jb/OFL.txt" "$DEST/JetBrainsMono-OFL.txt"
+
+echo "==> installed:"
+du -ch "$DEST"/*.ttf "$DEST"/*.otf 2>/dev/null | tail -1
+
+# The build fails here rather than shipping an image whose manifest
+# promises families typst cannot see.
+if command -v typst >/dev/null 2>&1; then
+  echo "==> families typst resolves from the collection:"
+  typst fonts --font-path "$DEST" --ignore-system-fonts --ignore-embedded-fonts | sed 's/^/    /'
+
+  # A manifest that names a family typst cannot resolve is the failure
+  # this whole area keeps producing — the server saying one thing and
+  # typst doing another. Fail the build rather than ship it.
+  if [ -f "$DEST/manifest.json" ]; then
+    resolved=$(typst fonts --font-path "$DEST" --ignore-system-fonts --ignore-embedded-fonts)
+    missing=0
+    # Read line by line: family names contain spaces, and a for-loop
+    # over command substitution would split "Source Sans 3" into three.
+    sed -n 's/.*"family": *"\([^"]*\)".*/\1/p' "$DEST/manifest.json" | while IFS= read -r fam; do
+      echo "$resolved" | grep -qxF "$fam" || { echo "    MISSING: manifest promises \"$fam\""; exit 1; }
+    done || missing=1
+    [ "$missing" -eq 0 ] || { echo "manifest and reality disagree"; exit 1; }
+  fi
+fi


### PR DESCRIPTION
Your reframe: search, not a list — and a collection worth searching.

## `search_fonts`

Fonts arrived from four places and none was discoverable together: typst's embedded faces, whatever the host had installed, a tenant's `fonts/`, and the fonts inside an importable template. Two research agents fetched typefaces from the internet rather than ask what was there, because there was no way to ask.

The answer is derived from **the same paths a compile resolves**, attributed by asking typst about each source separately. Not for tidiness — this area's recurring failure is the server saying one thing and typst doing another (#107). `TestSearchFonts_EverythingListedActuallyResolves` compiles a probe document in **every family the tool reports** and fails if typst substitutes any of them.

## The collection — 4 families, 4.7MB, all SIL OFL 1.1

| family | role |
|---|---|
| Source Serif 4 | transitional serif, running text |
| Source Sans 3 | humanist sans, warmer body text |
| Inter | neutral grotesque, dense documents and tables |
| JetBrains Mono | monospace, code and anything that must align |

**Statics rather than variable builds, which was not the plan.** typst *does* honour variable axes — I verified one file covering weights 300/400/700 at 880KB versus 1.66MB for four statics that cover less. But Adobe's variable builds report themselves as `Source Serif 4 Variable` and `SourceSans3VF`, and Inter's pair as `Inter Variable`. A family nobody can name is a family nobody can use: `#set text(font: "Inter")` would have silently substituted — precisely what the collection exists to prevent. Correct names beat 2MB.

## The build fails if the manifest lies

The manifest records licence and origin per family, and `install-fonts.sh` refuses to finish if it names a family typst cannot resolve. **That check found the Inter discrepancy** — I had already written `"Inter"` into the manifest and would have shipped it.

Versions pinned, archives fetched directly, no install script resolving "latest" — the #103 mistake, not repeated.

## `workspace_info` reports a count now

The full list cost more than the entire instruction block on a font-rich host and answered a question nobody asks. Which fonts exist is `search_fonts`' job, and it can say where each one came from.

## One regression, caught by its own test

Probing a tenant's font directory passed the raw path to typst, which splits on `:` — **#107 reappearing in new code within a day of being fixed**. The probe now borrows a colon-free name, with a test that a colon path and a clean path agree.

## Not done here

Category search (serif/sans/mono) — the manifest has the vocabulary in its notes but nothing structured. Worth adding if "find me a humanist sans" turns out to be a real query rather than one I imagined.

Refers #120
