### PR TITLE
fix(workspace): stop putting a colon in tenant paths

### DIFF
--- a/cmd/typst-d2-mcp/capabilities.go
+++ b/cmd/typst-d2-mcp/capabilities.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -180,18 +181,15 @@ func familiesUnder(dir string) []string {
 	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 		return nil
 	}
-	// #107, again. typst splits --font-path on the list separator, and a
-	// tenant directory is gh:<id> — so probing it directly reads
-	// nothing and reports the tenant has no fonts. The compile path
-	// solves this by routing through the package view; a probe has no
-	// view, so it borrows a colon-free name for the duration.
+	// workspace.DirName guarantees tenant paths carry no list separator,
+	// so a path can simply be named. This is the assertion that the
+	// guarantee holds: an unsafe path is refused LOUDLY rather than
+	// quietly returning nothing. Silence was the actual harm in #107 —
+	// the fonts were missing and everything said they were fine.
 	if !safeFontPath(dir) {
-		linked, cleanup, err := linkColonFree(dir)
-		if err != nil {
-			return nil
-		}
-		defer cleanup()
-		dir = linked
+		slog.Error("refusing to probe a font path containing the list separator; "+
+			"typst would read nothing from it", "path", dir)
+		return nil
 	}
 	out, err := runProbe("typst", "fonts", "--font-path", dir,
 		"--ignore-system-fonts", "--ignore-embedded-fonts")
@@ -218,21 +216,4 @@ func nonEmptyLines(s string) []string {
 		}
 	}
 	return out
-}
-
-// linkColonFree gives a directory a name typst can be told about,
-// returning the safe path and a cleanup. The link target may contain
-// anything; only the argument on the command line has to be clean.
-func linkColonFree(dir string) (string, func(), error) {
-	tmp, err := os.MkdirTemp("", "typst-d2-fontprobe-*")
-	if err != nil {
-		return "", nil, err
-	}
-	cleanup := func() { _ = os.RemoveAll(tmp) }
-	link := filepath.Join(tmp, "fonts")
-	if err := os.Symlink(dir, link); err != nil {
-		cleanup()
-		return "", nil, err
-	}
-	return link, cleanup, nil
 }

