### PR TITLE
fix: three bugs found by reading one agent interview

### DIFF
--- a/cmd/typst-d2-mcp/publish.go
+++ b/cmd/typst-d2-mcp/publish.go
@@ -141,8 +141,13 @@ func handlePublishTemplate(factory workspace.Factory, store *authdb.Store) serve
 			return mcp.NewToolResultErrorFromErr("install package", err), nil
 		}
 
-		msg := fmt.Sprintf("Published @%s/%s:%s (%s, %d file(s)).\n\nImport it with:\n  #import \"@%s/%s:%s\": …\n",
-			namespace, pkgName, version, humanBytes(total), len(files), namespace, pkgName, version)
+		msg := fmt.Sprintf("Published @%s/%s:%s (%s).\n\nFiles shipped:\n",
+			namespace, pkgName, version, humanBytes(total))
+		for _, f := range files {
+			msg += "  " + f + "\n"
+		}
+		msg += fmt.Sprintf("\nImport it with:\n  #import \"@%s/%s:%s\": …\n",
+			namespace, pkgName, version)
 		msg += "\nThis version is now immutable. Publish a new version to change it; " +
 			"documents importing this one keep rendering the same way."
 		return mcp.NewToolResultText(msg), nil
@@ -206,12 +211,19 @@ func collectPackage(dir string) ([]string, int64, error) {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
+		// Skip anything the server staged, and anything hidden. A
+		// compile in the source directory leaves a staged file; reading
+		// a page leaves a .previews/ directory. One publish swept 86.8
+		// KiB of rendered PNGs into a package that should have held two
+		// files — and since versions are immutable, that mistake is
+		// permanent and shows in list_templates forever.
+		if strings.HasPrefix(d.Name(), workspace.StagePrefix) || strings.HasPrefix(d.Name(), ".") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
-		// Skip anything the server staged: a compile in the same
-		// directory would otherwise get published along with it.
-		if strings.HasPrefix(d.Name(), workspace.StagePrefix) {
+		if d.IsDir() {
 			return nil
 		}
 		info, infoErr := d.Info()

--- a/cmd/typst-d2-mcp/publish_test.go
+++ b/cmd/typst-d2-mcp/publish_test.go
@@ -522,3 +522,46 @@ func TestPublish_NewVersionCanBuildOnAnOlderOne(t *testing.T) {
 			resultText(res))
 	}
 }
+
+// Rendered pages live in a hidden directory beside the source. Sweeping
+// them into a package shipped 86.8 KiB of PNGs in a package that should
+// have held two files — and since versions are immutable, that mistake
+// is permanent and shows in list_templates forever.
+func TestPublish_ExcludesHiddenDirectories(t *testing.T) {
+	f := newPublishFixture(t)
+	f.stage(t, "tpl", map[string]string{
+		"typst.toml":               goodTOML,
+		"lib.typ":                  goodLib,
+		".previews/tpl/page-1.png": "not a real png",
+		".previews/tpl/page-2.png": "nor this",
+		".hidden-note":             "should not ship",
+	})
+
+	res := f.publish(t, "tpl", f.nsName, "1.0.0")
+	if res.IsError {
+		t.Fatalf("publish failed: %s", resultText(res))
+	}
+	// The result lists what it shipped, so a caller can see a mistake
+	// before it becomes permanent.
+	msg := resultText(res)
+	if !strings.Contains(msg, "Files shipped") {
+		t.Errorf("the publish result does not say what it shipped:\n%s", msg)
+	}
+	if strings.Contains(msg, "previews") || strings.Contains(msg, ".hidden") {
+		t.Errorf("a hidden file was shipped:\n%s", msg)
+	}
+
+	nsID, _ := f.store.ResolveName(t.Context(), f.nsName)
+	dest := filepath.Join(f.data, "typst", "packages", nsID, "templates", "1.0.0")
+	var shipped []string
+	_ = filepath.WalkDir(dest, func(p string, d os.DirEntry, err error) error {
+		if err == nil && !d.IsDir() {
+			rel, _ := filepath.Rel(dest, p)
+			shipped = append(shipped, rel)
+		}
+		return nil
+	})
+	if len(shipped) != 2 {
+		t.Errorf("shipped %v, want exactly typst.toml and lib.typ", shipped)
+	}
+}

