### PR TITLE
fix(previews): delete a document's rendered pages with it

### DIFF
--- a/cmd/typst-d2-mcp/files.go
+++ b/cmd/typst-d2-mcp/files.go
@@ -152,8 +152,29 @@ func handleDeleteFile(factory workspace.Factory) server.ToolHandlerFunc {
 		if err := os.Remove(resolved); err != nil {
 			return mcp.NewToolResultErrorFromErr("delete", err), nil
 		}
-		return mcp.NewToolResultText(fmt.Sprintf(
-			"Deleted %s (%s reclaimed).", path, humanBytes(info.Size()))), nil
+		reclaimed := info.Size()
+
+		// Take the rendered pages with it. They are derived from this
+		// document and meaningless without it, and leaving them behind
+		// charged a tenant for files they could not have known about:
+		// an agent deleted four probe documents, tried to tidy up, and
+		// left ten orphaned previews it was never told existed.
+		//
+		// Only for a source document. Deleting a PDF leaves the .typ,
+		// and pages rendered from that .typ are still current.
+		var previews int
+		if strings.EqualFold(filepath.Ext(path), ".typ") {
+			if dir, resolveErr := resolver.Resolve(previewDirFor(path)); resolveErr == nil {
+				previews, reclaimed = removePreviewDir(dir, reclaimed)
+			}
+		}
+
+		msg := fmt.Sprintf("Deleted %s (%s reclaimed).", path, humanBytes(reclaimed))
+		if previews > 0 {
+			msg = fmt.Sprintf("Deleted %s and %d rendered page(s) (%s reclaimed).",
+				path, previews, humanBytes(reclaimed))
+		}
+		return mcp.NewToolResultText(msg), nil
 	}
 }
 
@@ -303,4 +324,24 @@ func firstMatchingLine(path, needle string) (string, searchResult) {
 		}
 	}
 	return "", searchNoMatch
+}
+
+// removePreviewDir deletes a document's rendered pages, returning how
+// many went and the running total of bytes reclaimed.
+func removePreviewDir(dir string, reclaimed int64) (int, int64) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, reclaimed
+	}
+	n := 0
+	for _, e := range entries {
+		if info, infoErr := e.Info(); infoErr == nil && info.Mode().IsRegular() {
+			reclaimed += info.Size()
+			n++
+		}
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return 0, reclaimed
+	}
+	return n, reclaimed
 }

