### PR TITLE
Say that the workspace is not on the caller's machine

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -254,6 +254,14 @@ VERIFYING THE RESULT:
   yourself, advise the user to inspect it.
 
 WORKSPACE, FILES & LIMITS (put_file / workspace_info):
+  THE WORKSPACE MAY NOT BE ON YOUR MACHINE. Call workspace_info: if it
+  reports location "server", these tools are the only way to reach these
+  files. Do not shell out to check whether a write landed, do not cat or
+  ls a path a tool returned, and do not read a returned path as a path
+  on your filesystem. A local check will report the file missing — which
+  means you are looking in the wrong place, NOT that the write failed.
+  To read a file back, use get_file or the typst-d2://source/ resource.
+
   In hosted (HTTP) mode the server owns a per-tenant workspace and the
   document's own files do not reach it by themselves. Any asset a Typst
   document references — e.g. image("logo.png") — must be pushed with
@@ -1082,10 +1090,16 @@ for the full file / upload guide.`,
 	s.AddTool(putFileTool, handlePutFile(factory, store))
 
 	workspaceInfoTool := mcp.NewTool("workspace_info",
-		mcp.WithDescription(`Report the active workspace's storage limits and current usage. Call
-this before pushing a large asset with put_file to see what will fit.
+		mcp.WithDescription(`Report where the active workspace is and what it can hold. Call this
+first when orienting, and again before pushing a large asset with
+put_file to see what will fit.
 
 No arguments; returns JSON:
+  - location: "server" means the workspace is a directory the server
+    owns and these tools are the ONLY way to reach it — do not try to
+    verify your work by shelling out, and do not treat a path from these
+    tools as a path on your filesystem. "local" means this server shares
+    your filesystem. "access" says the same in a sentence.
   - per_call_limit_bytes / per_call_limit_human: max size of one put_file
     payload, on DECODED bytes.
   - usage_tracked: true in scoped/hosted mode (bounded per-tenant dir),
@@ -1747,6 +1761,20 @@ func projectedUsage(r workspace.Resolver, path string, newSize int64, mode strin
 // (not a misleading zero) when they do not apply: usage in local mode, and
 // budget/available when no budget is configured.
 type workspaceInfo struct {
+	// Where the files are, and what that means for reaching them.
+	//
+	// Agents reason about the workspace as if it were the filesystem
+	// they are standing on: they shell out to check whether a file
+	// landed, try to cat a path a tool just returned, plan around ls.
+	// The failure is quiet in the worst possible way — a local check
+	// reports that the file is not there, which reads as "my write
+	// failed" rather than "I am looking on the wrong machine" — so the
+	// agent redoes work that already succeeded, or concludes the server
+	// is broken. Nothing in the tool surface said otherwise, so this
+	// does, in the tool a caller uses to orient itself.
+	Location string `json:"location"`
+	Access   string `json:"access"`
+
 	PerCallLimitBytes int64  `json:"per_call_limit_bytes"`
 	PerCallLimitHuman string `json:"per_call_limit_human"`
 	UsageTracked      bool   `json:"usage_tracked"`
@@ -1795,6 +1823,16 @@ func handleWorkspaceInfo(factory workspace.Factory, store *authdb.Store) server.
 		}
 		if _, ok := resolver.(workspace.Bounded); ok {
 			info.FontsDir = FontsDir
+			info.Location = "server"
+			info.Access = "These files live in a directory the server owns — not your " +
+				"working directory, and possibly not your machine. These MCP tools are " +
+				"the only way to reach them: a shell, ls or cat will not find them, and " +
+				"a path you see here is not a path on your filesystem. Read a file back " +
+				"with get_file or the typst-d2://source/ resource, not by opening it."
+		} else {
+			info.Location = "local"
+			info.Access = "This server shares your filesystem, so these are ordinary " +
+				"local paths and your own tools can read them."
 		}
 		if tracked {
 			u := used

--- a/cmd/typst-d2-mcp/workspaceinfo_test.go
+++ b/cmd/typst-d2-mcp/workspaceinfo_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dlouwers/typst-d2-mcp/internal/identity"
@@ -127,5 +128,54 @@ func TestHandleWorkspaceInfo_AvailableFlooredAtZero(t *testing.T) {
 	info := callWorkspaceInfo(t, ctx, factory)
 	if info.AvailableBytes == nil || *info.AvailableBytes != 0 {
 		t.Fatalf("available_bytes = %v, want 0 (floored)", info.AvailableBytes)
+	}
+}
+
+// The most repeated failure in the agent research: the workspace is
+// treated as the filesystem the caller is standing on. Agents shelled
+// out to confirm a write, tried to cat a path a tool had just returned,
+// and planned around ls. A local check reports the file missing, which
+// reads as "my write failed" rather than "I am looking on the wrong
+// machine" — so the work gets redone, or the server gets blamed.
+//
+// Nothing in the tool surface said otherwise. workspace_info is where a
+// caller orients, so it is where this has to be said.
+func TestHandleWorkspaceInfo_SaysWhereTheFilesAre(t *testing.T) {
+	root := t.TempDir()
+	ctx := identity.WithIdentity(context.Background(), identity.Identity{UserID: "user123"})
+	scoped := callWorkspaceInfo(t, ctx, workspace.TenantFactory{Root: root})
+
+	if scoped.Location != "server" {
+		t.Errorf("scoped location = %q, want %q", scoped.Location, "server")
+	}
+	// The sentence has to name the mistake, not merely the fact — an
+	// agent that reads "server-owned" and still runs `ls` has been told
+	// nothing useful.
+	for _, want := range []string{"only way", "get_file"} {
+		if !strings.Contains(scoped.Access, want) {
+			t.Errorf("scoped access note does not mention %q: %s", want, scoped.Access)
+		}
+	}
+
+	local := callWorkspaceInfo(t, context.Background(), workspace.LocalFactory{})
+	if local.Location != "local" {
+		t.Errorf("local location = %q, want %q", local.Location, "local")
+	}
+	if local.Access == "" {
+		t.Error("local access note is empty; silence is what caused the confusion")
+	}
+	if strings.Contains(local.Access, "only way") {
+		t.Errorf("local mode claims the tools are the only route, which is false: %s", local.Access)
+	}
+}
+
+// The instruction block is read every session and said nothing about
+// this, so an agent that never calls workspace_info learned it the
+// expensive way.
+func TestServerInstructions_WarnAboutTheRemoteWorkspace(t *testing.T) {
+	for _, want := range []string{"workspace_info", "shell out", "location \"server\""} {
+		if !strings.Contains(serverInstructions, want) {
+			t.Errorf("server instructions do not mention %q", want)
+		}
 	}
 }


### PR DESCRIPTION
Agents treat the workspace as the filesystem they are standing on. Across the research they shelled out to check whether a file landed, tried to `cat` a path a tool had just returned, and planned around `ls`. None of it works when the server is elsewhere, and nothing in the tool surface said so.

The failure mode is what makes it worth fixing rather than tolerating. A local check does not error — it reports the file is not there. That reads as *"my write failed"*, not *"I am looking on the wrong machine"*. So the agent redoes work that already succeeded, or decides the tool is broken.

## What changed

`workspace_info` now leads with where the files are:

```json
{
  "location": "server",
  "access": "These files live in a directory the server owns — not your working directory, and possibly not your machine. These MCP tools are the only way to reach them: a shell, ls or cat will not find them, and a path you see here is not a path on your filesystem. Read a file back with get_file or the typst-d2://source/ resource, not by opening it."
}
```

The sentence names the *mistake*, not just the fact — an agent told "server-owned" that still runs `ls` has been told nothing useful. In stdio mode it says the opposite, accurately: the server shares your filesystem and your own tools can read these paths. The discriminator is `workspace.Bounded`, which is already exactly this distinction.

The server instruction block gains the same warning, because a caller that never calls `workspace_info` is precisely the one that needs it, and there is a test asserting it stays there.

## What was already right

A compile returns the `typst-d2://` resource URI for its PDF and says it works whether or not you share a filesystem — #109 fixed that after every agent tested ran `find /` on a successful compile. So the paths in tool *output* were already accompanied by something unambiguous. The gap was orientation before the first call.

Refers #135