--- a/cmd/typst-d2-mcp/templates_test.go
+++ b/cmd/typst-d2-mcp/templates_test.go
@@ -301,3 +301,45 @@ func stageHousePackage(t *testing.T) string {
 	}
 	return staged
 }
+
+// numbering: must PRINT the numbers it lets you reference. Rendering
+// only the heading body meant @label resolved to "Section 8" on a page
+// where nothing was numbered 8 — a document that compiled cleanly and
+// read as nonsense.
+func TestHouseTemplates_NumberedHeadingsShowTheirNumbers(t *testing.T) {
+	if _, err := exec.LookPath("typst"); err != nil {
+		t.Skip("typst not installed")
+	}
+	staged := stageHousePackage(t)
+	dir := t.TempDir()
+	in := filepath.Join(dir, "doc.typ")
+	out := filepath.Join(dir, "doc.html")
+	src := `#import "@house/templates:0.1.0": report
+#show: report.with(title: "T", numbering: "1.")
+= Alpha <a>
+= Beta
+See @a.
+`
+	if err := os.WriteFile(in, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("typst", "compile", "--format", "html", "--features", "html", in, out)
+	cmd.Env = append(os.Environ(), "XDG_DATA_HOME="+staged)
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("html export unavailable: %s", b)
+	}
+	raw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+
+	// The reference resolves to a number, so that number must appear on
+	// the heading it points at.
+	if !strings.Contains(body, "1.") {
+		t.Errorf("numbered headings do not show a number:\n%s", body)
+	}
+	if strings.Contains(body, "Section") && !strings.Contains(body, "1.") {
+		t.Errorf("a reference names a number the document never prints:\n%s", body)
+	}
+}

--- a/internal/preprocessor/preprocessor.go
+++ b/internal/preprocessor/preprocessor.go
@@ -55,8 +55,18 @@ func Preprocess(ctx context.Context, r workspace.Resolver, inputPath string) (st
 	}
 	content := string(contentBytes)
 
-	// Remove old lib.typ imports
-	content = regexp.MustCompile(`#import\s+["'].*?lib\.typ["'].*?\n`).ReplaceAllString(content, "")
+	// A line importing anything named lib.typ used to be deleted here,
+	// left over from when this preprocessor injected its own library.
+	// It matched ANY path ending in lib.typ, so a caller's own
+	// `#import "lib.typ"` vanished during staging — silently, with the
+	// resulting "unknown variable" pointing at a line number that no
+	// longer matched their file. An agent lost three tool calls to it
+	// and abandoned local testing entirely.
+	//
+	// Nothing needs the removal: the injected import is @preview/based,
+	// added below and idempotent, and #91 made a relative import of a
+	// workspace file resolve properly — so this was deleting code that
+	// now works.
 
 	// Find all D2 calls
 	d2Blocks, skipped := extractD2Calls(content)

--- a/internal/preprocessor/preprocessor_test.go
+++ b/internal/preprocessor/preprocessor_test.go
@@ -372,3 +372,27 @@ func TestPreprocess_NamesTheDiagramThatFailed(t *testing.T) {
 		t.Errorf("error names the wrong diagram: %v", err)
 	}
 }