--- a/cmd/typst-d2-mcp/files_test.go
+++ b/cmd/typst-d2-mcp/files_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -344,5 +345,115 @@ func TestSearchFile_BinaryIsANonMatchNotASkip(t *testing.T) {
 	}
 	if int(got["count"].(float64)) != 0 {
 		t.Errorf("a binary file matched a content search")
+	}
+}
+
+// Deleting a document must take its rendered pages with it. An agent
+// deleted four probe documents, tried to tidy up, and left ten orphaned
+// previews charged to its byte budget in a directory it was never told
+// about.
+func TestDeleteFile_TakesRenderedPagesWithIt(t *testing.T) {
+	requireTypst(t)
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "doc.typ", "= One\n#pagebreak()\n= Two\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	// Render, the way a caller does — by reading a page.
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = pageURIPrefix + "doc.typ/1"
+	if _, err := handleReadPage(f)(ctx, req); err != nil {
+		t.Fatalf("render pages: %v", err)
+	}
+
+	resolver, err := f.Resolver(identity.Identity{UserID: "gh:4242"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	withPreviews, _, _ := workspace.Usage(resolver)
+
+	got := callTool(t, handleDeleteFile(f), ctx, map[string]any{"path": "doc.typ"})
+	if got.IsError {
+		t.Fatalf("delete_file: %s", resultText(got))
+	}
+	if !strings.Contains(resultText(got), "rendered page") {
+		t.Errorf("deletion did not mention the pages it removed: %s", resultText(got))
+	}
+
+	after, _, _ := workspace.Usage(resolver)
+	if after >= withPreviews {
+		t.Errorf("usage did not drop: %d then %d", withPreviews, after)
+	}
+	dir, err := resolver.Resolve(previewDirFor("doc.typ"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Error("the preview directory survived the document")
+	}
+}
+
+// Deleting the PDF leaves the source, and pages rendered from that
+// source are still current — so they must NOT be swept away.
+func TestDeleteFile_PDFDeletionKeepsPages(t *testing.T) {
+	requireTypst(t)
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "doc.typ", "= One\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	if res := compile(t, ctx, f, "doc.typ"); res.IsError {
+		t.Fatalf("compile: %s", resultText(res))
+	}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = pageURIPrefix + "doc.typ/1"
+	if _, err := handleReadPage(f)(ctx, req); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if res := callTool(t, handleDeleteFile(f), ctx, map[string]any{"path": "doc.pdf"}); res.IsError {
+		t.Fatalf("delete pdf: %s", resultText(res))
+	}
+	resolver, _ := f.Resolver(identity.Identity{UserID: "gh:4242"})
+	dir, _ := resolver.Resolve(previewDirFor("doc.typ"))
+	if _, err := os.Stat(dir); err != nil {
+		t.Error("deleting the PDF removed pages that are still current")
+	}
+}
+
+// A document that shrinks must not keep a preview for a page it no
+// longer has — charged to the budget, and readable as content the
+// document does not contain.
+func TestPageResource_ShrinkingADocumentDropsStalePages(t *testing.T) {
+	requireTypst(t)
+	f, ctx := fileFixture(t)
+	if res := putFile(t, ctx, f, "doc.typ", "= One\n#pagebreak()\n= Two\n#pagebreak()\n= Three\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = pageURIPrefix + "doc.typ/3"
+	if _, err := handleReadPage(f)(ctx, req); err != nil {
+		t.Fatalf("render three pages: %v", err)
+	}
+
+	// Now it is one page.
+	if res := putFile(t, ctx, f, "doc.typ", "= Only one\n"); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	req.Params.URI = pageURIPrefix + "doc.typ/1"
+	if _, err := handleReadPage(f)(ctx, req); err != nil {
+		t.Fatalf("re-render: %v", err)
+	}
+
+	resolver, _ := f.Resolver(identity.Identity{UserID: "gh:4242"})
+	dir, _ := resolver.Resolve(previewDirFor("doc.typ"))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("previews after shrinking: %v, want only page-1", names)
 	}
 }

--- a/cmd/typst-d2-mcp/resources.go
+++ b/cmd/typst-d2-mcp/resources.go
@@ -160,8 +160,7 @@ func handleReadPage(factory workspace.Factory) server.ResourceTemplateHandlerFun
 // hiding storage a caller caused is how quotas stop meaning anything.
 // delete_file reclaims them.
 func renderPages(ctx context.Context, r workspace.Resolver, docRel, srcPath string, page int) (string, error) {
-	outDir, err := r.Resolve(filepath.Join(filepath.Dir(docRel), previewDir,
-		strings.TrimSuffix(filepath.Base(docRel), filepath.Ext(docRel))))
+	outDir, err := r.Resolve(previewDirFor(docRel))
 	if err != nil {
 		return "", err
 	}
@@ -173,6 +172,13 @@ func renderPages(ctx context.Context, r workspace.Resolver, docRel, srcPath stri
 	}
 	if info, statErr := os.Stat(want); statErr == nil && info.ModTime().After(srcInfo.ModTime()) {
 		return want, nil // cached and newer than the source
+	}
+	// Clear before rendering. A document that has SHRUNK would otherwise
+	// keep a preview for a page it no longer has — charged to the
+	// tenant's budget, and reachable by a reader who would then be
+	// looking at content the document does not contain.
+	if err := os.RemoveAll(outDir); err != nil {
+		return "", fmt.Errorf("prepare previews: %w", err)
 	}
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return "", fmt.Errorf("prepare previews: %w", err)
@@ -261,6 +267,14 @@ func handleReadIndex(factory workspace.Factory) server.ResourceHandlerFunc {
 			URI: indexURI, MIMEType: "application/json", Text: string(payload),
 		}}, nil
 	}
+}
+
+// previewDirFor is where a document's rendered pages live, relative to
+// the workspace. One definition, because two would drift and the
+// deletion path has to find exactly what the render path wrote.
+func previewDirFor(docRel string) string {
+	return filepath.Join(filepath.Dir(docRel), previewDir,
+		strings.TrimSuffix(filepath.Base(docRel), filepath.Ext(docRel)))
 }
 
 func fileExists(p string) bool {


### PR DESCRIPTION
Found by a research agent on the current build.

It deleted four probe documents, tried to tidy its workspace, and left **ten orphaned previews** behind — charged to its byte budget, in a dot-directory it was never told about. It did everything right and still could not finish.

```
documents:  onboarding
previews:   onboarding, probe, probe2, probe4
ORPHANED:   probe, probe2, probe4     (10 of 14 preview files)
```

## The fix

`delete_file` removes a document's rendered pages with it and reports how many, so the reclaimed figure is the true one. **Only for a source document** — deleting a PDF leaves the `.typ`, and pages rendered from that `.typ` are still current. Tested both ways.

Rendering now also clears the directory first: a document that **shrinks** was keeping a preview for a page it no longer has, charged for and readable as content the document does not contain.

## Worth noting

Both are consequences of previews counting against the byte budget — which was the right call. Honest accounting made the leak visible instead of hiding it somewhere nobody would look.