### PR TITLE
Let a namespace have owners, and never lose its last

### DIFF
--- a/cmd/typst-d2-mcp/listtemplates_test.go
+++ b/cmd/typst-d2-mcp/listtemplates_test.go
@@ -71,7 +71,7 @@ func TestListTemplates_MatchesWhatTheCallerCanCompile(t *testing.T) {
 	writePackageForName(t, store, data, "acme", "1.0.0")
 	writePackageForName(t, store, data, "globex", "2.0.0")
 	member := seedUser(t, store, "member", 1)
-	if err := store.AddOrgMember(ctx, "admin", "acme", "member"); err != nil {
+	if err := store.AddOrgMember(ctx, "admin", "acme", "member", authdb.RoleMember); err != nil {
 		t.Fatal(err)
 	}
 
@@ -245,7 +245,7 @@ func TestListTemplates_MembershipIsNotWritable(t *testing.T) {
 		t.Fatal(err)
 	}
 	user := seedUser(t, store, "member", 6)
-	if err := store.AddOrgMember(context.Background(), "admin", "acme", "member"); err != nil {
+	if err := store.AddOrgMember(context.Background(), "admin", "acme", "member", authdb.RoleMember); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/typst-d2-mcp/namespaces_test.go
+++ b/cmd/typst-d2-mcp/namespaces_test.go
@@ -96,7 +96,7 @@ func TestAllowedNamespaces_MembershipDecides(t *testing.T) {
 	}
 	member := seedUser(t, store, "member", 1)
 	outsider := seedUser(t, store, "outsider", 2)
-	if err := store.AddOrgMember(ctx, "admin", "acme", "member"); err != nil {
+	if err := store.AddOrgMember(ctx, "admin", "acme", "member", authdb.RoleMember); err != nil {
 		t.Fatal(err)
 	}
 
@@ -346,7 +346,7 @@ func TestCompile_OrgTemplateAssetResolves(t *testing.T) {
 		t.Fatal(err)
 	}
 	member := seedUser(t, store, "member", 1)
-	if err := store.AddOrgMember(t.Context(), "admin", "acme", "member"); err != nil {
+	if err := store.AddOrgMember(t.Context(), "admin", "acme", "member", authdb.RoleMember); err != nil {
 		t.Fatal(err)
 	}
 	nsID, err := store.ResolveName(t.Context(), "acme")

--- a/cmd/typst-d2-mcp/publish_test.go
+++ b/cmd/typst-d2-mcp/publish_test.go
@@ -215,7 +215,7 @@ func TestPublish_RequiresOwnership(t *testing.T) {
 	if err := f.store.CreateOrg(t.Context(), "admin", "acme", "Acme"); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.store.AddOrgMember(t.Context(), "admin", "acme", "author"); err != nil {
+	if err := f.store.AddOrgMember(t.Context(), "admin", "acme", "author", authdb.RoleMember); err != nil {
 		t.Fatal(err)
 	}
 	res := f.publish(t, "tpl", "acme", "1.0.0")
@@ -563,5 +563,45 @@ func TestPublish_ExcludesHiddenDirectories(t *testing.T) {
 	})
 	if len(shipped) != 2 {
 		t.Errorf("shipped %v, want exactly typst.toml and lib.typ", shipped)
+	}
+}
+
+// The end of the dead feature: an owner of an organisation namespace
+// can publish to it. Before ownership could be assigned, nobody could —
+// every org namespace was permanently unpublishable, and it went
+// unnoticed because every test published to a personal namespace, where
+// you are the owner by construction.
+func TestPublish_OwnerOfAnOrgCanPublishToIt(t *testing.T) {
+	f := newPublishFixture(t)
+	if err := f.store.CreateOrg(t.Context(), "admin", "acme", "Acme"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.store.AddOrgMember(t.Context(), "admin", "acme", "author", authdb.RoleOwner); err != nil {
+		t.Fatal(err)
+	}
+	f.stage(t, "tpl", map[string]string{"typst.toml": goodTOML, "lib.typ": goodLib})
+
+	if res := f.publish(t, "tpl", "acme", "1.0.0"); res.IsError {
+		t.Fatalf("an owner could not publish to their organisation: %s", resultText(res))
+	}
+}
+
+// And a member still cannot — ownership is the boundary, not membership.
+func TestPublish_MemberOfAnOrgStillCannot(t *testing.T) {
+	f := newPublishFixture(t)
+	if err := f.store.CreateOrg(t.Context(), "admin", "acme", "Acme"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.store.AddOrgMember(t.Context(), "admin", "acme", "author", authdb.RoleMember); err != nil {
+		t.Fatal(err)
+	}
+	f.stage(t, "tpl", map[string]string{"typst.toml": goodTOML, "lib.typ": goodLib})
+
+	res := f.publish(t, "tpl", "acme", "1.0.0")
+	if !res.IsError {
+		t.Fatal("a member published to an organisation they do not own")
+	}
+	if !strings.Contains(resultText(res), "not an owner") {
+		t.Errorf("refusal does not explain: %s", resultText(res))
 	}
 }

--- a/cmd/typst-d2-mcp/resources_test.go
+++ b/cmd/typst-d2-mcp/resources_test.go
@@ -179,7 +179,7 @@ func TestPageResource_RendersADocumentUsingAnOrgTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 	member := seedUser(t, store, "member", 21)
-	if err := store.AddOrgMember(t.Context(), "admin", "acme", "member"); err != nil {
+	if err := store.AddOrgMember(t.Context(), "admin", "acme", "member", authdb.RoleMember); err != nil {
 		t.Fatal(err)
 	}
 	nsID, err := store.ResolveName(t.Context(), "acme")

--- a/internal/authdb/namespaces_test.go
+++ b/internal/authdb/namespaces_test.go
@@ -139,7 +139,7 @@ func TestNamespace_GrowsWithoutMigrating(t *testing.T) {
 	if _, err := s.UpsertGitHubUser(ctx, 2, "colleague", "c@example.com"); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.AddOrgMember(ctx, "admin", "acme", "colleague"); err != nil {
+	if err := s.AddOrgMember(ctx, "admin", "acme", "colleague", RoleMember); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/authdb/orgs.go
+++ b/internal/authdb/orgs.go
@@ -24,7 +24,19 @@ const (
 	ActionDeleteOrg       = "delete_org"
 	ActionAddOrgMember    = "add_org_member"
 	ActionRemoveOrgMember = "remove_org_member"
+	ActionSetOrgRole      = "set_org_role"
 )
+
+// ErrLastOwner is returned when an action would leave a namespace with
+// nobody able to publish to it.
+//
+// A namespace without an owner is not merely awkward — it is
+// permanently unpublishable, because ownership is the only thing that
+// grants publishing and there is no way to acquire it from outside.
+// That state was reachable and went unnoticed: CreateOrg made a
+// namespace and no owner at all, so every organisation namespace was
+// dead on arrival.
+var ErrLastOwner = errors.New("that would leave the namespace with no owner")
 
 // Org is one shared namespace, presented for the admin UI.
 type Org struct {
@@ -124,7 +136,10 @@ SELECT nn.name, nn.display_name, nn.created_by, nn.created_at,
 // They join as a member, not an owner: publishing is an owner's right,
 // and handing it out as a side effect of being added to an organisation
 // is not something an administrator asked for.
-func (s *Store) AddOrgMember(ctx context.Context, actor, slug, login string) error {
+func (s *Store) AddOrgMember(ctx context.Context, actor, slug, login, role string) error {
+	if role != RoleOwner && role != RoleMember {
+		return fmt.Errorf("unknown role %q (expected %q or %q)", role, RoleOwner, RoleMember)
+	}
 	target := NormalizeLogin(login)
 	return s.inTx(ctx, func(tx *sql.Tx) error {
 		id, err := resolveNameTx(ctx, tx, slug)
@@ -143,7 +158,7 @@ func (s *Store) AddOrgMember(ctx context.Context, actor, slug, login string) err
 		userID := fmt.Sprintf("gh:%d", githubID.Int64)
 		res, err := tx.ExecContext(ctx, `
 INSERT INTO namespace_members (namespace_id, user_id, role, created_by) VALUES (?, ?, ?, ?)
-ON CONFLICT (namespace_id, user_id) DO NOTHING`, id, userID, RoleMember, actor)
+ON CONFLICT (namespace_id, user_id) DO NOTHING`, id, userID, role, actor)
 		if err != nil {
 			return fmt.Errorf("add member: %w", err)
 		}
@@ -161,6 +176,11 @@ func (s *Store) RemoveOrgMember(ctx context.Context, actor, slug, login string) 
 		id, err := resolveNameTx(ctx, tx, slug)
 		if err != nil {
 			return err
+		}
+		if last, checkErr := wouldStrandNamespace(ctx, tx, id, target); checkErr != nil {
+			return checkErr
+		} else if last {
+			return ErrLastOwner
 		}
 		res, err := tx.ExecContext(ctx, `
 DELETE FROM namespace_members
@@ -216,4 +236,66 @@ func resolveNameTx(ctx context.Context, tx *sql.Tx, name string) (string, error)
 		return "", fmt.Errorf("resolve name: %w", err)
 	}
 	return id, nil
+}
+
+// SetOrgMemberRole promotes or demotes an existing member.
+//
+// Ownership is what grants publishing, so this is how a namespace
+// acquires somebody who can publish to it. Demoting the last owner is
+// refused for the same reason removing them is: the namespace would
+// become permanently unpublishable with no way back.
+func (s *Store) SetOrgMemberRole(ctx context.Context, actor, slug, login, role string) error {
+	if role != RoleOwner && role != RoleMember {
+		return fmt.Errorf("unknown role %q (expected %q or %q)", role, RoleOwner, RoleMember)
+	}
+	target := NormalizeLogin(login)
+	return s.inTx(ctx, func(tx *sql.Tx) error {
+		id, err := resolveNameTx(ctx, tx, slug)
+		if err != nil {
+			return err
+		}
+		if role == RoleMember {
+			if last, checkErr := wouldStrandNamespace(ctx, tx, id, target); checkErr != nil {
+				return checkErr
+			} else if last {
+				return ErrLastOwner
+			}
+		}
+		res, err := tx.ExecContext(ctx, `
+UPDATE namespace_members SET role = ?
+ WHERE namespace_id = ?
+   AND user_id = (SELECT 'gh:' || github_id FROM users WHERE LOWER(github_login) = ?)`,
+			role, id, target)
+		if err != nil {
+			return fmt.Errorf("set role: %w", err)
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return ErrNoSuchUser
+		}
+		return auditTx(ctx, tx, actor, ActionSetOrgRole, target, slug+" → "+role)
+	})
+}
+
+// wouldStrandNamespace reports whether removing or demoting this member
+// would leave the namespace with no owner.
+func wouldStrandNamespace(ctx context.Context, tx *sql.Tx, namespaceID, login string) (bool, error) {
+	var isOwner int
+	err := tx.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM namespace_members
+ WHERE namespace_id = ? AND role = ?
+   AND user_id = (SELECT 'gh:' || github_id FROM users WHERE LOWER(github_login) = ?)`,
+		namespaceID, RoleOwner, login).Scan(&isOwner)
+	if err != nil {
+		return false, fmt.Errorf("check ownership: %w", err)
+	}
+	if isOwner == 0 {
+		return false, nil // not an owner; removing them strands nothing
+	}
+	var owners int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM namespace_members WHERE namespace_id = ? AND role = ?`,
+		namespaceID, RoleOwner).Scan(&owners); err != nil {
+		return false, fmt.Errorf("count owners: %w", err)
+	}
+	return owners <= 1, nil
 }

--- a/internal/authdb/orgs_test.go
+++ b/internal/authdb/orgs_test.go
@@ -60,16 +60,16 @@ func TestOrg_Membership(t *testing.T) {
 		t.Fatalf("CreateOrg: %v", err)
 	}
 
-	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "alice"); err != nil {
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "alice", RoleMember); err != nil {
 		t.Fatalf("AddOrgMember alice: %v", err)
 	}
-	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "bob"); err != nil {
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "bob", RoleMember); err != nil {
 		t.Fatalf("AddOrgMember bob: %v", err)
 	}
 
 	// Idempotency guard: adding the same member again is a clear signal,
 	// not a silent success.
-	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "alice"); !errors.Is(err, ErrAlreadyMember) {
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "alice", RoleMember); !errors.Is(err, ErrAlreadyMember) {
 		t.Errorf("re-add = %v, want ErrAlreadyMember", err)
 	}
 
@@ -113,12 +113,136 @@ func TestOrg_MembershipErrors(t *testing.T) {
 		t.Fatalf("CreateOrg: %v", err)
 	}
 	// Unknown user (never signed in).
-	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "ghost"); !errors.Is(err, ErrNoSuchUser) {
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "ghost", RoleMember); !errors.Is(err, ErrNoSuchUser) {
 		t.Errorf("AddOrgMember(unknown user) = %v, want ErrNoSuchUser", err)
 	}
 	// Unknown org.
 	seedUser(t, s, 1, "alice")
-	if err := s.AddOrgMember(ctx, "dlouwers", "nope", "alice"); !errors.Is(err, ErrNoSuchNamespace) {
+	if err := s.AddOrgMember(ctx, "dlouwers", "nope", "alice", RoleMember); !errors.Is(err, ErrNoSuchNamespace) {
 		t.Errorf("AddOrgMember(unknown org) = %v, want ErrNoSuchNamespace", err)
+	}
+}
+
+// Ownership is what grants publishing. Without a way to assign it, an
+// organisation namespace could be created, filled with members, and
+// remain permanently unpublishable by everyone — which is the state
+// every org namespace was in.
+func TestOrg_OwnershipCanBeAssigned(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+	if err := s.CreateOrg(ctx, "dlouwers", "acme", "Acme"); err != nil {
+		t.Fatal(err)
+	}
+	alice := seedUser(t, s, 1, "alice")
+
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "alice", RoleMember); err != nil {
+		t.Fatal(err)
+	}
+	id, err := s.ResolveName(ctx, "acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if role, _ := s.RoleFor(ctx, id, alice); role != RoleMember {
+		t.Fatalf("role = %q, want member", role)
+	}
+
+	if err := s.SetOrgMemberRole(ctx, "dlouwers", "acme", "alice", RoleOwner); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if role, _ := s.RoleFor(ctx, id, alice); role != RoleOwner {
+		t.Errorf("role after promotion = %q, want owner", role)
+	}
+}
+
+// A member may be added straight as an owner, so a new organisation is
+// not born unpublishable.
+func TestOrg_MemberCanBeAddedAsOwner(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+	if err := s.CreateOrg(ctx, "dlouwers", "acme", ""); err != nil {
+		t.Fatal(err)
+	}
+	alice := seedUser(t, s, 1, "alice")
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "alice", RoleOwner); err != nil {
+		t.Fatal(err)
+	}
+	id, _ := s.ResolveName(ctx, "acme")
+	if role, _ := s.RoleFor(ctx, id, alice); role != RoleOwner {
+		t.Errorf("role = %q, want owner", role)
+	}
+}
+
+// The last owner cannot be removed or demoted. A namespace with no
+// owner is permanently unpublishable and there is no way back, so the
+// state must be unreachable rather than merely discouraged.
+func TestOrg_LastOwnerIsProtected(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+	if err := s.CreateOrg(ctx, "dlouwers", "acme", ""); err != nil {
+		t.Fatal(err)
+	}
+	seedUser(t, s, 1, "alice")
+	seedUser(t, s, 2, "bob")
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "alice", RoleOwner); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "bob", RoleMember); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.SetOrgMemberRole(ctx, "dlouwers", "acme", "alice", RoleMember); !errors.Is(err, ErrLastOwner) {
+		t.Errorf("demoting the only owner = %v, want ErrLastOwner", err)
+	}
+	if err := s.RemoveOrgMember(ctx, "dlouwers", "acme", "alice"); !errors.Is(err, ErrLastOwner) {
+		t.Errorf("removing the only owner = %v, want ErrLastOwner", err)
+	}
+	// A non-owner is removable, and does not count as protection.
+	if err := s.RemoveOrgMember(ctx, "dlouwers", "acme", "bob"); err != nil {
+		t.Errorf("removing a plain member: %v", err)
+	}
+
+	// With a second owner, the first may go.
+	seedUser(t, s, 3, "carol")
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "carol", RoleOwner); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemoveOrgMember(ctx, "dlouwers", "acme", "alice"); err != nil {
+		t.Errorf("removing an owner when another remains: %v", err)
+	}
+	// …and now carol is protected in turn.
+	if err := s.RemoveOrgMember(ctx, "dlouwers", "acme", "carol"); !errors.Is(err, ErrLastOwner) {
+		t.Errorf("removing the new last owner = %v, want ErrLastOwner", err)
+	}
+}
+
+// A personal namespace has exactly one owner, so the same guard keeps
+// somebody from being orphaned out of their own workspace.
+func TestOrg_PersonalNamespaceOwnerIsProtected(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+	if _, err := s.UpsertGitHubUser(ctx, 9, "solo", "solo@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	name := DerivedName(9)
+	if err := s.RemoveOrgMember(ctx, "dlouwers", name, "solo"); !errors.Is(err, ErrLastOwner) {
+		t.Errorf("removing someone from their own namespace = %v, want ErrLastOwner", err)
+	}
+}
+
+func TestOrg_UnknownRoleRejected(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+	if err := s.CreateOrg(ctx, "dlouwers", "acme", ""); err != nil {
+		t.Fatal(err)
+	}
+	seedUser(t, s, 1, "alice")
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "alice", "admin"); err == nil {
+		t.Error("an unknown role was accepted on add")
+	}
+	if err := s.AddOrgMember(ctx, "dlouwers", "acme", "alice", RoleMember); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetOrgMemberRole(ctx, "dlouwers", "acme", "alice", "superuser"); err == nil {
+		t.Error("an unknown role was accepted on change")
 	}
 }

--- a/internal/web/handlers_orgs.go
+++ b/internal/web/handlers_orgs.go
@@ -117,7 +117,11 @@ func (s *Server) handleAddOrgMember(w http.ResponseWriter, r *http.Request) {
 		s.respondOrgAction(w, r, flashError, err.Error())
 		return
 	}
-	if err := s.cfg.Store.AddOrgMember(r.Context(), adminLogin(r.Context()), slug, login); err != nil {
+	role := authdb.RoleMember
+	if r.PostFormValue("role") == authdb.RoleOwner {
+		role = authdb.RoleOwner
+	}
+	if err := s.cfg.Store.AddOrgMember(r.Context(), adminLogin(r.Context()), slug, login, role); err != nil {
 		switch {
 		case errors.Is(err, authdb.ErrNoSuchUser):
 			s.respondOrgAction(w, r, flashError, login+" has not signed in yet, so there is no account to add")
@@ -144,6 +148,12 @@ func (s *Server) handleRemoveOrgMember(w http.ResponseWriter, r *http.Request) {
 	if err := s.cfg.Store.RemoveOrgMember(r.Context(), adminLogin(r.Context()), slug, login); err != nil {
 		if errors.Is(err, authdb.ErrNoSuchUser) {
 			s.respondOrgAction(w, r, flashError, login+" is not a member of "+slug)
+			return
+		}
+		if errors.Is(err, authdb.ErrLastOwner) {
+			s.respondOrgAction(w, r, flashError,
+				login+" is the only owner of "+slug+". Make someone else an owner first, "+
+					"or nobody will be able to publish to it.")
 			return
 		}
 		slog.Error("admin: remove org member", "slug", slug, "login", login, "err", err)
@@ -195,4 +205,43 @@ func (s *Server) renderOrgsFragment(w http.ResponseWriter, r *http.Request) {
 	if err := s.fragments.ExecuteTemplate(w, "orgs-list", vm); err != nil {
 		slog.Error("admin: render orgs fragment", "err", err)
 	}
+}
+
+// handleSetOrgRole promotes a member to owner, or demotes them back.
+//
+// Ownership is what grants publishing, so without this an organisation
+// namespace could be created, filled with members, and still be
+// permanently unpublishable by everyone.
+func (s *Server) handleSetOrgRole(w http.ResponseWriter, r *http.Request) {
+	slug, login, err := orgMemberForm(r)
+	if err != nil {
+		s.respondOrgAction(w, r, flashError, err.Error())
+		return
+	}
+	role := r.PostFormValue("role")
+	if role != authdb.RoleOwner && role != authdb.RoleMember {
+		s.respondOrgAction(w, r, flashError, "role must be owner or member")
+		return
+	}
+	if err := s.cfg.Store.SetOrgMemberRole(r.Context(), adminLogin(r.Context()), slug, login, role); err != nil {
+		switch {
+		case errors.Is(err, authdb.ErrNoSuchUser):
+			s.respondOrgAction(w, r, flashError, login+" is not a member of "+slug)
+		case errors.Is(err, authdb.ErrNoSuchNamespace):
+			s.respondOrgAction(w, r, flashError, "no organisation named "+slug)
+		case errors.Is(err, authdb.ErrLastOwner):
+			s.respondOrgAction(w, r, flashError,
+				login+" is the only owner of "+slug+". Make someone else an owner first, "+
+					"or nobody will be able to publish to it.")
+		default:
+			slog.Error("admin: set org role", "slug", slug, "login", login, "err", err)
+			s.respondOrgAction(w, r, flashError, "could not change "+login+"'s role in "+slug)
+		}
+		return
+	}
+	article := "a"
+	if role == authdb.RoleOwner {
+		article = "an"
+	}
+	s.respondOrgAction(w, r, flashNotice, login+" is now "+article+" "+role+" of "+slug)
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -144,6 +144,7 @@ func (s *Server) Handler() http.Handler {
 		"POST /admin/orgs/delete":         s.handleDeleteOrg,
 		"POST /admin/orgs/members/add":    s.handleAddOrgMember,
 		"POST /admin/orgs/members/remove": s.handleRemoveOrgMember,
+		"POST /admin/orgs/members/role":   s.handleSetOrgRole,
 	} {
 		mux.Handle(path, s.requireAdmin(handler))
 	}

--- a/internal/web/templates/orgs.tmpl
+++ b/internal/web/templates/orgs.tmpl
@@ -1,10 +1,11 @@
 {{define "content"}}
 <sl-card padding="lg">
   <h1 slot="header">Organisations</h1>
-  <p class="muted">An organisation is a template owner: its slug is the
-  namespace people import as <code>@slug/…</code>. Membership decides whose
-  documents may resolve it (compile-time resolution lands later — see #63).
-  Workspaces and quota stay per-user.</p>
+  <p class="muted">An organisation is a template owner: its name is the
+  namespace people import as <code>@name/…</code>. <strong>Members</strong> may
+  import its templates; <strong>owners</strong> may also publish to it. A
+  namespace with no owner cannot be published to by anyone, so the last owner
+  cannot be removed or demoted. Workspaces and quota stay per-user.</p>
 
   <form method="post" action="/admin/orgs/create" hx-post="/admin/orgs/create" hx-target="#orgs" hx-swap="outerHTML" class="row">
     <label>Slug

--- a/internal/web/templates/partials.tmpl
+++ b/internal/web/templates/partials.tmpl
@@ -154,8 +154,26 @@
       <tbody>
       {{range .Members}}
         <tr>
-          <td><strong>{{.GitHubLogin}}</strong>{{if .Email}} <span class="muted">{{.Email}}</span>{{end}}</td>
+          <td>
+            <strong>{{.GitHubLogin}}</strong>{{if .Email}} <span class="muted">{{.Email}}</span>{{end}}
+            {{if eq .Role "owner"}}<sl-badge variant="success">owner</sl-badge>{{end}}
+          </td>
           <td class="num">
+            {{/* Ownership is what grants publishing, so it is set here.
+                 Without it an organisation namespace can be created,
+                 filled with members, and still be unpublishable by
+                 everyone. */}}
+            <form method="post" action="/admin/orgs/members/role" hx-post="/admin/orgs/members/role" hx-target="#orgs" hx-swap="outerHTML">
+              <input type="hidden" name="slug" value="{{$slug}}">
+              <input type="hidden" name="login" value="{{.GitHubLogin}}">
+              {{if eq .Role "owner"}}
+                <input type="hidden" name="role" value="member">
+                <button type="submit" class="btn btn-sm">Make member</button>
+              {{else}}
+                <input type="hidden" name="role" value="owner">
+                <button type="submit" class="btn btn-sm">Make owner</button>
+              {{end}}
+            </form>
             <form method="post" action="/admin/orgs/members/remove" hx-post="/admin/orgs/members/remove" hx-target="#orgs" hx-swap="outerHTML">
               <input type="hidden" name="slug" value="{{$slug}}">
               <input type="hidden" name="login" value="{{.GitHubLogin}}">
@@ -174,6 +192,12 @@
         <input type="hidden" name="slug" value="{{.Slug}}">
         <label>Add member
           <input type="text" name="login" placeholder="github-login" autocomplete="off" required>
+        </label>
+        <label>Role
+          <select name="role">
+            <option value="member">member — may import</option>
+            <option value="owner">owner — may publish</option>
+          </select>
         </label>
         <button type="submit" class="btn btn-sm">Add</button>
       </form>

--- a/playwright/helpers/db.ts
+++ b/playwright/helpers/db.ts
@@ -128,3 +128,18 @@ export function orgMemberCount(slug: string): number {
     ).trim(),
   );
 }
+
+/**
+ * A member's role in a namespace, addressed by NAME, or '' when they are
+ * not a member. Ownership is what grants publishing, so this is the
+ * column that decides whether an organisation is usable at all.
+ */
+export function orgMemberRole(slug: string, login: string): string {
+  return sql(
+    `SELECT m.role
+       FROM namespace_members m
+       JOIN namespace_names nn ON nn.namespace_id = m.namespace_id
+       JOIN users u ON 'gh:' || u.github_id = m.user_id
+      WHERE nn.name = '${slug}' AND u.github_login = '${login}'`,
+  ).trim();
+}

--- a/playwright/tests/no-js.spec.ts
+++ b/playwright/tests/no-js.spec.ts
@@ -1,7 +1,13 @@
 import { test, expect } from "@playwright/test";
 import { APP_ORIGIN } from "../playwright.config";
 import { signIn } from "../helpers/session";
-import { countInvites, countUsers, quotaFor, seedSignedInUser } from "../helpers/db";
+import {
+  countInvites,
+  countUsers,
+  quotaFor,
+  seedSignedInUser,
+  orgMemberRole,
+} from "../helpers/db";
 
 // The admin UI is supposed to work with JavaScript unavailable: the
 // forms are ordinary POSTs, the handlers redirect with a banner instead
@@ -52,6 +58,35 @@ test.describe("without javascript", () => {
 
     await expect(page.locator("#flash")).toContainText("Quota updated");
     expect(quotaFor("nojsquota")).toBe("0");
+  });
+
+  // Ownership is the only route to a publishable organisation namespace,
+  // so the buttons that grant it must not be the one part of the admin
+  // UI that needs script.
+  test("ownership can be granted and the last owner protected without script", async ({
+    page,
+  }) => {
+    seedSignedInUser(5260, "nojsowner");
+    await page.goto(`${APP_ORIGIN}/admin/orgs`);
+    await page.fill('form[action="/admin/orgs/create"] input[name="slug"]', "nojsorg");
+    await page.click('form[action="/admin/orgs/create"] button[type="submit"]');
+
+    const card = () => page.locator("sl-card.org", { hasText: "@nojsorg" });
+    await card().locator('form[action="/admin/orgs/members/add"] input[name="login"]').fill("nojsowner");
+    await card().getByRole("button", { name: "Add" }).click();
+    expect(orgMemberRole("nojsorg", "nojsowner")).toBe("member");
+
+    await card().getByRole("button", { name: "Make owner" }).click();
+    await expect(page).toHaveURL(/\/admin\/orgs\?flash=/);
+    await expect(page.locator("#flash")).toContainText("is now an owner");
+    expect(orgMemberRole("nojsorg", "nojsowner")).toBe("owner");
+
+    await card().getByRole("button", { name: "Make member" }).click();
+    await expect(page.locator("#flash")).toContainText("only owner");
+    expect(orgMemberRole("nojsorg", "nojsowner")).toBe("owner");
+
+    await card().getByRole("button", { name: "Delete" }).click();
+    await expect(page.locator("#orgs")).not.toContainText("@nojsorg");
   });
 
   test("delete still enforces the typed confirmation", async ({ page }) => {

--- a/playwright/tests/orgs.spec.ts
+++ b/playwright/tests/orgs.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from "@playwright/test";
 import { APP_ORIGIN } from "../playwright.config";
 import { signIn } from "../helpers/session";
-import { seedSignedInUser, orgCount, orgMemberCount } from "../helpers/db";
+import {
+  seedSignedInUser,
+  orgCount,
+  orgMemberCount,
+  orgMemberRole,
+} from "../helpers/db";
 
 // Organisation management is a second admin page (#63 rung 3). These
 // checks drive the create / add-member / remove / delete flow in a real
@@ -51,6 +56,53 @@ test.describe("organisations", () => {
       .click();
     await expect(page.locator("#orgs")).not.toContainText("@acme");
     expect(orgCount()).toBe(0);
+  });
+
+  // Ownership is the only thing that grants publishing, and it is only
+  // reachable through this page — so if these controls do not work, an
+  // organisation namespace can be created and then never published to.
+  test("promote to owner, and refuse to strand the last one", async ({ page }) => {
+    await page.locator('form[action="/admin/orgs/create"] input[name="slug"]').fill("acme");
+    await page.getByRole("button", { name: "Create organisation" }).click();
+    await expect(page.locator("#orgs")).toContainText("@acme");
+
+    // Added straight as an owner, so the organisation is publishable
+    // from the moment it has anyone in it.
+    seedSignedInUser(4310, "orgowner");
+    const card = () => page.locator("sl-card.org", { hasText: "@acme" });
+    await card().locator('form[action="/admin/orgs/members/add"] input[name="login"]').fill("orgowner");
+    await card().locator('form[action="/admin/orgs/members/add"] select[name="role"]').selectOption("owner");
+    await card().getByRole("button", { name: "Add" }).click();
+
+    await expect(page.locator("#orgs")).toContainText("orgowner");
+    expect(orgMemberRole("acme", "orgowner")).toBe("owner");
+    await expect(card().locator("sl-badge", { hasText: "owner" })).toBeVisible();
+
+    // The only owner can be neither demoted nor removed.
+    await card().getByRole("button", { name: "Make member" }).click();
+    await expect(page.locator("#flash")).toContainText("only owner");
+    expect(orgMemberRole("acme", "orgowner")).toBe("owner");
+
+    await card().getByRole("button", { name: "Remove" }).click();
+    await expect(page.locator("#flash")).toContainText("only owner");
+    expect(orgMemberCount("acme")).toBe(1);
+
+    // A second owner lifts the protection from the first.
+    seedSignedInUser(4311, "orgsecond");
+    await card().locator('form[action="/admin/orgs/members/add"] input[name="login"]').fill("orgsecond");
+    await card().locator('form[action="/admin/orgs/members/add"] select[name="role"]').selectOption("owner");
+    await card().getByRole("button", { name: "Add" }).click();
+    await expect(page.locator("#orgs")).toContainText("orgsecond");
+
+    await card()
+      .locator("tr", { hasText: "orgowner" })
+      .getByRole("button", { name: "Remove" })
+      .click();
+    await expect(page.locator("#orgs")).not.toContainText("orgowner");
+    expect(orgMemberRole("acme", "orgsecond")).toBe("owner");
+
+    await card().getByRole("button", { name: "Delete" }).click();
+    await expect(page.locator("#orgs")).not.toContainText("@acme");
   });
 
   test("a malformed slug is rejected with a flash", async ({ page }) => {


### PR DESCRIPTION
Ownership grants publishing, and no code path ever granted ownership. `CreateOrg` inserted a namespace and a name but no member row; `AddOrgMember` hard-coded `member`; nothing anywhere changed a role. Every organisation namespace was therefore unpublishable by everyone in it, permanently, with a refusal message that was accurate and impossible to act on.

It stayed hidden because every publish test published to a *personal* namespace, where `EnsurePersonalNamespace` makes you the owner by construction. The organisation path was never exercised end to end.

## What changed

- `AddOrgMember` takes a role, so an organisation can be publishable from the moment it has anyone in it.
- New `SetOrgMemberRole` promotes and demotes existing members; audited as `set_org_role`.
- New `ErrLastOwner`, enforced by a shared `wouldStrandNamespace` guard on both removal and demotion. Any number of owners is fine — the last one may not go. Because ownership cannot be acquired from outside, a namespace that loses its last owner is unrecoverable in exactly the way a fresh organisation was, so the state is made unreachable rather than discouraged.
- Personal namespaces inherit the guard for free: they have exactly one owner, so nobody can be orphaned out of their own workspace.
- Admin UI: a role select on add, an owner badge, Make owner / Make member, and a refusal flash that names the way out. Works over htmx and as a plain form post.

The publish path is now covered from both sides: an owner of an organisation can publish to it, and a member still cannot.

Refers #131