+
+// A caller's own `#import "lib.typ"` must survive preprocessing. The
+// line used to be deleted outright — leftover from when this package
+// injected its own library — so a workspace file called lib.typ became
+// invisible and the compile failed with "unknown variable" at a line
+// number that no longer matched the source.
+func TestPreprocess_KeepsTheCallersOwnLibImport(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.typ")
+	content := "#import \"lib.typ\": accent\n#import \"helpers/lib.typ\": other\n= Title\nBody.\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Preprocess(context.Background(), workspace.LocalFS{}, path)
+	if err != nil {
+		t.Fatalf("preprocess: %v", err)
+	}
+	for _, want := range []string{`#import "lib.typ": accent`, `#import "helpers/lib.typ": other`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("preprocessing removed the caller's import %q:\n%s", want, got)
+		}
+	}
+}

--- a/templates/house/templates/0.1.0/lib.typ
+++ b/templates/house/templates/0.1.0/lib.typ
@@ -55,14 +55,21 @@
   set text(size: 10.5pt, lang: "en")
   set par(justify: true, leading: 0.7em)
 
-  show heading.where(level: 1): it => block(
-    above: 1.6em, below: 0.8em,
-    text(size: 15pt, weight: 700, fill: _accent, it.body),
+  // The number is printed, not just counted. Rendering `it.body` alone
+  // meant `numbering:` enabled @label references that resolved to
+  // "Section 8" on a page where nothing was numbered 8 — a document
+  // that compiled cleanly and read as nonsense. An agent caught it by
+  // looking at the rasterised page; the compiler was perfectly happy.
+  let _numbered(it, size, weight, colour) = block(
+    above: if it.level == 1 { 1.6em } else { 1.2em },
+    below: if it.level == 1 { 0.8em } else { 0.6em },
+    text(size: size, weight: weight, fill: colour)[
+      #if it.numbering != none [#counter(heading).display(it.numbering) #h(0.35em)]
+      #it.body
+    ],
   )
-  show heading.where(level: 2): it => block(
-    above: 1.2em, below: 0.6em,
-    text(size: 12pt, weight: 600, it.body),
-  )
+  show heading.where(level: 1): it => _numbered(it, 15pt, 700, _accent)
+  show heading.where(level: 2): it => _numbered(it, 12pt, 600, black)
   show link: it => text(fill: _accent, it)
   show raw.where(block: false): it => box(
     fill: luma(240), inset: (x: 3pt), outset: (y: 3pt), radius: 2pt, it,


### PR DESCRIPTION
Three bugs, all found by **reading one agent's interview**. None was visible in its tool trace — the calls all looked fine.

## 1. `numbering:` referenced numbers the document never printed

The argument I added yesterday for #112 let `@label` resolve — and `report` rendered only a heading's *body*, discarding the number it was now counting. So a reference read "Section 8" on a page where nothing was numbered 8. Compiled cleanly, read as nonsense.

> *"A house style can be silently incompatible with a documented feature of itself… I only caught it because I was reading the rasterized page rather than trusting a successful compile."*

Before / after, same source:

```
Alpha      Beta      See Section 1.      ← number appears nowhere
1. Alpha   2. Beta   See Section 1.      ← fixed
```

## 2. Preprocessing deleted the caller's own `#import "lib.typ"`

A regex left over from when this package injected its own library matched **any** path ending in `lib.typ`, so a workspace file of that name vanished during staging. The failure surfaced as `unknown variable` at a line number that no longer matched the source.

> *"That one cost me three tool calls of confusion… The `#import` stripping killed my whole local test strategy."*

Nothing needed the removal: the injected import is `@preview/based`, and #91 made relative imports of workspace files resolve — so this was deleting code that now works.

## 3. Publishing swept `.previews/` into the package

86.8 KiB of PNGs in a package that should have held two files. **Versions are immutable, so that mistake is permanent** — a dead `1.0.0` sitting next to the real `1.0.1` in `list_templates` forever.

Hidden entries are now excluded, and the result lists what it shipped — which is what the agent asked for: *"it should exclude dotfiles, or at minimum list what it's about to ship."*

## One self-inflicted detour

My first heading fix defaulted a `fill` to `none`, invalid for `text()`. It passed my spot check because I only tried a level-1 heading; the suite caught it on level 2.
