### PR TITLE
Give a wide figure a sanctioned route

### DIFF
--- a/cmd/typst-d2-mcp/main.go
+++ b/cmd/typst-d2-mcp/main.go
@@ -452,6 +452,26 @@ func templateInstructions() string {
   single exception, and it is bounded: it decides whether headings are
   numbered and nothing else.
 
+  PAGE ORIENTATION IS THE TEMPLATE'S, not the document's — do not reach
+  for #page(flipped: true). A WIDE FIGURE still has two answers, so do
+  not silently ship a worse diagram for want of one:
+
+    1. Turn the figure, not the page. This leaves the template's page
+       setup untouched:
+
+         #figure(
+           rotate(-90deg, reflow: true, <the wide thing>),
+           caption: [...],
+         )
+
+    2. If a whole document genuinely wants landscape, that is a
+       different template, not an argument on this one. Write it and
+       publish_template it into your own namespace.
+
+  For a D2 diagram specifically, try "direction: down" first — a
+  diagram that is wide because of its layout engine is not a diagram
+  that needs a wider page.
+
 `,
 		templateNamespace, templateName, templateVersion)
 }

--- a/cmd/typst-d2-mcp/templates_test.go
+++ b/cmd/typst-d2-mcp/templates_test.go
@@ -91,6 +91,29 @@ Trailing content.
 #show: report.with(title: "Minimal")
 = Only a title
 `,
+		// #124: orientation is the template's, so a caller with a wide
+		// figure needs a route that leaves page setup alone — the one
+		// the instructions and templates/README.md both name. An agent
+		// that found no such route redesigned its diagram worse instead,
+		// so this is here to keep the documented answer true.
+		"report with a rotated wide figure": `#import "@house/templates:0.1.0": report
+#show: report.with(title: "Wide figure")
+= Overview
+#figure(
+  rotate(-90deg, reflow: true,
+    block(width: 24cm, height: 6cm, fill: luma(230))[A very wide diagram]),
+  caption: [A wide diagram, turned to fit the page.],
+)
+`,
+		"adr with a rotated wide figure": `#import "@house/templates:0.1.0": adr
+#show: adr.with(title: "A decision", background: [Why.], decision: [What.], consequences: [So what.])
+== Appendix
+#figure(
+  rotate(-90deg, reflow: true,
+    block(width: 24cm, height: 6cm, fill: luma(230))[A very wide diagram]),
+  caption: [A wide diagram, turned to fit the page.],
+)
+`,
 		// #112: @ref to a heading is impossible in typst without
 		// numbering, and the compiler's own hint is the restyling these
 		// templates forbid. The argument exists so a caller need not

--- a/templates/README.md
+++ b/templates/README.md
@@ -165,6 +165,34 @@ Two things follow for a template author:
 #let memo(title: "Untitled", cc: none, body) = { ... }
 ```
 
+### Page orientation belongs to the template
+
+Not to the document. Unlike heading numbering, nothing in Typst becomes
+impossible without landscape, so there is no forcing function — and the
+general answer to "I need a different page" is a different template
+published to your namespace, not another argument on this one.
+`numbering:` is the exception that proves the rule.
+
+Note that this is *advice*, not enforcement: a document-level
+`#page(flipped: true)` simply wins, because that is how Typst's page
+rules compose. A caller who flips a page has opted out, and nothing
+here stops them.
+
+The reason to state it anyway is what happens when a caller obeys it
+without knowing the alternatives. An agent writing an architecture
+document wanted one wide page for a five-lifeline sequence diagram,
+found no sanctioned route, and redesigned the diagram narrower —
+"probably the right call, but it was a constraint, not a preference".
+All-or-nothing produced nothing. So the two routes that do exist are
+worth saying out loud:
+
+- **Turn the figure, not the page.** `rotate(-90deg, reflow: true, …)`
+  inside a `#figure` leaves page setup alone and is covered by a
+  compile test, so it is known to work with both house templates.
+- **Write a landscape template.** If a whole document wants landscape,
+  that is a different document type, and publishing one into your own
+  namespace is the supported way to have it.
+
 ### The one styling argument
 
 `report` and `adr` both take `numbering:`, defaulting to `none`. It


### PR DESCRIPTION
#124 records a decision — page orientation belongs to the template, not the document — and then names the problem the decision does not solve. This PR does the second half only.

The observed failure was not somebody breaking the rule. It was somebody **obeying** it. An agent writing a nine-page architecture document wanted one wide page for a five-lifeline sequence diagram, found that "don't override page setup" offered no escape hatch, and redesigned the diagram narrower:

> *"That was probably the right call but it was a constraint, not a preference."*

All-or-nothing produced nothing. Two routes already existed; neither was written down anywhere a caller would look.

## What changed

The server instructions and `templates/README.md` now both say orientation is the template's, **and** what to do about a wide figure:

1. **Turn the figure, not the page** — `rotate(-90deg, reflow: true, …)` inside a `#figure` leaves page setup entirely untouched.
2. **Write a landscape template** — if a whole document wants landscape, that is a different document type, and publishing one into your own namespace is the supported way to have it.

For D2 specifically, the instructions point at `direction: down` first: a diagram that is wide because of its layout engine does not need a wider page.

Route 1 is now a compile case for both `report` and `adr`, so documented advice that stops working fails the build rather than misleading the next caller.

## Deliberately not here

- The **`wide` affordance** the issue asks about. That is a decision about whether the template should offer a bounded route of its own, and it belongs with the same question at the brand axis.
- **Enforcement.** A document-level `#page(flipped: true)` still wins, because that is how Typst composes page rules. The rule stays advice; making it anything else should be a decision, not a side effect of writing documentation.

So #124 stays open for the `wide` question.

Refers #124