### PR TITLE
fix(previews): render pages through the caller's package view

### DIFF
--- a/cmd/typst-d2-mcp/files_test.go
+++ b/cmd/typst-d2-mcp/files_test.go
@@ -361,7 +361,7 @@ func TestDeleteFile_TakesRenderedPagesWithIt(t *testing.T) {
 	// Render, the way a caller does — by reading a page.
 	req := mcp.ReadResourceRequest{}
 	req.Params.URI = pageURIPrefix + "doc.typ/1"
-	if _, err := handleReadPage(f)(ctx, req); err != nil {
+	if _, err := handleReadPage(f, nil)(ctx, req); err != nil {
 		t.Fatalf("render pages: %v", err)
 	}
 
@@ -405,7 +405,7 @@ func TestDeleteFile_PDFDeletionKeepsPages(t *testing.T) {
 	}
 	req := mcp.ReadResourceRequest{}
 	req.Params.URI = pageURIPrefix + "doc.typ/1"
-	if _, err := handleReadPage(f)(ctx, req); err != nil {
+	if _, err := handleReadPage(f, nil)(ctx, req); err != nil {
 		t.Fatalf("render: %v", err)
 	}
 
@@ -430,7 +430,7 @@ func TestPageResource_ShrinkingADocumentDropsStalePages(t *testing.T) {
 	}
 	req := mcp.ReadResourceRequest{}
 	req.Params.URI = pageURIPrefix + "doc.typ/3"
-	if _, err := handleReadPage(f)(ctx, req); err != nil {
+	if _, err := handleReadPage(f, nil)(ctx, req); err != nil {
 		t.Fatalf("render three pages: %v", err)
 	}
 
@@ -439,7 +439,7 @@ func TestPageResource_ShrinkingADocumentDropsStalePages(t *testing.T) {
 		t.Fatalf("put_file: %s", resultText(res))
 	}
 	req.Params.URI = pageURIPrefix + "doc.typ/1"
-	if _, err := handleReadPage(f)(ctx, req); err != nil {
+	if _, err := handleReadPage(f, nil)(ctx, req); err != nil {
 		t.Fatalf("re-render: %v", err)
 	}
 

--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -532,7 +532,7 @@ func main() {
 	)
 
 	registerTools(s, factory, store)
-	registerResources(s, factory)
+	registerResources(s, factory, store)
 
 	slog.Info("starting",
 		"version", serverVersion,

--- a/cmd/typst-d2-mcp/resources.go
+++ b/cmd/typst-d2-mcp/resources.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
+	"github.com/dlouwers/typst-d2-mcp/internal/identity"
 	"github.com/dlouwers/typst-d2-mcp/internal/preprocessor"
 	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -44,7 +46,7 @@ const (
 	previewDir      = ".previews"
 )
 
-func registerResources(s *server.MCPServer, factory workspace.Factory) {
+func registerResources(s *server.MCPServer, factory workspace.Factory, store *authdb.Store) {
 	s.AddResourceTemplate(mcp.ResourceTemplate{
 		URITemplate: templateFor(pdfURIPrefix + "{+path}"),
 		Name:        "pdf",
@@ -66,7 +68,7 @@ func registerResources(s *server.MCPServer, factory workspace.Factory) {
 			"Address as typst-d2://page/<document.typ>/<page number>. " +
 			"Pages are rendered on first read, not at compile time.",
 		MIMEType: "image/png",
-	}, handleReadPage(factory))
+	}, handleReadPage(factory, store))
 
 	// A concrete resource, so resources/list has something to return.
 	// Without it a caller asking what is readable is told nothing is,
@@ -113,7 +115,7 @@ func handleReadSource(factory workspace.Factory) server.ResourceTemplateHandlerF
 // pages in the workspace, so the second read is free. Cached pages
 // older than the source are re-rendered, so a stale preview cannot be
 // served as if it were current.
-func handleReadPage(factory workspace.Factory) server.ResourceTemplateHandlerFunc {
+func handleReadPage(factory workspace.Factory, store *authdb.Store) server.ResourceTemplateHandlerFunc {
 	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 		spec, err := uriPath(req.Params.URI, pageURIPrefix)
 		if err != nil {
@@ -137,7 +139,8 @@ func handleReadPage(factory workspace.Factory) server.ResourceTemplateHandlerFun
 			return nil, err
 		}
 
-		pageFile, err := renderPages(ctx, resolver, docRel, srcPath, page)
+		id, _ := identity.FromContext(ctx)
+		pageFile, err := renderPages(ctx, store, id, resolver, docRel, srcPath, page)
 		if err != nil {
 			return nil, err
 		}
@@ -159,7 +162,8 @@ func handleReadPage(factory workspace.Factory) server.ResourceTemplateHandlerFun
 // byte budget, which is deliberate: the caller asked for them, and
 // hiding storage a caller caused is how quotas stop meaning anything.
 // delete_file reclaims them.
-func renderPages(ctx context.Context, r workspace.Resolver, docRel, srcPath string, page int) (string, error) {
+func renderPages(ctx context.Context, store *authdb.Store, id identity.Identity,
+	r workspace.Resolver, docRel, srcPath string, page int) (string, error) {
 	outDir, err := r.Resolve(previewDirFor(docRel))
 	if err != nil {
 		return "", err
@@ -201,9 +205,28 @@ func renderPages(ctx context.Context, r workspace.Resolver, docRel, srcPath stri
 		return "", err
 	}
 
-	args := typstArgs(r, staged.Name(), filepath.Join(outDir, "page-{n}.png"))
+	// Render through the caller's package view, exactly as a compile
+	// does. Without it the child inherited the server's store, which is
+	// keyed by namespace ID rather than name — so a document importing
+	// @acme/templates failed with "package not found", and previews
+	// worked only for @house, where the id happens to equal the name.
+	// The documents most worth previewing were the ones that could not
+	// be. Found by an agent whose org template would not render.
+	allowed, err := allowedNamespaces(ctx, store, id)
+	if err != nil {
+		return "", fmt.Errorf("resolve namespaces: %w", err)
+	}
+	view, cleanupView, err := packageView(typstDataDir(), allowed, workspaceFontPath(r))
+	if err != nil {
+		return "", fmt.Errorf("prepare packages: %w", err)
+	}
+	defer cleanupView()
+
+	args := typstArgs(r, staged.Name(), filepath.Join(outDir, "page-{n}.png"),
+		packageFontPath(view))
 	args = append([]string{args[0], "--format", "png", "--ppi", "96"}, args[1:]...)
 	cmd := exec.CommandContext(ctx, "typst", args...)
+	cmd.Env = compileEnv(view)
 	if out, runErr := cmd.CombinedOutput(); runErr != nil {
 		return "", fmt.Errorf("render pages of %s: %s", docRel, strings.TrimSpace(string(out)))
 	}

--- a/cmd/typst-d2-mcp/resources_test.go
+++ b/cmd/typst-d2-mcp/resources_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dlouwers/typst-d2-mcp/internal/authdb"
 	"github.com/dlouwers/typst-d2-mcp/internal/identity"
 	"github.com/dlouwers/typst-d2-mcp/internal/workspace"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -94,7 +95,7 @@ func TestPageResource_RendersLazilyAndStaysCurrent(t *testing.T) {
 	}
 	before, _, _ := workspace.Usage(resolver)
 
-	got := readResource(t, handleReadPage(f), ctx, pageURIPrefix+"doc.typ/2")
+	got := readResource(t, handleReadPage(f, nil), ctx, pageURIPrefix+"doc.typ/2")
 	blob := got[0].(mcp.BlobResourceContents)
 	if blob.MIMEType != "image/png" {
 		t.Errorf("mime = %q, want image/png", blob.MIMEType)
@@ -115,7 +116,7 @@ func TestPageResource_RendersLazilyAndStaysCurrent(t *testing.T) {
 	if res := putFile(t, ctx, f, "doc.typ", "= Different\n#pagebreak()\n= Pages\n"); res.IsError {
 		t.Fatalf("put_file: %s", resultText(res))
 	}
-	again := readResource(t, handleReadPage(f), ctx, pageURIPrefix+"doc.typ/2")
+	again := readResource(t, handleReadPage(f, nil), ctx, pageURIPrefix+"doc.typ/2")
 	if again[0].(mcp.BlobResourceContents).Blob == blob.Blob {
 		t.Error("a stale page was served after the source changed")
 	}
@@ -133,7 +134,7 @@ func TestPageResource_RejectsBadAddresses(t *testing.T) {
 	} {
 		req := mcp.ReadResourceRequest{}
 		req.Params.URI = uri
-		if _, err := handleReadPage(f)(ctx, req); err == nil {
+		if _, err := handleReadPage(f, nil)(ctx, req); err == nil {
 			t.Errorf("accepted a malformed page address: %s", uri)
 		}
 	}
@@ -159,5 +160,85 @@ func TestResources_ArePerTenant(t *testing.T) {
 	}
 	if strings.Contains(got[0].(mcp.TextResourceContents).Text, "mine.typ") {
 		t.Error("another tenant's index listed my document")
+	}
+}
+
+// An agent could not preview a document that used its organisation's
+// template: the page renderer inherited the server's store, which is
+// keyed by namespace ID rather than name, so @acme/templates was
+// "package not found". Previews worked only for @house — the documents
+// most worth looking at were the ones that could not be.
+func TestPageResource_RendersADocumentUsingAnOrgTemplate(t *testing.T) {
+	requireTypst(t)
+
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+
+	store := newTestStore(t)
+	if err := store.CreateOrg(t.Context(), "admin", "acme", "Acme"); err != nil {
+		t.Fatal(err)
+	}
+	member := seedUser(t, store, "member", 21)
+	if err := store.AddOrgMember(t.Context(), "admin", "acme", "member"); err != nil {
+		t.Fatal(err)
+	}
+	nsID, err := store.ResolveName(t.Context(), "acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePackage(t, data, nsID, "1.0.0")
+
+	root := t.TempDir()
+	f := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), member)
+
+	src := "#import \"@acme/templates:1.0.0\": mark\n#mark()\n= Heading\n"
+	if res := putFileStore(t, ctx, f, store, "doc.typ", src); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = pageURIPrefix + "doc.typ/1"
+	got, err := handleReadPage(f, store)(ctx, req)
+	if err != nil {
+		t.Fatalf("a document using an org template could not be previewed: %v", err)
+	}
+	blob := got[0].(mcp.BlobResourceContents)
+	raw, err := base64.StdEncoding.DecodeString(blob.Blob)
+	if err != nil || len(raw) < 100 || string(raw[1:4]) != "PNG" {
+		t.Fatalf("page 1 is not a PNG (%d bytes)", len(raw))
+	}
+}
+
+// And a namespace the caller cannot see stays unreachable from the
+// preview path too — widening what previews resolve must not widen what
+// a caller can reach.
+func TestPageResource_CannotReachAnotherTenantsTemplate(t *testing.T) {
+	requireTypst(t)
+
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+
+	store := newTestStore(t)
+	stranger := seedUser(t, store, "stranger", 22)
+	otherNS, err := store.EnsurePersonalNamespace(t.Context(), stranger.UserID, 22)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePackage(t, data, otherNS, "1.0.0")
+
+	outsider := seedUser(t, store, "outsider", 23)
+	root := t.TempDir()
+	f := workspace.TenantFactory{Root: root}
+	ctx := identity.WithIdentity(context.Background(), outsider)
+
+	src := "#import \"@" + authdb.DerivedName(22) + "/templates:1.0.0\": mark\n#mark()\n"
+	if res := putFileStore(t, ctx, f, store, "doc.typ", src); res.IsError {
+		t.Fatalf("put_file: %s", resultText(res))
+	}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = pageURIPrefix + "doc.typ/1"
+	if _, err := handleReadPage(f, store)(ctx, req); err == nil {
+		t.Fatal("previewed a document importing another tenant's template")
 	}
 }


### PR DESCRIPTION
An agent could not preview a document that used its organisation's template:

> *"The `typst-d2://page/...` preview resource fails with `package not found` on the org package."*

`renderPages` built no package view and set no environment, so the typst child inherited the **server's** store — which is keyed by namespace **ID**, not name. `@acme/templates` doesn't exist there; `ns-acmefixture/templates` does.

So previews worked only for `@house` (where the id happens to equal the name) and for documents importing nothing. **The documents most worth previewing were precisely the ones that couldn't be.**

## The fix

Rendering goes through the same `packageView` a compile gets, with the same font path — so what a preview resolves and what a compile resolves cannot diverge.

Widening what previews resolve must not widen what a caller can *reach*: `TestPageResource_CannotReachAnotherTenantsTemplate` asserts a namespace the caller cannot see stays unreachable from the preview path.

## How it was found

By reading an interview, not a tool trace. The call sequence showed a preview being requested and nothing obviously wrong — the agent explaining what failed is what surfaced it. I had collected fourteen interviews and stopped reading them; this is what was in the ones I skipped.