--- a/cmd/typst-d2-mcp/capabilities_test.go
+++ b/cmd/typst-d2-mcp/capabilities_test.go
@@ -93,7 +93,7 @@ func TestRenderEnvironment_HasProportionalSans(t *testing.T) {
 // so naming that path directly was silently discarded (#107).
 func TestTypstArgs_WorkspaceFontsReachTypstViaTheView(t *testing.T) {
 	root := t.TempDir()
-	tenant := filepath.Join(root, "gh:4242")
+	tenant := filepath.Join(root, workspace.DirName("gh:4242"))
 	fonts := filepath.Join(tenant, FontsDir)
 	if err := os.MkdirAll(fonts, 0o755); err != nil {
 		t.Fatal(err)

--- a/cmd/typst-d2-mcp/compileassets_test.go
+++ b/cmd/typst-d2-mcp/compileassets_test.go
@@ -68,7 +68,7 @@ func TestCompile_WorkspaceAssetIsReferenceable(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("compile failed: %s", resultText(res))
 	}
-	assertPDF(t, filepath.Join(root, "user123", "doc.pdf"))
+	assertPDF(t, filepath.Join(root, workspace.DirName("user123"), "doc.pdf"))
 }
 
 // Same for a raster asset, which travels through put_file as base64.
@@ -102,7 +102,7 @@ func TestCompile_WorkspaceRasterAssetIsReferenceable(t *testing.T) {
 	if res := compile(t, ctx, factory, "doc.typ"); res.IsError {
 		t.Fatalf("compile failed: %s", resultText(res))
 	}
-	assertPDF(t, filepath.Join(root, "user123", "doc.pdf"))
+	assertPDF(t, filepath.Join(root, workspace.DirName("user123"), "doc.pdf"))
 }
 
 // A relative #import of another workspace file must resolve too — the
@@ -126,7 +126,7 @@ func TestCompile_WorkspaceImportResolves(t *testing.T) {
 	if res := compile(t, ctx, factory, "doc.typ"); res.IsError {
 		t.Fatalf("compile failed: %s", resultText(res))
 	}
-	assertPDF(t, filepath.Join(root, "user123", "doc.pdf"))
+	assertPDF(t, filepath.Join(root, workspace.DirName("user123"), "doc.pdf"))
 }
 
 // An asset in a subdirectory, referenced both relatively and from the
@@ -151,7 +151,7 @@ func TestCompile_AssetInSubdirectory(t *testing.T) {
 	if res := compile(t, ctx, factory, "docs/doc.typ"); res.IsError {
 		t.Fatalf("compile failed: %s", resultText(res))
 	}
-	assertPDF(t, filepath.Join(root, "user123", "docs", "doc.pdf"))
+	assertPDF(t, filepath.Join(root, workspace.DirName("user123"), "docs", "doc.pdf"))
 }
 
 // Moving the compile root into the workspace must not open a way out of
@@ -245,7 +245,7 @@ func TestCompile_D2StillPreprocessed(t *testing.T) {
 	if res := compile(t, ctx, factory, "doc.typ"); res.IsError {
 		t.Fatalf("compile failed: %s", resultText(res))
 	}
-	assertPDF(t, filepath.Join(root, "user123", "doc.pdf"))
+	assertPDF(t, filepath.Join(root, workspace.DirName("user123"), "doc.pdf"))
 }
 
 // The staged source is server scratch: it must be gone once the compile
@@ -264,7 +264,7 @@ func TestCompile_StagedFileIsCleanedUp(t *testing.T) {
 		t.Fatalf("compile failed: %s", resultText(res))
 	}
 
-	entries, err := os.ReadDir(filepath.Join(root, "user123"))
+	entries, err := os.ReadDir(filepath.Join(root, workspace.DirName("user123")))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/typst-d2-mcp/fonts_test.go
+++ b/cmd/typst-d2-mcp/fonts_test.go
@@ -156,41 +156,33 @@ func TestSearchFonts_EmptyResultIsActionable(t *testing.T) {
 	}
 }
 
-// #107 came back in new code, and this is the guard. A tenant path
-// contains a colon; typst splits --font-path on it and reads nothing,
-// so probing a tenant's font directory directly reported that they had
-// no fonts. Caught by a skipping test, which is exactly how the
-// original hid for a day.
-func TestFamiliesUnder_SurvivesAColonInThePath(t *testing.T) {
-	requireTypst(t)
-	src := findSystemFont(t)
-
+// #107's root cause is gone: workspace.DirName means a tenant path
+// cannot contain the list separator, so nothing downstream has to
+// compensate for one. What remains is the assertion that the guarantee
+// holds — an unsafe path is refused loudly rather than quietly
+// returning nothing, because silence was the actual harm.
+func TestFontPaths_CannotContainTheListSeparator(t *testing.T) {
 	root := t.TempDir()
-	colon := filepath.Join(root, "gh:4242", "fonts")
-	if err := os.MkdirAll(colon, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	raw, err := os.ReadFile(src)
+	f := workspace.TenantFactory{Root: root}
+	r, err := f.Resolver(identity.Identity{UserID: "gh:4242"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(colon, filepath.Base(src)), raw, 0o644); err != nil {
-		t.Fatal(err)
+	b, ok := r.(workspace.Bounded)
+	if !ok {
+		t.Fatal("tenant resolver is not bounded")
+	}
+	if !safeFontPath(b.WorkspaceRoot()) {
+		t.Errorf("a tenant workspace root still contains the list separator: %s", b.WorkspaceRoot())
+	}
+	if !safeFontPath(workspaceFontPath(r)) && workspaceFontPath(r) != "" {
+		t.Errorf("a tenant font path still contains the list separator: %s", workspaceFontPath(r))
 	}
 
-	if got := familiesUnder(colon); len(got) == 0 {
-		t.Error("a font directory whose path contains a colon reported no families")
-	}
-
-	plain := filepath.Join(root, "plain")
-	if err := os.MkdirAll(plain, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(plain, filepath.Base(src)), raw, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if a, b := familiesUnder(colon), familiesUnder(plain); len(a) != len(b) {
-		t.Errorf("colon path found %d families, colon-free found %d — must agree", len(a), len(b))
+	// And the probe refuses an unsafe path rather than reporting no
+	// fonts, which is what made the original undiagnosable.
+	if got := familiesUnder("/tmp/has:colon"); got != nil {
+		t.Errorf("an unsafe path was probed rather than refused: %v", got)
 	}
 }
 

--- a/cmd/typst-d2-mcp/namespaces_test.go
+++ b/cmd/typst-d2-mcp/namespaces_test.go
@@ -329,7 +329,7 @@ func TestCompile_TemplateAssetResolves(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("a template could not read its own bundled asset: %s", resultText(res))
 	}
-	assertPDF(t, filepath.Join(root, "user123", "doc.pdf"))
+	assertPDF(t, filepath.Join(root, workspace.DirName("user123"), "doc.pdf"))
 }
 
 // The same, for a template reached through organisation membership
@@ -374,7 +374,7 @@ func TestCompile_OrgTemplateAssetResolves(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("an org template could not read its own asset: %s", resultText(res))
 	}
-	assertPDF(t, filepath.Join(root, member.UserID, "doc.pdf"))
+	assertPDF(t, filepath.Join(root, workspace.DirName(member.UserID), "doc.pdf"))
 }
 
 // The package view is a font path, so a template can ship the typeface
@@ -579,7 +579,7 @@ func TestCompile_ANameOnlyReachesItsOwnNamespace(t *testing.T) {
 // in it.
 func TestTypstArgs_NeverPassesAColonInAFontPath(t *testing.T) {
 	root := t.TempDir()
-	tenant := filepath.Join(root, "gh:4242")
+	tenant := filepath.Join(root, workspace.DirName("gh:4242"))
 	if err := os.MkdirAll(filepath.Join(tenant, FontsDir), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/typst-d2-mcp/pdfdownload_test.go
+++ b/cmd/typst-d2-mcp/pdfdownload_test.go
@@ -31,7 +31,7 @@ func newDownloadFixture(t *testing.T) (http.Handler, *authdb.Store, string) {
 	t.Cleanup(func() { _ = store.Close() })
 
 	root := t.TempDir()
-	userDir := filepath.Join(root, "gh:1")
+	userDir := filepath.Join(root, workspace.DirName("gh:1"))
 	if err := os.MkdirAll(userDir, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}

--- a/internal/workspace/dirname.go
+++ b/internal/workspace/dirname.go
@@ -1,0 +1,68 @@
+package workspace
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// DirName maps an identity to the directory that holds its workspace.
+//
+// It exists because the obvious thing — using the user id directly —
+// put a colon in every tenant path, and a colon is the OS path-list
+// separator. Tools that take a list of directories split on it and
+// silently read nothing: typst's --font-path did exactly that, so
+// workspace fonts never loaded and typst substituted without a word
+// (#107). There is no escape to apply, either; backslash, percent
+// encoding and the environment variable all fail identically. The only
+// fix is to never create the character.
+//
+// This is the single place that decision is made, matching how
+// ScopedFS.Resolve is the single place traversal is decided. A rule
+// enforced at each call site is a rule that comes back — #107 was
+// patched twice at call sites and reappeared within a day.
+//
+// The encoding keeps the identity readable and adds a hash only when it
+// has to. Sanitising alone is not injective — the standard example is
+// that "file?" and "*file*" both reduce to "file" — so any name that
+// was altered carries a short digest of the original, which restores
+// uniqueness without making every directory unreadable. An operator
+// looking at a volume still sees whose workspace is whose.
+func DirName(userID string) string {
+	// No special case for the empty id: giving it a friendly name would
+	// collide with a real identity that happens to have that name, which
+	// is the exact non-injectivity this function exists to avoid. It
+	// falls through and gets a hashed form like anything else unsafe.
+	safe := sanitiseSegment(userID)
+	if safe == userID {
+		return safe // already safe: leave it exactly as it is
+	}
+	sum := sha256.Sum256([]byte(userID))
+	return safe + "-" + hex.EncodeToString(sum[:])[:8]
+}
+
+// safeSegmentRunes is the alphabet a path segment may use: unreserved
+// on every filesystem this runs on, and free of every character that
+// means something to a shell, a path list or a URL.
+func sanitiseSegment(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := b.String()
+	// A segment that is empty, or that a filesystem treats specially,
+	// is not a name. Fall through to the hashed form by returning
+	// something that cannot equal the input.
+	if out == "" || out == "." || out == ".." {
+		return "id"
+	}
+	return out
+}

--- a/internal/workspace/dirname_test.go
+++ b/internal/workspace/dirname_test.go
@@ -1,0 +1,153 @@
+package workspace
+
+import (
+	"os"
+
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
+	"strings"
+	"testing"
+)
+
+// The bug this exists to end: a tenant path containing the OS list
+// separator. Tools that take a directory list split on it and read
+// nothing, silently.
+func TestDirName_NeverContainsThePathListSeparator(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	for _, id := range []string{
+		"gh:12345", "gh:1", "anonymous", "user123",
+		"weird:id/with\\stuff", "spaces here", "semi;colon", "quote'apos",
+		strings.Repeat("gh:9", 40),
+	} {
+		got := DirName(id)
+		if strings.Contains(got, sep) {
+			t.Errorf("DirName(%q) = %q, which contains %q", id, got, sep)
+		}
+		for _, bad := range []string{"/", "\\", ":", " ", ";", "'", "\"", "*", "?"} {
+			if strings.Contains(got, bad) {
+				t.Errorf("DirName(%q) = %q, which contains %q", id, got, bad)
+			}
+		}
+	}
+}
+
+// Sanitising alone is not injective — "file?" and "*file*" both reduce
+// to "file". Two identities must never share a workspace.
+func TestDirName_IsInjective(t *testing.T) {
+	ids := []string{
+		"gh:1", "gh-1", "gh_1", "gh 1", "gh?1", "gh*1",
+		"gh:12345", "gh-12345", "a:b", "a-b", "a/b", "a\\b",
+		"", "anonymous", ".", "..",
+	}
+	seen := map[string]string{}
+	for _, id := range ids {
+		got := DirName(id)
+		if prev, clash := seen[got]; clash {
+			t.Errorf("%q and %q both map to %q", prev, id, got)
+		}
+		seen[got] = id
+	}
+}
+
+// An identity that is already safe keeps its name, so a volume stays
+// readable and nothing existing has to move for no reason.
+func TestDirName_LeavesSafeIdentitiesAlone(t *testing.T) {
+	for _, id := range []string{"anonymous", "user123", "gh-12345", "a_b-c"} {
+		if got := DirName(id); got != id {
+			t.Errorf("DirName(%q) = %q, want it unchanged", id, got)
+		}
+	}
+}
+
+// The readable part survives, so an operator can still tell whose
+// workspace a directory is.
+func TestDirName_StaysRecognisable(t *testing.T) {
+	got := DirName("gh:12345")
+	if !strings.HasPrefix(got, "gh-12345-") {
+		t.Errorf("DirName(gh:12345) = %q, want a readable gh-12345 prefix", got)
+	}
+	if len(got) != len("gh-12345-")+8 {
+		t.Errorf("DirName(gh:12345) = %q, want an 8-character digest suffix", got)
+	}
+}
+
+// Stability matters more than beauty: a workspace must be found again
+// after a restart, a redeploy, and a year.
+func TestDirName_IsStable(t *testing.T) {
+	first := DirName("gh:12345")
+	for i := 0; i < 100; i++ {
+		if got := DirName("gh:12345"); got != first {
+			t.Fatalf("DirName is not stable: %q then %q", first, got)
+		}
+	}
+}
+
+// The sweeper and the admin UI walk the tenant root and must find
+// exactly the directories the resolvers create. A migration that left
+// two names, or a name the walker cannot match back to a user, would
+// make usage accounting silently wrong.
+func TestDirName_MigratesALegacyWorkspaceOnce(t *testing.T) {
+	root := t.TempDir()
+	legacy := root + "/gh:12345"
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacy+"/doc.typ", []byte("= Existing\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	f := TenantFactory{Root: root}
+	for i := 0; i < 3; i++ { // idempotent
+		if _, err := f.Resolver(identity.Identity{UserID: "gh:12345"}); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+	}
+
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Error("the legacy directory is still there; two names for one workspace")
+	}
+	moved := root + "/" + DirName("gh:12345")
+	if _, err := os.Stat(moved + "/doc.typ"); err != nil {
+		t.Errorf("the document did not survive the move: %v", err)
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("tenant root holds %v, want exactly one directory", names)
+	}
+}
+
+// If someone has already been migrated and a stale legacy directory
+// reappears, the current workspace wins and the old one is left for a
+// person to look at — merging two directories of somebody's documents
+// is not a decision code should make silently.
+func TestDirName_MigrationDoesNotClobberAnExistingWorkspace(t *testing.T) {
+	root := t.TempDir()
+	legacy := root + "/gh:7"
+	current := root + "/" + DirName("gh:7")
+	for _, d := range []string{legacy, current} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(current+"/keep.typ", []byte("current\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	f := TenantFactory{Root: root}
+	if _, err := f.Resolver(identity.Identity{UserID: "gh:7"}); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if _, err := os.Stat(current + "/keep.typ"); err != nil {
+		t.Errorf("the current workspace was clobbered: %v", err)
+	}
+	if _, err := os.Stat(legacy); err != nil {
+		t.Errorf("the legacy directory was removed rather than left for inspection: %v", err)
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -226,7 +227,44 @@ func (f TenantFactory) Resolver(id identity.Identity) (Resolver, error) {
 	if id.UserID == "" {
 		return nil, fmt.Errorf("tenant factory requires non-empty UserID")
 	}
-	return NewScopedFS(filepath.Join(f.Root, id.UserID))
+	dir := filepath.Join(f.Root, DirName(id.UserID))
+	// A workspace created before DirName existed sits under the raw user
+	// id. Move it once, rather than leaving the old path to be found by
+	// some code paths and not others.
+	if err := migrateLegacyDir(filepath.Join(f.Root, id.UserID), dir); err != nil {
+		return nil, err
+	}
+	return NewScopedFS(dir)
+}
+
+// migrateLegacyDir renames a pre-DirName workspace into place.
+//
+// Idempotent and safe to race: two servers starting together may both
+// try, and the loser sees the destination already exists, which is the
+// correct outcome rather than an error. If both exist — a half-finished
+// move, or something hand-made — the new one wins and the old is left
+// alone for a person to look at, because silently merging two
+// directories of someone's documents is not a decision code should make.
+func migrateLegacyDir(legacy, current string) error {
+	if legacy == current {
+		return nil
+	}
+	if _, err := os.Stat(current); err == nil {
+		return nil // already migrated, or never needed
+	}
+	info, err := os.Stat(legacy)
+	if err != nil || !info.IsDir() {
+		return nil //nolint:nilerr // nothing to migrate is the normal case
+	}
+	if err := os.Rename(legacy, current); err != nil {
+		if _, statErr := os.Stat(current); statErr == nil {
+			return nil // someone else won the race
+		}
+		return fmt.Errorf("migrate workspace %s: %w", legacy, err)
+	}
+	slog.Info("migrated a workspace to a path-safe directory name",
+		"from", filepath.Base(legacy), "to", filepath.Base(current))
+	return nil
 }
 
 // WriteFile resolves path through r and writes content, creating parent


### PR DESCRIPTION
The root-cause fix for something patched twice at call sites and returned both times.

## Why call-site fixes kept failing

The tenant workspace was `Root/<UserID>`, and `UserID` is `gh:<id>`. A colon is the OS path-list separator, so a tool given that path *as a list* splits it and reads nothing — silently. `--font-path` did exactly that (#107): fonts never loaded, typst substituted, and every signal a caller had said the upload worked.

I fixed it in #113 by routing compiles through the package view, then again with a symlink dance for probes — and it reappeared in #125's new code within a day. **A rule enforced at each call site is a rule that returns**, because the next call site hasn't been written yet.

## And escaping is not available

Worth testing rather than assuming. None of these work:

```
has:colon        -> 0 families
has\:colon       -> 0 families
has%3Acolon      -> 0 families
TYPST_FONT_PATHS -> 0 families
```

A `:`-separated list has no quoting mechanism. So "escape correctly at the boundary" is not implementable for this consumer — the only fix is to never create the character.

## The change

`workspace.DirName` is the single place the decision is made, matching how `ScopedFS.Resolve` is the single place traversal is decided.

It keeps the identity readable and adds a digest **only when sanitising changed something**: `gh:12345` → `gh-12345-a1b2c3d4`, while `user123` and `anonymous` are left exactly as they are. That's the compromise the general guidance points at — sanitising alone is not injective ([node-sanitize-filename](https://github.com/parshap/node-sanitize-filename) documents `file?` and `*file*` both reducing to `file`), and two identities sharing a workspace is far worse than an unreadable directory name.

My own test caught me creating exactly that: I had special-cased the empty id to `"anonymous"`, which collides with a real identity of that name.

## Migration

Old workspaces are renamed on first resolve. Idempotent, survives two servers racing, and **refuses to merge** if both directories somehow exist — silently combining two directories of someone's documents isn't a decision code should make. Tested both ways.

## Both workarounds deleted

What remains is an assertion rather than a compensation: a font path carrying the separator is refused **loudly** instead of quietly returning nothing. Silence was the actual harm in #107 — two agents independently diagnosed "the font book is built at startup" because nothing contradicted them.

Refers #107
